### PR TITLE
feat(search): add live search functionality to navbar

### DIFF
--- a/bookshelf-frontend/src/App.jsx
+++ b/bookshelf-frontend/src/App.jsx
@@ -16,6 +16,7 @@ import './App.css';
 
 export default function App() {
   const [cart, setCart] = useState([]);
+  const [searchQuery, setSearchQuery] = useState('');
 
   function handleAddToCart(book) {
     setCart((prev) => {
@@ -35,11 +36,16 @@ export default function App() {
       <ScrollToTop />
       <CustomCursor />
 
-      <Navbar cartCount={cart.length} onCartClick={() => {}} />
+      <Navbar 
+        cartCount={cart.length} 
+        onCartClick={() => {}} 
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+      />
       <div className="nav-spacer" />
 
       <Routes>
-        <Route path="/" element={<Home onAddToCart={handleAddToCart} />} />
+        <Route path="/" element={<Home onAddToCart={handleAddToCart} searchQuery={searchQuery} />} />
         <Route path="/about" element={<AboutUs />} />
         <Route path="/privacy" element={<PrivacyPolicy />} />
         <Route path="/terms" element={<TermsOfService />} />

--- a/bookshelf-frontend/src/components/Navbar.jsx
+++ b/bookshelf-frontend/src/components/Navbar.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import './Navbar.css';
 
-export default function Navbar({ cartCount, onCartClick }) {
+export default function Navbar({ cartCount, onCartClick, searchQuery, setSearchQuery }) {
   const [mobileOpen, setMobileOpen] = useState(false);
 
   return (
@@ -30,7 +30,13 @@ export default function Navbar({ cartCount, onCartClick }) {
 
           {/* Desktop actions */}
           <div className="nav__actions">
-            <input className="nav__search" type="search" placeholder="Search titles, authors…" />
+            <input 
+              className="nav__search" 
+              type="search" 
+              placeholder="Search titles, authors…" 
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
             <button className="nav__cart" onClick={onCartClick} aria-label="Open cart">
               Cart
               <span className="nav__cart-count">{cartCount}</span>
@@ -67,7 +73,13 @@ export default function Navbar({ cartCount, onCartClick }) {
             <a href="#shelf" onClick={() => setMobileOpen(false)}>The Shelf</a>
             <a href="#catalog" onClick={() => setMobileOpen(false)}>Browse</a>
             <Link to="/about" onClick={() => setMobileOpen(false)}>About</Link>
-            <input className="nav__search nav__search--mobile" type="search" placeholder="Search titles, authors…" />
+            <input 
+              className="nav__search nav__search--mobile" 
+              type="search" 
+              placeholder="Search titles, authors…" 
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
           </div>
         )}
       </header>

--- a/bookshelf-frontend/src/pages/Home.jsx
+++ b/bookshelf-frontend/src/pages/Home.jsx
@@ -4,13 +4,20 @@ import GenreFilter from '../components/GenreFilter.jsx';
 import BookCard from '../components/BookCard.jsx';
 import { books, genres } from '../data/books.js';
 
-export default function Home({ onAddToCart }) {
+export default function Home({ onAddToCart, searchQuery = '' }) {
   const [activeGenre, setActiveGenre] = useState('All');
 
   const visibleBooks = useMemo(() => {
-    if (activeGenre === 'All') return books;
-    return books.filter((book) => book.genre === activeGenre);
-  }, [activeGenre]);
+    return books.filter((book) => {
+      const matchesGenre = activeGenre === 'All' || book.genre === activeGenre;
+      const query = searchQuery.toLowerCase();
+      const matchesSearch =
+        book.title.toLowerCase().includes(query) ||
+        book.author.toLowerCase().includes(query);
+
+      return matchesGenre && matchesSearch;
+    });
+  }, [activeGenre, searchQuery]);
 
   return (
     <>


### PR DESCRIPTION
resolves #61 
# Summary
Implemented real-time live search functionality directly into the Navbar, filtering the catalog by title or author dynamically as the user types, combined seamlessly with the genre selection.

---

# Root Cause
The `<Navbar />` contained decorative search inputs, but they were unmanaged strings that were not connected to a shared reactive state capable of driving changes in the `visibleBooks` calculation in `<Home />`.

---

# Solution
Lifted a `searchQuery` state into the `<App />` component. We pass the setter down to `<Navbar />` making the inputs controlled, and we pass the query string itself down to `<Home />`. Within `Home.jsx`, the `useMemo` block was updated to compute filtering for both genre and search text simultaneously (case-insensitive string inclusion).

---

# Files Changed
* **`bookshelf-frontend/src/App.jsx`**: Introduced the `searchQuery` state and passed the relevant props into the Navbar and Home components.
* **`bookshelf-frontend/src/components/Navbar.jsx`**: Bound the new props to the mobile and desktop `<input>` fields, making them controlled components.
* **`bookshelf-frontend/src/pages/Home.jsx`**: Integrated `searchQuery` into the `visibleBooks` memoized selector logic for simultaneous title and author matching.

---

# Testing
* Build passed (`npm run build`)
* Lint passed (no syntax errors)
* Tests passed (all components compile and mount cleanly)
* Manual verification completed (live search responds immediately upon typing, preserving state alongside genre).

---

# Impact
* Breaking changes: No
* Performance impact: Negligible (Filter runs cleanly via React `useMemo`)
* Security impact: None
* Compatibility: Fully backward compatible with the Cart additions and existing GenreFilter logic.

---

# Checklist

* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
   