### PR TITLE
feat: add interactive custom cursor with hover and click animations (#4)

### DIFF
--- a/bookshelf-frontend/src/App.jsx
+++ b/bookshelf-frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import CustomCursor from './components/CustomCursor.jsx';
 import Navbar from './components/Navbar.jsx';
 import Hero from './components/Hero.jsx';
 import GenreFilter from './components/GenreFilter.jsx';
@@ -22,6 +23,7 @@ export default function App() {
 
   return (
     <div className="app">
+      <CustomCursor />
       <Navbar cartCount={cart.length} onCartClick={() => {}} />
       <Hero />
 

--- a/bookshelf-frontend/src/components/CustomCursor.css
+++ b/bookshelf-frontend/src/components/CustomCursor.css
@@ -1,0 +1,47 @@
+.custom-cursor {
+  position: fixed;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  will-change: transform;
+}
+
+body.custom-cursor-active .custom-cursor {
+  opacity: 1;
+}
+
+.custom-cursor__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--leather);
+}
+
+.custom-cursor__ring {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1.5px solid var(--leather);
+  background: rgba(184, 92, 44, 0.06);
+  transition: width 0.2s ease, height 0.2s ease, border-color 0.2s ease,
+    background 0.2s ease, opacity 0.2s ease;
+}
+
+.custom-cursor__ring--hover {
+  width: 50px;
+  height: 50px;
+  border-color: var(--gold);
+  background: rgba(198, 154, 42, 0.12);
+}
+
+.custom-cursor__ring--click {
+  width: 24px;
+  height: 24px;
+}
+
+.custom-cursor--hidden {
+  opacity: 0 !important;
+}

--- a/bookshelf-frontend/src/components/CustomCursor.jsx
+++ b/bookshelf-frontend/src/components/CustomCursor.jsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from 'react';
+import './CustomCursor.css';
+
+const HOVER_SELECTOR =
+  'a, button, input, textarea, select, label, [role="button"], .book-card, .shelf__spine, .genre-filter__chip';
+
+export default function CustomCursor() {
+  const dotRef = useRef(null);
+  const ringRef = useRef(null);
+
+  useEffect(() => {
+    const isTouchDevice =
+      window.matchMedia('(pointer: coarse)').matches || 'ontouchstart' in window;
+
+    // Don't run any of the cursor logic on touch devices.
+    if (isTouchDevice) return undefined;
+
+    document.body.classList.add('custom-cursor-active');
+
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)'
+    ).matches;
+
+    let mouseX = window.innerWidth / 2;
+    let mouseY = window.innerHeight / 2;
+    let ringX = mouseX;
+    let ringY = mouseY;
+    let rafId = null;
+
+    function moveDot() {
+      if (dotRef.current) {
+        dotRef.current.style.transform = `translate3d(${mouseX}px, ${mouseY}px, 0) translate(-50%, -50%)`;
+      }
+    }
+
+    function handleMouseMove(event) {
+      mouseX = event.clientX;
+      mouseY = event.clientY;
+      moveDot();
+
+      // If the user prefers reduced motion, skip the smooth "lag" and
+      // move the ring instantly along with the dot.
+      if (prefersReducedMotion && ringRef.current) {
+        ringRef.current.style.transform = `translate3d(${mouseX}px, ${mouseY}px, 0) translate(-50%, -50%)`;
+      }
+    }
+
+    function animateRing() {
+      // Smoothly "chase" the mouse position (simple linear interpolation).
+      ringX += (mouseX - ringX) * 0.15;
+      ringY += (mouseY - ringY) * 0.15;
+      if (ringRef.current) {
+        ringRef.current.style.transform = `translate3d(${ringX}px, ${ringY}px, 0) translate(-50%, -50%)`;
+      }
+      rafId = requestAnimationFrame(animateRing);
+    }
+
+    function handleMouseDown() {
+      ringRef.current?.classList.add('custom-cursor__ring--click');
+    }
+
+    function handleMouseUp() {
+      ringRef.current?.classList.remove('custom-cursor__ring--click');
+    }
+
+    function handleMouseOver(event) {
+      if (event.target.closest(HOVER_SELECTOR)) {
+        ringRef.current?.classList.add('custom-cursor__ring--hover');
+      }
+    }
+
+    function handleMouseOut(event) {
+      if (event.target.closest(HOVER_SELECTOR)) {
+        ringRef.current?.classList.remove('custom-cursor__ring--hover');
+      }
+    }
+
+    function handleLeaveWindow() {
+      dotRef.current?.classList.add('custom-cursor--hidden');
+      ringRef.current?.classList.add('custom-cursor--hidden');
+    }
+
+    function handleEnterWindow() {
+      dotRef.current?.classList.remove('custom-cursor--hidden');
+      ringRef.current?.classList.remove('custom-cursor--hidden');
+    }
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mousedown', handleMouseDown);
+    window.addEventListener('mouseup', handleMouseUp);
+    window.addEventListener('mouseover', handleMouseOver);
+    window.addEventListener('mouseout', handleMouseOut);
+    document.addEventListener('mouseleave',

--- a/bookshelf-frontend/src/index.css
+++ b/bookshelf-frontend/src/index.css
@@ -52,6 +52,11 @@ button {
   cursor: pointer;
 }
 
+body.custom-cursor-active,
+body.custom-cursor-active,
+body.custom-cursor-active * {
+  cursor: none;
+}
 a {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
Closes #4

Adds a lightweight custom cursor to replace the default browser cursor, as requested in the issue.

What was added:
- A new `CustomCursor` component that renders a small dot + a ring that smoothly "chases" the mouse using requestAnimationFrame.
- Hover state: the ring grows and changes color (leather → gold) when hovering over links, buttons, inputs, book cards, shelf spines, and genre filter chips.
- Click state: the ring shrinks slightly on mousedown for tactile feedback.
- The custom cursor auto-disables on touch devices (checked via `pointer: coarse` / `ontouchstart`), so mobile/tablet users still get the native cursor/touch behavior.
- Respects `prefers-reduced-motion`: the ring follows the mouse instantly instead of animating with a lag.
- The native browser cursor is hidden only while the custom cursor is active (via a `body.custom-cursor-active` class), so nothing changes on touch devices.

No existing components were modified beyond one import + one render line in `App.jsx`, and one small CSS addition in `index.css`. All styling uses the existing color tokens (`--leather`, `--gold`) so it matches the current design.

Tested with `npm run build` — builds with no errors.

I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PRs.
Hi @chinmay1126 , could you please review this merged PR for a potential bonus label based on the metrics below? Thanks! 
<img width="662" height="301" alt="labels" src="https://github.com/user-attachments/assets/64e7e095-383d-4a28-8f13-833237630f17" />
