### PR TITLE
Theme toggle/navbar/footer updated for TOS page

### DIFF
--- a/bookshelf-frontend/src/pages/PrivacyPolicy.jsx
+++ b/bookshelf-frontend/src/pages/PrivacyPolicy.jsx
@@ -19,7 +19,7 @@ export default function PrivacyPolicy() {
       <ThemeToggle />
 
       {/* ── Navbar (same as landing page) ── */}
-      <Navbar cartCount={0} onCartClick={() => {}} />
+      <Navbar cartCount={0} onCartClick={() => { }} />
       <div className="nav-spacer" />
 
       {/* ── Hero ── */}

--- a/bookshelf-frontend/src/pages/TermsOfService.css
+++ b/bookshelf-frontend/src/pages/TermsOfService.css
@@ -1,112 +1,19 @@
 /* ═══════════════════════════════════════════════════
-   Terms of Service — LIGHT MODE ONLY
-   Self-contained with custom navbar & footer
+   Terms of Service page — Supports light & dark themes
    ═══════════════════════════════════════════════════ */
 
-/* ── Force light palette ── */
-.tos-page,
-.tos-page * {
-  --tos-bg: #FAFBFD;
-  --tos-surface: #FFFFFF;
-  --tos-surface-dim: #F3F4F8;
-  --tos-ink: #1A1D26;
-  --tos-ink-soft: #5A5F72;
-  --tos-accent: #3B5BDB;
-  --tos-accent-deep: #2B44A8;
-  --tos-accent-bg: rgba(59, 91, 219, 0.06);
-  --tos-teal: #0C8E7E;
-  --tos-teal-bg: rgba(12, 142, 126, 0.06);
-  --tos-border: rgba(26, 29, 38, 0.09);
-  --tos-border-strong: rgba(26, 29, 38, 0.16);
-}
-
 .tos-page {
-  background: var(--tos-bg);
-  color: var(--tos-ink);
+  background: var(--paper);
+  color: var(--ink);
   min-height: 100vh;
   font-family: 'Inter', sans-serif;
   overflow-x: hidden;
+  transition: background-color 0.25s ease, color 0.25s ease;
 }
 
-/* ═══════════════════════════════════════════════════
-   Custom Navbar
-   ═══════════════════════════════════════════════════ */
-.tos-nav {
-  position: sticky;
-  top: 0;
-  z-index: 100;
-  background: rgba(250, 251, 253, 0.92);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border-bottom: 1px solid var(--tos-border);
-}
-
-.tos-nav__inner {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 16px 32px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.tos-nav__brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 9px;
-  font-family: 'Fraunces', serif;
-  font-size: 20px;
-  font-weight: 700;
-  color: var(--tos-ink);
-  text-decoration: none;
-  letter-spacing: -0.02em;
-  transition: opacity 0.2s ease;
-}
-
-.tos-nav__brand:hover {
-  opacity: 0.75;
-}
-
-.tos-nav__icon {
-  display: flex;
-  color: var(--tos-accent);
-}
-
-.tos-nav__links {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.tos-nav__links a {
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--tos-ink-soft);
-  text-decoration: none;
-  padding: 7px 14px;
-  border-radius: 8px;
-  transition: all 0.2s ease;
-}
-
-.tos-nav__links a:hover {
-  color: var(--tos-accent);
-  background: var(--tos-accent-bg);
-}
-
-.tos-nav__back {
-  border: 1px solid var(--tos-border) !important;
-  margin-left: 8px;
-}
-
-.tos-nav__back:hover {
-  border-color: var(--tos-border-strong) !important;
-}
-
-/* ═══════════════════════════════════════════════════
-   Hero
-   ═══════════════════════════════════════════════════ */
+/* ── Hero section ── */
 .tos-hero {
-  padding: 72px 32px 48px;
+  padding: 80px 32px 48px;
   text-align: center;
   position: relative;
 }
@@ -114,67 +21,138 @@
 .tos-hero::before {
   content: '';
   position: absolute;
-  top: -80px;
+  top: 0;
   left: 50%;
   transform: translateX(-50%);
-  width: 700px;
-  height: 700px;
-  background: radial-gradient(circle, rgba(59, 91, 219, 0.04) 0%, transparent 65%);
+  width: 550px;
+  height: 550px;
+  background: radial-gradient(circle, rgba(184, 92, 44, 0.06) 0%, transparent 70%);
   pointer-events: none;
 }
 
 .tos-hero__inner {
-  max-width: 620px;
+  max-width: 680px;
   margin: 0 auto;
   position: relative;
 }
 
-.tos-hero__badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
+.tos-hero__eyebrow {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--tos-accent);
-  background: var(--tos-accent-bg);
-  border: 1px solid rgba(59, 91, 219, 0.12);
-  padding: 6px 14px;
-  border-radius: 999px;
-  margin-bottom: 24px;
+  color: var(--leather);
+  margin-bottom: 14px;
+  font-weight: 500;
 }
 
 .tos-hero__title {
   font-family: 'Fraunces', serif;
   font-size: 48px;
   font-weight: 600;
-  line-height: 1.08;
-  letter-spacing: -0.025em;
-  color: var(--tos-ink);
-  margin: 0 0 14px;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  margin: 0 0 16px;
+}
+
+.tos-hero__title em {
+  font-style: italic;
+  color: var(--leather);
 }
 
 .tos-hero__updated {
-  font-size: 12px;
-  color: var(--tos-ink-soft);
+  font-size: 13px;
+  color: var(--ink-soft);
   font-family: 'IBM Plex Mono', monospace;
-  letter-spacing: 0.02em;
-  margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 16px;
 }
 
-.tos-hero__intro {
+.tos-hero__bullet {
+  opacity: 0.4;
+}
+
+.tos-hero__sub {
   font-size: 16px;
   line-height: 1.7;
-  color: var(--tos-ink-soft);
-  max-width: 520px;
+  color: var(--ink-soft);
+  max-width: 580px;
   margin: 0 auto;
 }
 
-/* ═══════════════════════════════════════════════════
-   Content layout
-   ═══════════════════════════════════════════════════ */
+/* ── Summary Key Takeaways Banner ── */
+.tos-summary {
+  padding: 0 32px 48px;
+}
+
+.tos-summary__inner {
+  max-width: 1080px;
+  margin: 0 auto;
+  background: var(--paper-dim);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 36px 32px;
+}
+
+.tos-summary__title {
+  font-family: 'Fraunces', serif;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--ink);
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.tos-summary__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+}
+
+.tos-summary__card {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 24px 20px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.tos-summary__card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-card);
+}
+
+.tos-summary__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  background: rgba(184, 92, 44, 0.08);
+  color: var(--leather);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 14px;
+}
+
+.tos-summary__card h3 {
+  font-family: 'Fraunces', serif;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ink);
+  margin-bottom: 8px;
+}
+
+.tos-summary__card p {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--ink-soft);
+}
+
+/* ── Content Layout ── */
 .tos-content {
   padding: 0 32px 72px;
 }
