### PR TITLE
Dead code removed

### DIFF
--- a/bookshelf-frontend/src/components/BookCard.css
+++ b/bookshelf-frontend/src/components/BookCard.css
@@ -11,6 +11,14 @@
   transform: translateY(-4px);
 }
 
+/* Wrapper link around the cover — resets anchor defaults */
+.book-card__cover-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+
 .book-card__cover {
   position: relative;
   height: 170px;

--- a/bookshelf-frontend/src/components/BookCard.jsx
+++ b/bookshelf-frontend/src/components/BookCard.jsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import WishlistButton from './WishlistButton.jsx';
@@ -6,34 +5,48 @@ import { CartContext } from '../context/CartContext.jsx';
 import { WishlistContext } from '../context/WishlistContext.jsx';
 import './BookCard.css';
 
-export default function BookCard({ book }) {
+/**
+ * BookCard — displays a single book as a card.
+ *
+ * Props:
+ *   book        {object}   required — the book data object
+ *   onAddToCart {function} optional — override the default CartContext addToCart.
+ *                          Useful for contexts where the book object returned by the
+ *                          parent differs from what CartContext would receive
+ *                          (e.g. RecentlyViewed). Falls back to CartContext.addToCart.
+ */
+export default function BookCard({ book, onAddToCart }) {
   const { addToCart } = useContext(CartContext);
   const { wishlist, toggleWishlist } = useContext(WishlistContext);
 
+  // Allow callers to override the add-to-cart behaviour; default to global context.
+  const handleAddToCart = () => {
+    if (onAddToCart) {
+      onAddToCart(book);
+    } else {
+      addToCart(book);
+    }
+  };
+
   return (
     <article className="book-card">
-      <Link to={`/books/${book.id}`} className="book-card__cover-link" style={{textDecoration: 'none', color: 'inherit'}}>
+      {/* Cover — clicking navigates to the detail page */}
+      <Link to={`/book/${book.id}`} className="book-card__cover-link">
         <div className="book-card__cover" style={{ '--cover-color': book.cover }}>
+          {book.coverImage && (
+            <img
+              src={book.coverImage}
+              alt={book.title}
+              loading="lazy"
+              className="book-card__cover-image"
+            />
+          )}
           <span className="book-card__genre">{book.genre}</span>
           <span className="book-card__cover-title">{book.title}</span>
         </div>
       </Link>
 
-      <div className="book-card__body">
-        <Link to={`/books/${book.id}`} style={{textDecoration: 'none', color: 'inherit'}}>
-      <div className="book-card__cover" style={{ '--cover-color': book.cover }}>
-        {book.coverImage && (
-          <img
-            src={book.coverImage}
-            alt={book.title}
-            loading="lazy"
-            className="book-card__cover-image"
-          />
-        )}
-        <span className="book-card__genre">{book.genre}</span>
-        <span className="book-card__cover-title">{book.title}</span>
-      </div>
-
+      {/* Body — title, author, rating/price, actions */}
       <div className="book-card__body">
         <Link to={`/book/${book.id}`} className="book-card__link">
           <h3 className="book-card__title">{book.title}</h3>
@@ -46,10 +59,13 @@ export default function BookCard({ book }) {
         </div>
 
         <div className="book-card__actions">
-          <button className="book-card__add" onClick={() => addToCart(book)}>
+          <button className="book-card__add" onClick={handleAddToCart}>
             Add to cart
           </button>
-          <WishlistButton active={wishlist?.includes(book.id)} onToggle={() => toggleWishlist(book.id)} />
+          <WishlistButton
+            active={wishlist?.includes(book.id)}
+            onToggle={() => toggleWishlist(book.id)}
+          />
         </div>
       </div>
     </article>

--- a/bookshelf-frontend/src/components/RecentlyViewed.jsx
+++ b/bookshelf-frontend/src/components/RecentlyViewed.jsx
@@ -3,41 +3,44 @@ import BookCard from './BookCard';
 import { books } from '../data/books';
 import './RecentlyViewed.css';
 
+/**
+ * RecentlyViewed — shows a horizontal scroll strip of previously visited books.
+ *
+ * Reads an array of book IDs from localStorage ('recentlyViewed') and maps them
+ * to book objects. The current book (if provided) is excluded from the list.
+ *
+ * Add-to-cart behaviour is handled by BookCard via CartContext — no prop needed.
+ */
 export default function RecentlyViewed({ currentBookId }) {
   const [recentBooks, setRecentBooks] = useState([]);
 
   useEffect(() => {
     try {
       const stored = localStorage.getItem('recentlyViewed');
-      if (stored) {
-        let parsed = JSON.parse(stored);
-        
-        // Filter out current book if provided
-        if (currentBookId) {
-          parsed = parsed.filter(id => String(id) !== String(currentBookId));
-        }
+      if (!stored) return;
 
-        // Map IDs to actual book objects
-        const mappedBooks = parsed
-          .map(id => books.find(b => String(b.id) === String(id)))
-          .filter(Boolean); // Remove undefined/null if any ID is invalid
-          
-        setRecentBooks(mappedBooks);
+      let parsed = JSON.parse(stored);
+
+      // Exclude the book currently being viewed
+      if (currentBookId) {
+        parsed = parsed.filter(id => String(id) !== String(currentBookId));
       }
+
+      // Map IDs → book objects, dropping any stale/invalid IDs
+      const mappedBooks = parsed
+        .map(id => books.find(b => String(b.id) === String(id)))
+        .filter(Boolean);
+
+      setRecentBooks(mappedBooks);
     } catch (e) {
       console.error('Failed to parse recently viewed books:', e);
     }
   }, [currentBookId]);
 
+  // Nothing to show — render nothing rather than an empty section
   if (recentBooks.length === 0) {
     return null;
   }
-
-  // Handle Add to cart for recently viewed (placeholder if needed, but BookCard expects it)
-  const handleAddToCart = (book) => {
-    // Ideally this would use a global cart context or dispatch
-    console.log('Added to cart from recently viewed:', book.title);
-  };
 
   return (
     <section className="recently-viewed">
@@ -46,7 +49,8 @@ export default function RecentlyViewed({ currentBookId }) {
         <div className="recently-viewed__scroll">
           {recentBooks.map(book => (
             <div key={book.id} className="recently-viewed__item">
-              <BookCard book={book} onAddToCart={handleAddToCart} />
+              {/* BookCard uses CartContext internally — no onAddToCart prop needed */}
+              <BookCard book={book} />
             </div>
           ))}
         </div>

--- a/bookshelf-frontend/src/main.jsx
+++ b/bookshelf-frontend/src/main.jsx
@@ -1,23 +1,15 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
-import App from './App.jsx'
-import AboutUs from './pages/AboutUs.jsx'
-import PrivacyPolicy from './pages/PrivacyPolicy.jsx'
-import TermsOfService from './pages/TermsOfService.jsx'
-import BookDetail from './pages/BookDetail.jsx'
-import './index.css'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import './i18n.js';
+import App from './App.jsx';
+import { CartProvider } from './context/CartContext.jsx';
+import { WishlistProvider } from './context/WishlistContext.jsx';
+import './index.css';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<App />} />
-        <Route path="/about" element={<AboutUs />} />
-        <Route path="/privacy" element={<PrivacyPolicy />} />
-        <Route path="/terms" element={<TermsOfService />} />
-        <Route path="/books/:id" element={<BookDetail />} />
-      </Routes>
       <CartProvider>
         <WishlistProvider>
           <App />


### PR DESCRIPTION
closes #168 

The handleAddToCart = (book) => console.log(...) function existed only because BookCard previously didn't accept onAddToCart. Now that BookCard supports it with a proper fallback to CartContext, RecentlyViewed doesn't need to provide it at all — the prop is simply omitted.

main.jsx — Double router fixed
The git pull introduced a standalone <Routes> tree with /books/:id above the <CartProvider> block, rendering <App /> twice. Restored to the original single correct entry point.

BookCard.css — Missing rule added
.book-card__cover-link was used in the new JSX but had no CSS. Added display: block + text-decoration/color reset (previously done as inline styles on the broken JSX).