### PR TITLE
Extra footer removed

### DIFF
--- a/bookshelf-frontend/src/pages/AboutUs.jsx
+++ b/bookshelf-frontend/src/pages/AboutUs.jsx
@@ -162,7 +162,7 @@ export default function AboutUs() {
       </section>
 
       {/* ── Footer (same as landing page) ── */}
-      <Footer />
+      {/* <Footer /> */}
     </div>
   );
 }

--- a/bookshelf-frontend/src/pages/PrivacyPolicy.jsx
+++ b/bookshelf-frontend/src/pages/PrivacyPolicy.jsx
@@ -223,9 +223,6 @@ export default function PrivacyPolicy() {
           </div>
         </div>
       </article>
-
-      {/* ── Footer (same as landing page) ── */}
-      <Footer />
     </div>
   );
 }

--- a/bookshelf-frontend/src/pages/TermsOfService.jsx
+++ b/bookshelf-frontend/src/pages/TermsOfService.jsx
@@ -354,9 +354,6 @@ export default function TermsOfService() {
           </div>
         </div>
       </article>
-
-      {/* ── Footer ── */}
-      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
extra footer on the privacy policy, terms of service and about us page is being removed/

image:-
<img width="1366" height="683" alt="image" src="https://github.com/user-attachments/assets/b20bdb77-4417-40e0-8994-04bc2e00792f" />