@@ -183,79 +161,62 @@
   max-width: 960px;
   margin: 0 auto;
   display: grid;
-  grid-template-columns: 220px 1fr;
+  grid-template-columns: 260px 1fr;
   gap: 48px;
   align-items: start;
 }
 
-/* ── Table of Contents ── */
+/* ── Table of Contents Sidebar ── */
 .tos-toc {
   position: sticky;
-  top: 76px;
-  background: var(--tos-surface);
-  border: 1px solid var(--tos-border);
+  top: 88px;
+  background: var(--paper-dim);
+  border: 1px solid var(--line);
   border-radius: 14px;
   padding: 24px 20px;
-  box-shadow: 0 1px 3px rgba(26, 29, 38, 0.04);
+  max-height: calc(100vh - 110px);
+  overflow-y: auto;
 }
 
-.tos-toc__heading {
-  font-family: 'Inter', sans-serif;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--tos-ink-soft);
-  margin: 0 0 14px;
+.tos-toc__title {
+  font-family: 'Fraunces', serif;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 0 0 16px;
   padding-bottom: 10px;
-  border-bottom: 1px solid var(--tos-border);
+  border-bottom: 1px solid var(--line);
 }
 
 .tos-toc__list {
   list-style: none;
-  counter-reset: tos-toc;
   padding: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
 }
 
-.tos-toc__list li {
-  counter-increment: tos-toc;
-}
-
-.tos-toc__list a {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
+.tos-toc__list li a {
+  display: block;
   font-size: 12.5px;
-  color: var(--tos-ink-soft);
+  color: var(--ink-soft);
   text-decoration: none;
-  padding: 6px 8px;
+  padding: 6px 10px;
   border-radius: 6px;
+  line-height: 1.4;
   transition: all 0.15s ease;
-  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.tos-toc__list a::before {
-  content: counter(tos-toc, decimal-leading-zero);
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 9px;
-  font-weight: 600;
-  color: var(--tos-accent);
-  flex-shrink: 0;
-  opacity: 0.7;
+.tos-toc__list li a:hover {
+  color: var(--ink);
+  background: rgba(184, 92, 44, 0.08);
 }
 
-.tos-toc__list a:hover {
-  color: var(--tos-ink);
-  background: var(--tos-surface-dim);
-}
-
-/* ═══════════════════════════════════════════════════
-   Sections
-   ═══════════════════════════════════════════════════ */
+/* ── Sections ── */
 .tos-sections {
   display: flex;
   flex-direction: column;
@@ -264,42 +225,40 @@
 
 .tos-section {
   position: relative;
-  scroll-margin-top: 90px;
+  scroll-margin-top: 100px;
 }
 
-.tos-section__marker {
+.tos-section__number {
   font-family: 'Fraunces', serif;
-  font-size: 44px;
-  font-weight: 800;
-  color: rgba(59, 91, 219, 0.05);
+  font-size: 40px;
+  font-weight: 700;
+  color: rgba(34, 30, 25, 0.06);
   position: absolute;
-  top: -16px;
-  left: -6px;
+  top: -14px;
+  left: -8px;
   pointer-events: none;
   user-select: none;
-  line-height: 1;
 }
 
 .tos-section__title {
   font-family: 'Fraunces', serif;
-  font-size: 21px;
+  font-size: 22px;
   font-weight: 600;
-  color: var(--tos-ink);
+  color: var(--ink);
   margin: 0 0 14px;
   padding-bottom: 12px;
-  border-bottom: 1px solid var(--tos-border);
+  border-bottom: 1px solid var(--line);
 }
 
 .tos-section p {
   font-size: 14.5px;
-  line-height: 1.78;
-  color: var(--tos-ink-soft);
+  line-height: 1.75;
+  color: var(--ink-soft);
   margin: 0 0 12px;
 }
 
 .tos-section p strong {
-  color: var(--tos-ink);
-  font-weight: 600;
+  color: var(--ink);
 }
 
 .tos-section ul {
@@ -313,10 +272,10 @@
 
 .tos-section ul li {
   position: relative;
-  padding-left: 22px;
+  padding-left: 20px;
   font-size: 14px;
-  line-height: 1.72;
-  color: var(--tos-ink-soft);
+  line-height: 1.7;
+  color: var(--ink-soft);
 }
 
 .tos-section ul li::before {
@@ -324,255 +283,197 @@
   position: absolute;
   left: 0;
   top: 9px;
-  width: 7px;
-  height: 7px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
-  background: var(--tos-accent);
-  opacity: 0.3;
+  background: var(--leather);
+  opacity: 0.6;
 }
 
 .tos-section ul li strong {
-  color: var(--tos-ink);
+  color: var(--ink);
   font-weight: 600;
 }
 
 .tos-section a {
-  color: var(--tos-accent);
+  color: var(--leather);
   text-decoration: underline;
   text-underline-offset: 2px;
   transition: color 0.15s ease;
 }
 
 .tos-section a:hover {
-  color: var(--tos-accent-deep);
+  color: var(--leather-deep);
 }
 
-/* ── Callout ── */
+/* ── Callout Box ── */
 .tos-callout {
   display: flex;
   align-items: flex-start;
   gap: 14px;
-  background: var(--tos-teal-bg);
-  border: 1px solid rgba(12, 142, 126, 0.14);
+  background: rgba(31, 75, 67, 0.05);
+  border: 1px solid rgba(31, 75, 67, 0.12);
   border-radius: 10px;
-  padding: 18px 20px;
+  padding: 20px 22px;
   margin: 16px 0 4px;
 }
 
 .tos-callout__icon {
   flex-shrink: 0;
-  color: var(--tos-teal);
+  color: var(--pine);
   margin-top: 1px;
 }
 
 .tos-callout p {
   font-size: 13.5px;
   line-height: 1.7;
-  color: var(--tos-ink);
+  color: var(--ink);
   margin: 0;
 }
 
-/* ── Contact card ── */
+.tos-callout strong {
+  color: var(--pine);
+}
+
+/* ── Contact Card ── */
 .tos-contact-card {
-  background: var(--tos-surface);
-  border: 1px solid var(--tos-border);
-  border-radius: 10px;
-  padding: 20px 24px;
+  background: var(--paper-dim);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 28px 28px;
+  margin-top: 20px;
+}
+
+.tos-contact-card__title {
+  font-family: 'Fraunces', serif;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--ink);
+  margin-bottom: 6px;
+}
+
+.tos-contact-card__sub {
+  font-size: 14px;
+  color: var(--ink-soft);
+  margin-bottom: 20px;
+}
+
+.tos-contact-card__details {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  margin-top: 12px;
-  box-shadow: 0 1px 3px rgba(26, 29, 38, 0.04);
 }
 
 .tos-contact-card__row {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   font-size: 14px;
-  color: var(--tos-ink-soft);
+  color: var(--ink-soft);
 }
 
 .tos-contact-card__row svg {
   flex-shrink: 0;
-  color: var(--tos-accent);
+  color: var(--leather);
 }
 
 .tos-contact-card__row a {
-  color: var(--tos-accent);
-  text-decoration: none;
+  color: var(--leather);
   font-weight: 500;
-  transition: color 0.15s ease;
 }
 
-.tos-contact-card__row a:hover {
-  color: var(--tos-accent-deep);
-}
-
-/* ═══════════════════════════════════════════════════
-   Custom Footer
-   ═══════════════════════════════════════════════════ */
-.tos-footer {
-  background: var(--tos-ink);
-  color: #FFFFFF;
-  padding: 0;
-}
-
-.tos-footer__inner {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 0 32px;
-}
-
-.tos-footer__top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 36px 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.tos-footer__brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 9px;
-  font-family: 'Fraunces', serif;
-  font-size: 18px;
-  font-weight: 700;
-  color: #FFFFFF;
-  text-decoration: none;
-  letter-spacing: -0.02em;
-  transition: opacity 0.2s ease;
-}
-
-.tos-footer__brand:hover {
-  opacity: 0.8;
-}
-
-.tos-footer__brand svg {
-  color: var(--tos-accent);
-  opacity: 0.7;
-}
-
-.tos-footer__links {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.tos-footer__links a {
-  font-size: 13px;
-  color: rgba(255, 255, 255, 0.55);
-  text-decoration: none;
-  padding: 6px 12px;
-  border-radius: 6px;
-  transition: all 0.2s ease;
-}
-
-.tos-footer__links a:hover {
-  color: #FFFFFF;
-  background: rgba(255, 255, 255, 0.06);
-}
-
-.tos-footer__links-active {
-  font-size: 13px;
-  font-weight: 600;
-  color: #FFFFFF;
-  padding: 6px 12px;
-  border-radius: 6px;
-  background: rgba(59, 91, 219, 0.2);
-}
-
-.tos-footer__bottom {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 20px 0;
-}
-
-.tos-footer__bottom p {
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.3);
-}
-
-.tos-footer__note {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 11px !important;
-  letter-spacing: 0.02em;
+/* ── Footer margin reset ── */
+.tos-page .footer {
+  margin-top: 0;
 }
 
 /* ═══════════════════════════════════════════════════
-   Responsive
+   Dark mode overrides
    ═══════════════════════════════════════════════════ */
-@media (max-width: 768px) {
+[data-theme="dark"] .tos-hero::before {
+  background: radial-gradient(circle, rgba(217, 121, 61, 0.08) 0%, transparent 70%);
+}
+
+[data-theme="dark"] .tos-summary__card {
+  background: var(--paper-dim);
+}
+
+[data-theme="dark"] .tos-summary__card:hover {
+  box-shadow: 0 16px 36px -12px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .tos-toc__list li a:hover {
+  background: rgba(217, 121, 61, 0.12);
+}
+
+[data-theme="dark"] .tos-section__number {
+  color: rgba(243, 236, 221, 0.04);
+}
+
+[data-theme="dark"] .tos-callout {
+  background: rgba(47, 110, 95, 0.08);
+  border-color: rgba(47, 110, 95, 0.18);
+}
+
+/* ═══════════════════════════════════════════════════
+   Responsive Media Queries
+   ═══════════════════════════════════════════════════ */
+@media (max-width: 992px) {
+  .tos-summary__grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
   .tos-content__inner {
     grid-template-columns: 1fr;
-    gap: 28px;
+    gap: 32px;
   }
 
   .tos-toc {
     position: static;
+    max-height: none;
   }
+}
 
+@media (max-width: 768px) {
   .tos-hero {
-    padding: 56px 24px 36px;
+    padding: 64px 24px 36px;
   }
 
   .tos-hero__title {
     font-size: 34px;
   }
 
+  .tos-summary__inner {
+    padding: 24px 20px;
+  }
+
+  .tos-summary__grid {
+    grid-template-columns: 1fr;
+  }
+
   .tos-section__title {
-    font-size: 18px;
+    font-size: 19px;
   }
 
-  .tos-section__marker {
-    font-size: 34px;
-  }
-
-  .tos-footer__top {
-    flex-direction: column;
-    gap: 20px;
-    align-items: flex-start;
-  }
-
-  .tos-footer__links {
-    flex-wrap: wrap;
-  }
-
-  .tos-footer__bottom {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 6px;
-  }
-
-  .tos-nav__links a:not(.tos-nav__back) {
-    display: none;
+  .tos-section__number {
+    font-size: 32px;
   }
 }
 
 @media (max-width: 560px) {
-  .tos-nav__inner {
-    padding: 14px 20px;
-  }
-
   .tos-hero {
-    padding: 44px 20px 28px;
+    padding: 48px 20px 28px;
   }
 
   .tos-hero__title {
     font-size: 28px;
   }
 
-  .tos-hero__intro {
-    font-size: 14.5px;
-  }
-
   .tos-content {
     padding: 0 20px 48px;
   }
 
-  .tos-footer__inner {
-    padding: 0 20px;
+  .tos-summary {
+    padding: 0 20px 32px;
   }
 }

--- a/bookshelf-frontend/src/pages/TermsOfService.jsx
+++ b/bookshelf-frontend/src/pages/TermsOfService.jsx
@@ -1,260 +1,352 @@
 import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import Navbar from '../components/Navbar.jsx';
+import Footer from '../components/Footer.jsx';
+import ThemeToggle from '../components/ThemeToggle.jsx';
 import './TermsOfService.css';
 
 export default function TermsOfService() {
-  /* Force light mode on this page */
+  /* Scroll to top on mount */
   useEffect(() => {
-    const root = document.documentElement;
-    const prev = root.getAttribute('data-theme');
-    root.setAttribute('data-theme', 'light');
     window.scrollTo(0, 0);
-    return () => {
-      if (prev) root.setAttribute('data-theme', prev);
-      else root.removeAttribute('data-theme');
-    };
   }, []);
 
   const lastUpdated = 'July 25, 2025';
+  const effectiveDate = 'August 1, 2025';
 
   return (
     <div className="tos-page">
-      {/* ── Custom Navbar ── */}
-      <header className="tos-nav">
-        <div className="tos-nav__inner">
-          <Link to="/" className="tos-nav__brand">
-            <span className="tos-nav__icon" aria-hidden="true">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none"
-                stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
-                <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
-              </svg>
-            </span>
-            BookShelf
-          </Link>
-          <div className="tos-nav__links">
-            <Link to="/about">About</Link>
-            <Link to="/privacy">Privacy</Link>
-            <Link to="/" className="tos-nav__back">← Back to Store</Link>
-          </div>
-        </div>
-      </header>
+      {/* ── Theme toggle ── */}
+      <ThemeToggle />
 
-      {/* ── Hero ── */}
+      {/* ── Navbar ── */}
+      <Navbar cartCount={0} onCartClick={() => {}} />
+      <div className="nav-spacer" />
+
+      {/* ── Hero Section ── */}
       <section className="tos-hero">
         <div className="tos-hero__inner">
-          <div className="tos-hero__badge">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
-              stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-              <polyline points="14 2 14 8 20 8" />
-              <line x1="16" y1="13" x2="8" y2="13" />
-              <line x1="16" y1="17" x2="8" y2="17" />
-              <polyline points="10 9 9 9 8 9" />
-            </svg>
-            Legal Document
-          </div>
-          <h1 className="tos-hero__title">Terms of Service</h1>
-          <p className="tos-hero__updated">Last updated: {lastUpdated}</p>
-          <p className="tos-hero__intro">
-            Please read these terms carefully before using BookShelf. By accessing or using our
-            platform, you agree to be bound by these terms.
+          <p className="tos-hero__eyebrow">Legal &amp; Policy</p>
+          <h1 className="tos-hero__title">Terms of <em>Service</em></h1>
+          <p className="tos-hero__updated">
+            <span>Last Updated: {lastUpdated}</span>
+            <span className="tos-hero__bullet">•</span>
+            <span>Effective Date: {effectiveDate}</span>
+          </p>
+          <p className="tos-hero__sub">
+            Please read these Terms of Service carefully before purchasing books, creating an account, or browsing the BookShelf platform.
           </p>
         </div>
       </section>
 
-      {/* ── Content ── */}
+      {/* ── Summary Key Takeaways Banner ── */}
+      <section className="tos-summary">
+        <div className="tos-summary__inner">
+          <h2 className="tos-summary__title">At a Glance — Key Takeaways</h2>
+          <div className="tos-summary__grid">
+            <div className="tos-summary__card">
+              <div className="tos-summary__icon">
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                  <line x1="16" y1="13" x2="8" y2="13" />
+                  <line x1="16" y1="17" x2="8" y2="17" />
+                </svg>
+              </div>
+              <h3>Binding Agreement</h3>
+              <p>By browsing, creating an account, or placing an order on BookShelf, you enter into a legal contract governed by these Terms.</p>
+            </div>
+            <div className="tos-summary__card">
+              <div className="tos-summary__icon">
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="1" y="4" width="22" height="16" rx="2" ry="2" />
+                  <line x1="1" y1="10" x2="23" y2="10" />
+                </svg>
+              </div>
+              <h3>Fair Pricing &amp; Orders</h3>
+              <p>All transactions are processed securely. Prices are clearly listed, and refunds are covered by our 14-day policy for physical items.</p>
+            </div>
+            <div className="tos-summary__card">
+              <div className="tos-summary__icon">
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                </svg>
+              </div>
+              <h3>Copyright Protection</h3>
+              <p>Book Content, author materials, and storefront designs are protected by copyright laws. Unauthorized reproduction is strictly prohibited.</p>
+            </div>
+            <div className="tos-summary__card">
+              <div className="tos-summary__icon">
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+                </svg>
+              </div>
+              <h3>Respectful Community</h3>
+              <p>User reviews and community interactions must remain respectful, honest, and free of malicious spam, hate speech, or harassment.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Main Legal Content Layout ── */}
       <article className="tos-content">
         <div className="tos-content__inner">
 
-          {/* Table of Contents */}
+          {/* Sticky Table of Contents Sidebar */}
           <nav className="tos-toc">
-            <h2 className="tos-toc__heading">In this document</h2>
+            <h2 className="tos-toc__title">Table of Contents</h2>
             <ol className="tos-toc__list">
-              <li><a href="#acceptance">Acceptance of Terms</a></li>
-              <li><a href="#eligibility">Eligibility</a></li>
-              <li><a href="#accounts">User Accounts</a></li>
-              <li><a href="#purchases">Purchases & Payments</a></li>
-              <li><a href="#content">User Content</a></li>
-              <li><a href="#ip">Intellectual Property</a></li>
-              <li><a href="#prohibited">Prohibited Conduct</a></li>
-              <li><a href="#disclaimers">Disclaimers</a></li>
-              <li><a href="#liability">Limitation of Liability</a></li>
-              <li><a href="#termination">Termination</a></li>
-              <li><a href="#governing">Governing Law</a></li>
-              <li><a href="#changes-tos">Changes to Terms</a></li>
-              <li><a href="#contact-tos">Contact Us</a></li>
+              <li><a href="#section-1">1. Acceptance of Terms</a></li>
+              <li><a href="#section-2">2. Platform Definitions</a></li>
+              <li><a href="#section-3">3. Account Registration &amp; Security</a></li>
+              <li><a href="#section-4">4. User Eligibility &amp; Minors</a></li>
+              <li><a href="#section-5">5. Orders, Pricing &amp; Availability</a></li>
+              <li><a href="#section-6">6. Payment Processing &amp; Billing</a></li>
+              <li><a href="#section-7">7. Shipping, Delivery &amp; Title</a></li>
+              <li><a href="#section-8">8. Returns, Refunds &amp; Cancellations</a></li>
+              <li><a href="#section-9">9. Digital Content &amp; E-Book License</a></li>
+              <li><a href="#section-10">10. Intellectual Property Rights</a></li>
+              <li><a href="#section-11">11. User Conduct &amp; Restrictions</a></li>
+              <li><a href="#section-12">12. User Reviews &amp; Submissions</a></li>
+              <li><a href="#section-13">13. Third-Party Links &amp; Services</a></li>
+              <li><a href="#section-14">14. Disclaimer of Warranties</a></li>
+              <li><a href="#section-15">15. Limitation of Liability</a></li>
+              <li><a href="#section-16">16. Indemnification</a></li>
+              <li><a href="#section-17">17. Dispute Resolution &amp; Arbitration</a></li>
+              <li><a href="#section-18">18. Governing Law &amp; Jurisdiction</a></li>
+              <li><a href="#section-19">19. Severability &amp; Entire Agreement</a></li>
+              <li><a href="#section-20">20. Amendments &amp; Contact Notice</a></li>
             </ol>
           </nav>
 
-          {/* Sections */}
+          {/* Detailed Legal Sections */}
           <div className="tos-sections">
 
-            <section className="tos-section" id="acceptance">
-              <div className="tos-section__marker">01</div>
+            <section className="tos-section" id="section-1">
+              <div className="tos-section__number">01</div>
               <h2 className="tos-section__title">Acceptance of Terms</h2>
-              <p>By accessing or using BookShelf ("the Platform"), you acknowledge that you have read, understood, and agree to be bound by these Terms of Service ("Terms"). If you do not agree with any part of these Terms, you must discontinue use of the Platform immediately.</p>
-              <p>These Terms constitute a legally binding agreement between you ("User," "you") and BookShelf ("we," "us," "our"). We reserve the right to update these Terms at any time, and your continued use of the Platform constitutes acceptance of any modifications.</p>
-            </section>
-
-            <section className="tos-section" id="eligibility">
-              <div className="tos-section__marker">02</div>
-              <h2 className="tos-section__title">Eligibility</h2>
-              <p>To use BookShelf, you must:</p>
-              <ul>
-                <li>Be at least 13 years of age (or the minimum age in your jurisdiction).</li>
-                <li>Have the legal capacity to enter into a binding agreement.</li>
-                <li>Not be prohibited from using the Platform under applicable laws.</li>
-              </ul>
-              <p>If you are using BookShelf on behalf of an organization, you represent that you have authority to bind that organization to these Terms.</p>
-            </section>
-
-            <section className="tos-section" id="accounts">
-              <div className="tos-section__marker">03</div>
-              <h2 className="tos-section__title">User Accounts</h2>
-              <p>When you create an account on BookShelf, you agree to:</p>
-              <ul>
-                <li>Provide accurate, complete, and current information.</li>
-                <li>Maintain the security and confidentiality of your login credentials.</li>
-                <li>Notify us immediately of any unauthorized access or security breach.</li>
-                <li>Accept responsibility for all activities that occur under your account.</li>
-              </ul>
-              <p>We reserve the right to suspend or terminate accounts that violate these Terms or engage in fraudulent activity.</p>
-            </section>
-
-            <section className="tos-section" id="purchases">
-              <div className="tos-section__marker">04</div>
-              <h2 className="tos-section__title">Purchases &amp; Payments</h2>
-              <p>When purchasing books through BookShelf:</p>
-              <ul>
-                <li><strong>Pricing:</strong> All prices are displayed in the currency indicated and include applicable taxes unless stated otherwise.</li>
-                <li><strong>Payment:</strong> We accept major credit cards, debit cards, and supported digital wallets. Payment is processed securely through third-party providers.</li>
-                <li><strong>Confirmation:</strong> A purchase confirmation will be sent to your registered email address.</li>
-                <li><strong>Refunds:</strong> Physical books may be returned within 14 days of delivery if in original condition. Digital content purchases are final unless required otherwise by law.</li>
-              </ul>
+              <p>Welcome to BookShelf. These Terms of Service ("Terms", "Agreement") govern your access to and use of the website located at <strong>bookshelf.com</strong>, including all subdomains, mobile-optimized versions, and services provided by BookShelf ("we", "us", "our").</p>
+              <p>By visiting our website, creating an account, browsing our catalog, or purchasing items from BookShelf, you acknowledge that you have read, understood, and agree to be bound by these Terms, as well as our <Link to="/privacy">Privacy Policy</Link>. If you do not agree to all of these Terms, you are expressly prohibited from using the platform and must discontinue use immediately.</p>
               <div className="tos-callout">
                 <div className="tos-callout__icon">
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                     <circle cx="12" cy="12" r="10" />
                     <line x1="12" y1="16" x2="12" y2="12" />
                     <line x1="12" y1="8" x2="12.01" y2="8" />
                   </svg>
                 </div>
-                <p>We never store your payment card details. All transactions are processed by PCI-DSS compliant payment processors.</p>
+                <p><strong>Important Note:</strong> We recommend saving or printing a copy of these Terms for your personal records. These terms constitute a legally binding agreement between you and BookShelf.</p>
               </div>
             </section>
 
-            <section className="tos-section" id="content">
-              <div className="tos-section__marker">05</div>
-              <h2 className="tos-section__title">User Content</h2>
-              <p>You may submit reviews, ratings, wishlists, and other content ("User Content") on BookShelf. By doing so, you:</p>
+            <section className="tos-section" id="section-2">
+              <div className="tos-section__number">02</div>
+              <h2 className="tos-section__title">Platform Definitions</h2>
+              <p>Throughout this document, the following terms carry specific legal definitions:</p>
               <ul>
-                <li>Grant us a non-exclusive, royalty-free, worldwide license to use, display, and distribute your User Content on the Platform.</li>
-                <li>Represent that you own or have rights to the content you submit.</li>
-                <li>Agree not to post content that is defamatory, obscene, infringing, or otherwise unlawful.</li>
-              </ul>
-              <p>We reserve the right to remove User Content that violates these Terms without prior notice.</p>
-            </section>
-
-            <section className="tos-section" id="ip">
-              <div className="tos-section__marker">06</div>
-              <h2 className="tos-section__title">Intellectual Property</h2>
-              <p>All content on BookShelf — including but not limited to text, graphics, logos, icons, images, audio clips, software, and compilations — is the property of BookShelf or its content suppliers and is protected by copyright and trademark laws.</p>
-              <p>You may not:</p>
-              <ul>
-                <li>Reproduce, distribute, or create derivative works from Platform content without express written permission.</li>
-                <li>Use our trademarks, service marks, or logos without prior authorization.</li>
-                <li>Scrape, crawl, or use automated means to access Platform content for commercial purposes.</li>
+                <li><strong>"Platform" / "Services":</strong> Refers collectively to the BookShelf e-commerce storefront, online catalog, digital reader interface, APIs, customer support, and related digital services.</li>
+                <li><strong>"User" / "Customer":</strong> Any individual or entity accessing the website, registering an account, or conducting transactions on BookShelf.</li>
+                <li><strong>"Physical Products":</strong> Printed books, hardcover editions, paperbacks, bookish merchandise, bookmarks, and physical goods sold via BookShelf.</li>
+                <li><strong>"Digital Products":</strong> E-books, audiobooks, downloadable literary content, and digital publications provided under license.</li>
+                <li><strong>"User Content":</strong> Product reviews, comments, ratings, reading list titles, profile descriptions, and communications submitted by users.</li>
               </ul>
             </section>
 
-            <section className="tos-section" id="prohibited">
-              <div className="tos-section__marker">07</div>
-              <h2 className="tos-section__title">Prohibited Conduct</h2>
-              <p>When using BookShelf, you agree <strong>not</strong> to:</p>
+            <section className="tos-section" id="section-3">
+              <div className="tos-section__number">03</div>
+              <h2 className="tos-section__title">Account Registration &amp; Security</h2>
+              <p>To access certain features of BookShelf, such as saving reading lists, writing reviews, and placing orders, you may be required to register for an account. When creating an account, you agree to the following conditions:</p>
               <ul>
-                <li>Violate any applicable laws, regulations, or third-party rights.</li>
-                <li>Use the Platform for any fraudulent or deceptive purpose.</li>
-                <li>Attempt to gain unauthorized access to any part of the Platform or its systems.</li>
-                <li>Introduce malware, viruses, or other harmful code.</li>
-                <li>Interfere with the proper functioning of the Platform.</li>
-                <li>Impersonate another person or entity.</li>
-                <li>Harvest or collect personal information of other users without consent.</li>
+                <li><strong>Accuracy of Information:</strong> You agree to provide true, accurate, current, and complete registration information and maintain its accuracy at all times.</li>
+                <li><strong>Credential Confidentiality:</strong> You are solely responsible for maintaining the confidentiality of your account credentials, password, and access codes.</li>
+                <li><strong>Account Activity:</strong> You accept full responsibility for all activities, purchases, and communications performed under your account.</li>
+                <li><strong>Unauthorized Access:</strong> You must immediately notify BookShelf at <a href="mailto:support@bookshelf.com">support@bookshelf.com</a> if you suspect any breach of security or unauthorized access to your account.</li>
+              </ul>
+              <p>We reserve the right to suspend, disable, or terminate any account at our sole discretion if we determine you have violated any provision of these Terms.</p>
+            </section>
+
+            <section className="tos-section" id="section-4">
+              <div className="tos-section__number">04</div>
+              <h2 className="tos-section__title">User Eligibility &amp; Minors</h2>
+              <p>BookShelf is intended for general audiences. By using the Platform, you represent and warrant that:</p>
+              <ul>
+                <li>You are at least 18 years of age, or possess legal parental or guardian consent if you are between 13 and 17 years old.</li>
+                <li>Children under 13 years of age may not register an account or submit personal data directly to BookShelf.</li>
+                <li>You have not been previously suspended or removed from BookShelf.</li>
+                <li>Your registration and use of BookShelf complies with all applicable local, national, and international laws.</li>
               </ul>
             </section>
 
-            <section className="tos-section" id="disclaimers">
-              <div className="tos-section__marker">08</div>
-              <h2 className="tos-section__title">Disclaimers</h2>
-              <p>BookShelf is provided on an <strong>"as is"</strong> and <strong>"as available"</strong> basis. We make no warranties, express or implied, regarding:</p>
+            <section className="tos-section" id="section-5">
+              <div className="tos-section__number">05</div>
+              <h2 className="tos-section__title">Orders, Pricing &amp; Availability</h2>
+              <p>All product descriptions, book prices, and availability displayed on BookShelf are subject to change at any time without notice. When you place an order on BookShelf:</p>
               <ul>
-                <li>The accuracy, completeness, or reliability of any content on the Platform.</li>
-                <li>Uninterrupted or error-free access to the Platform.</li>
-                <li>The security of data transmitted to or from the Platform (though we take reasonable precautions).</li>
-              </ul>
-              <p>We do not warrant that the Platform will meet your specific requirements or expectations.</p>
-            </section>
-
-            <section className="tos-section" id="liability">
-              <div className="tos-section__marker">09</div>
-              <h2 className="tos-section__title">Limitation of Liability</h2>
-              <p>To the fullest extent permitted by law, BookShelf and its affiliates, officers, employees, and agents shall not be liable for:</p>
-              <ul>
-                <li>Any indirect, incidental, special, consequential, or punitive damages.</li>
-                <li>Loss of profits, data, or goodwill arising from your use of the Platform.</li>
-                <li>Any damages resulting from unauthorized access to your account or personal data.</li>
-              </ul>
-              <p>Our total aggregate liability shall not exceed the amount you have paid to BookShelf in the 12 months preceding the claim.</p>
-            </section>
-
-            <section className="tos-section" id="termination">
-              <div className="tos-section__marker">10</div>
-              <h2 className="tos-section__title">Termination</h2>
-              <p>We may suspend or terminate your access to BookShelf at any time, with or without cause, and with or without notice. Upon termination:</p>
-              <ul>
-                <li>Your right to use the Platform ceases immediately.</li>
-                <li>We may delete your account and associated data, subject to our data retention policies.</li>
-                <li>Provisions that by their nature should survive termination (including intellectual property, disclaimers, and limitation of liability) will remain in effect.</li>
-              </ul>
-              <p>You may also delete your account at any time through your account settings or by contacting us.</p>
-            </section>
-
-            <section className="tos-section" id="governing">
-              <div className="tos-section__marker">11</div>
-              <h2 className="tos-section__title">Governing Law</h2>
-              <p>These Terms shall be governed by and construed in accordance with the laws of India, without regard to its conflict of law provisions.</p>
-              <p>Any disputes arising from these Terms or your use of BookShelf shall be resolved exclusively in the courts of Pune, Maharashtra, India.</p>
-            </section>
-
-            <section className="tos-section" id="changes-tos">
-              <div className="tos-section__marker">12</div>
-              <h2 className="tos-section__title">Changes to Terms</h2>
-              <p>We may revise these Terms from time to time. When we make changes:</p>
-              <ul>
-                <li>We will update the "Last updated" date at the top of this page.</li>
-                <li>For material changes, we will notify registered users via email.</li>
-                <li>Continued use of BookShelf after changes constitutes acceptance of the revised Terms.</li>
+                <li><strong>Order Acceptance:</strong> Receipt of an electronic order confirmation does not signify our final acceptance of your order. We reserve the right to accept, decline, or limit order quantities for any reason.</li>
+                <li><strong>Pricing Errors:</strong> Despite our best efforts, items in our catalog may occasionally be mispriced. If an item's correct price is higher than our stated price, we will contact you before shipping or cancel the order.</li>
+                <li><strong>Stock Availability:</strong> In the event a book becomes out of stock or out of print prior to order fulfillment, we will notify you promptly and issue a full refund for the unavailable item.</li>
               </ul>
             </section>
 
-            <section className="tos-section" id="contact-tos">
-              <div className="tos-section__marker">13</div>
-              <h2 className="tos-section__title">Contact Us</h2>
-              <p>If you have questions about these Terms of Service, please reach out:</p>
-              <div className="tos-contact-card">
-                <div className="tos-contact-card__row">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
-                    <polyline points="22,6 12,13 2,6" />
+            <section className="tos-section" id="section-6">
+              <div className="tos-section__number">06</div>
+              <h2 className="tos-section__title">Payment Processing &amp; Billing</h2>
+              <p>BookShelf supports multiple secure payment methods including major credit cards, debit cards, UPI, and digital wallet integrations. By submitting payment information, you agree to the following terms:</p>
+              <ul>
+                <li><strong>Authorization:</strong> You authorize BookShelf and its authorized payment gateways (e.g., Stripe, Razorpay) to charge your selected payment instrument for all orders placed under your account.</li>
+                <li><strong>Tax Responsibilities:</strong> Applicable sales taxes, GST, or value-added taxes will be calculated at checkout based on your shipping location and item categorization.</li>
+                <li><strong>Fraud Detection:</strong> We employ automated fraud monitoring. Orders flagged for suspicious activity may require additional identity verification or be subject to cancellation.</li>
+              </ul>
+              <div className="tos-callout">
+                <div className="tos-callout__icon">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="1" y="4" width="22" height="16" rx="2" ry="2" />
+                    <line x1="1" y1="10" x2="23" y2="10" />
                   </svg>
-                  <a href="mailto:legal@bookshelf.com">legal@bookshelf.com</a>
                 </div>
-                <div className="tos-contact-card__row">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
-                    <circle cx="12" cy="10" r="3" />
-                  </svg>
-                  <span>Pune, Maharashtra, India</span>
+                <p><strong>Payment Security:</strong> BookShelf never stores full credit card numbers or CVV codes on our servers. All transactions are processed using 256-bit SSL encryption and PCI-DSS Level 1 compliant infrastructure.</p>
+              </div>
+            </section>
+
+            <section className="tos-section" id="section-7">
+              <div className="tos-section__number">07</div>
+              <h2 className="tos-section__title">Shipping, Delivery &amp; Risk of Loss</h2>
+              <p>Physical orders are dispatched through trusted courier partners. The following shipping terms apply:</p>
+              <ul>
+                <li><strong>Delivery Timelines:</strong> Delivery estimates provided during checkout are non-binding estimates. We are not liable for shipping delays caused by weather, customs clearance, or carrier disruptions.</li>
+                <li><strong>Risk of Loss:</strong> All physical items purchased from BookShelf are made pursuant to a shipment contract. Risk of loss and title for such items pass to you upon our delivery to the carrier.</li>
+                <li><strong>International Shipping:</strong> For international orders, customers are responsible for paying any import duties, tariffs, customs fees, or taxes levied by destination authorities.</li>
+              </ul>
+            </section>
+
+            <section className="tos-section" id="section-8">
+              <div className="tos-section__number">08</div>
+              <h2 className="tos-section__title">Returns, Refunds &amp; Cancellations</h2>
+              <p>We want you to be completely satisfied with your reading experience. Our return policy is structured as follows:</p>
+              <ul>
+                <li><strong>14-Day Return Window:</strong> You may return undamaged, unread physical books in their original packaging within 14 days of delivery for a full refund or exchange.</li>
+                <li><strong>Damaged or Incorrect Items:</strong> If you receive a damaged book, printing defect, or wrong item, please notify us within 48 hours of receipt with photo evidence to receive a free replacement.</li>
+                <li><strong>Return Shipping:</strong> Customers are responsible for return shipping costs unless the return is due to a fulfillment error or defective product on our part.</li>
+                <li><strong>Refund Processing:</strong> Approved refunds will be credited back to your original payment method within 5 to 7 business days following inspect and approval at our warehouse.</li>
+              </ul>
+            </section>
+
+            <section className="tos-section" id="section-9">
+              <div className="tos-section__number">09</div>
+              <h2 className="tos-section__title">Digital Content &amp; E-Book License</h2>
+              <p>When purchasing digital books, e-books, or downloadable audio files on BookShelf:</p>
+              <ul>
+                <li><strong>Limited License:</strong> BookShelf grants you a personal, non-exclusive, non-transferable, non-sublicensable license to download and access the digital content for personal, non-commercial reading.</li>
+                <li><strong>Restrictions:</strong> You may not copy, share, redistribute, sell, broadcast, alter, perform Digital Rights Management (DRM) removal, or upload digital content to file-sharing networks.</li>
+                <li><strong>No Refunds on Digital Content:</strong> Digital downloads are non-refundable once access or download links have been delivered to your account or email address.</li>
+              </ul>
+            </section>
+
+            <section className="tos-section" id="section-10">
+              <div className="tos-section__number">10</div>
+              <h2 className="tos-section__title">Intellectual Property Rights</h2>
+              <p>The BookShelf platform and all of its original content, features, functionality, brand assets, typography, UI designs, graphics, and code are owned by BookShelf and protected by international copyright, trademark, trade secret, and intellectual property laws.</p>
+              <p>Book covers, book titles, author names, and excerpt excerpts remain the exclusive property of their respective publishers, authors, and copyright holders, displayed under license or fair editorial reference.</p>
+            </section>
+
+            <section className="tos-section" id="section-11">
+              <div className="tos-section__number">11</div>
+              <h2 className="tos-section__title">User Conduct &amp; Prohibited Activities</h2>
+              <p>When interacting with BookShelf, you agree NOT to engage in any of the following prohibited activities:</p>
+              <ul>
+                <li>Using automated bots, web scrapers, spiders, or data mining software to extract catalog information or prices.</li>
+                <li>Attempting to bypass security mechanisms, probe system vulnerabilities, or gain unauthorized access to servers.</li>
+                <li>Posting fraudulent reviews, artificial rating manipulation, or spam comments.</li>
+                <li>Using BookShelf to distribute malware, phishing attempts, or illegal materials.</li>
+                <li>Harassing, abusing, threatening, or impersonating other users, staff members, or authors.</li>
+              </ul>
+            </section>
+
+            <section className="tos-section" id="section-12">
+              <div className="tos-section__number">12</div>
+              <h2 className="tos-section__title">User Reviews &amp; Submissions</h2>
+              <p>BookShelf encourages community discussions and book reviews. By submitting reviews, ratings, or comments:</p>
+              <ul>
+                <li><strong>License Grant:</strong> You grant BookShelf a royalty-free, perpetual, worldwide license to publish, feature, translate, and display your reviews across our website and marketing channels.</li>
+                <li><strong>Ownership:</strong> You retain ownership of your submitted text, but warrant that your content does not violate copyright, privacy rights, or contain defamatory material.</li>
+                <li><strong>Moderation:</strong> We reserve the right (but have no obligation) to remove reviews containing profanity, spoilers, personal attacks, or promotional links.</li>
+              </ul>
+            </section>
+
+            <section className="tos-section" id="section-13">
+              <div className="tos-section__number">13</div>
+              <h2 className="tos-section__title">Third-Party Links &amp; Services</h2>
+              <p>BookShelf may contain links to third-party websites, publisher portals, payment processors, or external services that are not owned or controlled by BookShelf.</p>
+              <p>We have no control over, and assume no responsibility for, the content, privacy policies, or practices of any third-party websites. You access third-party links at your own risk.</p>
+            </section>
+
+            <section className="tos-section" id="section-14">
+              <div className="tos-section__number">14</div>
+              <h2 className="tos-section__title">Disclaimer of Warranties</h2>
+              <p>THE BOOKSHELF PLATFORM, SERVICES, AND ALL PRODUCTS SOLD ARE PROVIDED ON AN <strong>"AS IS"</strong> AND <strong>"AS AVAILABLE"</strong> BASIS WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED.</p>
+              <p>TO THE FULL EXTENT PERMISSIBLE BY APPLICABLE LAW, BOOKSHELF DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.</p>
+            </section>
+
+            <section className="tos-section" id="section-15">
+              <div className="tos-section__number">15</div>
+              <h2 className="tos-section__title">Limitation of Liability</h2>
+              <p>TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL BOOKSHELF, ITS DIRECTORS, EMPLOYEES, PARTNERS, OR SUPPLIERS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, CONSEQUENTIAL, SPECIAL, OR PUNITIVE DAMAGES, INCLUDING WITHOUT LIMITATION LOSS OF PROFITS, DATA, USE, OR GOODWILL.</p>
+              <p>OUR MAXIMUM TOTAL AGGREGATE LIABILITY ARISING FROM OR RELATED TO YOUR USE OF THE PLATFORM SHALL NOT EXCEED THE TOTAL AMOUNT PAID BY YOU TO BOOKSHELF IN THE SIX (6) MONTHS PRECEDING THE CLAIM.</p>
+            </section>
+
+            <section className="tos-section" id="section-16">
+              <div className="tos-section__number">16</div>
+              <h2 className="tos-section__title">Indemnification</h2>
+              <p>You agree to defend, indemnify, and hold harmless BookShelf, its affiliates, licensors, and service providers from and against any claims, liabilities, damages, judgments, awards, losses, costs, expenses, or fees (including reasonable attorneys' fees) arising out of or relating to your violation of these Terms or your misuse of the Platform.</p>
+            </section>
+
+            <section className="tos-section" id="section-17">
+              <div className="tos-section__number">17</div>
+              <h2 className="tos-section__title">Dispute Resolution &amp; Binding Arbitration</h2>
+              <p>In the event of any dispute, claim, or controversy arising out of these Terms or the breach thereof:</p>
+              <ul>
+                <li><strong>Informal Negotiation:</strong> Both parties agree to first attempt to resolve any dispute informally for at least 30 days by contacting <a href="mailto:legal@bookshelf.com">legal@bookshelf.com</a>.</li>
+                <li><strong>Binding Arbitration:</strong> If unresolved informally, disputes shall be submitted to final and binding arbitration in accordance with applicable arbitration rules, rather than litigated in court.</li>
+                <li><strong>Class Action Waiver:</strong> YOU AGREE THAT DISPUTES WILL BE ARBITRATED ON AN INDIVIDUAL BASIS AND NOT AS A CLASS ACTION OR REPRESENTATIVE PROCEEDING.</li>
+              </ul>
+            </section>
+
+            <section className="tos-section" id="section-18">
+              <div className="tos-section__number">18</div>
+              <h2 className="tos-section__title">Governing Law &amp; Jurisdiction</h2>
+              <p>These Terms shall be governed by and construed in accordance with the laws of India, without giving effect to any principles of conflicts of law. You agree that any legal action arising out of these Terms shall be filed exclusively in the state or federal courts located in Pune, Maharashtra, India.</p>
+            </section>
+
+            <section className="tos-section" id="section-19">
+              <div className="tos-section__number">19</div>
+              <h2 className="tos-section__title">Severability &amp; Entire Agreement</h2>
+              <p>If any provision of these Terms is found to be unlawful, void, or unenforceable, that provision shall be deemed severable and shall not affect the validity and enforceability of any remaining provisions.</p>
+              <p>These Terms, together with our <Link to="/privacy">Privacy Policy</Link> and <Link to="/about">About Us</Link> documentation, constitute the entire agreement between you and BookShelf regarding your use of the Platform.</p>
+            </section>
+
+            <section className="tos-section" id="section-20">
+              <div className="tos-section__number">20</div>
+              <h2 className="tos-section__title">Amendments &amp; Contact Notice</h2>
+              <p>We reserve the right to modify these Terms at any time. When we make material revisions, we will post the updated Terms on this page and revise the "Last Updated" date at the top of this page. Your continued use of BookShelf following notification of changes signifies your acceptance of the modified Terms.</p>
+
+              <div className="tos-contact-card">
+                <h3 className="tos-contact-card__title">Have Legal Questions?</h3>
+                <p className="tos-contact-card__sub">Our legal and customer experience teams are available to address any inquiries regarding these terms.</p>
+                <div className="tos-contact-card__details">
+                  <div className="tos-contact-card__row">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+                      <polyline points="22,6 12,13 2,6" />
+                    </svg>
+                    <span><strong>Email:</strong> <a href="mailto:legal@bookshelf.com">legal@bookshelf.com</a></span>
+                  </div>
+                  <div className="tos-contact-card__row">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+                      <circle cx="12" cy="10" r="3" />
+                    </svg>
+                    <span><strong>Legal Address:</strong> BookShelf Pvt Ltd, FC Road, Shivajinagar, Pune, Maharashtra 411005, India</span>
+                  </div>
                 </div>
               </div>
             </section>
@@ -263,31 +355,8 @@ export default function TermsOfService() {
         </div>
       </article>
 
-      {/* ── Custom Footer ── */}
-      <footer className="tos-footer">
-        <div className="tos-footer__inner">
-          <div className="tos-footer__top">
-            <Link to="/" className="tos-footer__brand">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
-                stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
-                <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
-              </svg>
-              BookShelf
-            </Link>
-            <div className="tos-footer__links">
-              <Link to="/">Home</Link>
-              <Link to="/about">About</Link>
-              <Link to="/privacy">Privacy Policy</Link>
-              <span className="tos-footer__links-active">Terms of Service</span>
-            </div>
-          </div>
-          <div className="tos-footer__bottom">
-            <p>© {new Date().getFullYear()} BookShelf. All rights reserved.</p>
-            <p className="tos-footer__note">This document was last reviewed on {lastUpdated}.</p>
-          </div>
-        </div>
-      </footer>
+      {/* ── Footer ── */}
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
closes #36 

Now the navbar, footer, and theme toggle is added to the Terms of service page

images:-
<img width="1366" height="680" alt="image" src="https://github.com/user-attachments/assets/9e55613d-d388-4c01-b89d-5ff9ab58188a" />
