### PR TITLE
Wire FilterSidebar into Home.jsx

### DIFF
--- a/bookshelf-frontend/src/App.css
+++ b/bookshelf-frontend/src/App.css
@@ -2,6 +2,8 @@
   min-height: 100vh;
 }
 
+/* ─── Catalog page ─────────────────────────────────────────────────────── */
+
 .catalog {
   padding: 88px 32px 40px;
 }
@@ -28,16 +30,53 @@
   color: var(--ink-soft);
 }
 
+/* ─── Two-column layout: sidebar + grid ────────────────────────────────── */
+
 .catalog__layout {
   display: flex;
   gap: 32px;
   align-items: flex-start;
 }
 
+/* The right-hand column that holds controls + grid + pagination */
 .catalog__grid-container {
   flex: 1;
-  min-width: 0;
+  min-width: 0; /* prevents flex children from overflowing */
 }
+
+/* ─── Sort / controls bar ───────────────────────────────────────────────── */
+
+.catalog__controls {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin: 0 0 16px;
+}
+
+.catalog__sort-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background-color: var(--paper-dim);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 6px 32px 6px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--ink);
+  cursor: pointer;
+  outline: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  transition: border-color 0.2s;
+}
+
+.catalog__sort-select:hover,
+.catalog__sort-select:focus {
+  border-color: var(--ink);
+}
+
+/* ─── Book grid ─────────────────────────────────────────────────────────── */
 
 .catalog__grid {
   display: grid;
@@ -45,12 +84,14 @@
   gap: 20px;
 }
 
+/* ─── Empty / active-filter indicator ──────────────────────────────────── */
+
 .catalog__empty {
   text-align: center;
   padding: 64px 20px;
   background: var(--paper-dim);
   border-radius: 12px;
-  border: 1px dashed var(--border);
+  border: 1px dashed var(--line);
 }
 
 .catalog__empty h3 {
@@ -66,51 +107,70 @@
   padding: 8px 16px;
   border-radius: 6px;
   cursor: pointer;
-.catalog__controls {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  margin: 14px 0 4px;
+  font-size: 14px;
+  transition: opacity 0.15s;
 }
 
-.catalog__sort-select {
-  appearance: none;
-  -webkit-appearance: none;
-  background-color: var(--surface, #fff);
-  border: 1px solid var(--line, #ddd);
-  border-radius: 8px;
-  padding: 6px 32px 6px 12px;
+.catalog__empty-btn:hover {
+  opacity: 0.8;
+}
+
+/* Active filter summary pill shown above the grid */
+.catalog__filter-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
   font-family: var(--font-mono);
   font-size: 12px;
-  color: var(--ink, #111);
-  cursor: pointer;
-  outline: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 10px center;
-  transition: border-color 0.2s;
+  color: var(--ink-soft);
 }
 
-.catalog__sort-select:hover,
-.catalog__sort-select:focus {
-  border-color: var(--ink, #111);
+.catalog__filter-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--paper-dim);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 3px 10px;
+  color: var(--ink);
 }
+
+.catalog__filter-tag button {
+  background: none;
+  border: none;
+  padding: 0;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--ink-soft);
+  font-size: 14px;
+}
+
+.catalog__filter-tag button:hover {
+  color: var(--leather);
+}
+
+/* ─── Responsive ────────────────────────────────────────────────────────── */
 
 @media (max-width: 960px) {
   .catalog__layout {
     flex-direction: column;
     gap: 24px;
   }
+
   .catalog__grid {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
 @media (max-width: 560px) {
-  .catalog__grid {
-    grid-template-columns: 1fr;
-  }
   .catalog {
     padding-top: 40px;
+  }
+
+  .catalog__grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/bookshelf-frontend/src/components/FilterSidebar.css
+++ b/bookshelf-frontend/src/components/FilterSidebar.css
@@ -1,66 +1,93 @@
+/* ─── Sidebar shell ────────────────────────────────────────────────────── */
+
 .filter-sidebar {
-  background: var(--paper);
+  background: var(--paper-dim);
   border-radius: 12px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--line);
   padding: 24px;
-  width: 280px;
+  width: 260px;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 0;
+  /* Stick to the top of the viewport when scrolling */
+  position: sticky;
+  top: 96px;
+  max-height: calc(100vh - 120px);
+  overflow-y: auto;
 }
+
+/* ─── Mobile header (toggle button row) ────────────────────────────────── */
 
 .filter-sidebar__header-mobile {
   display: none;
 }
 
+/* ─── Desktop header (title + Clear All) ───────────────────────────────── */
+
 .filter-sidebar__header-desktop {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
 }
 
 .filter-sidebar__title {
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 600;
   margin: 0;
+  color: var(--ink);
 }
+
+/* ─── Clear / utility buttons ──────────────────────────────────────────── */
 
 .filter-sidebar__clear {
   background: transparent;
   border: none;
-  color: var(--ink-soft);
+  color: var(--leather);
   cursor: pointer;
-  font-size: 14px;
+  font-size: 13px;
   text-decoration: underline;
   padding: 0;
+  font-family: var(--font-body);
 }
 
 .filter-sidebar__clear:hover {
-  color: var(--ink);
+  color: var(--leather-deep);
 }
+
+/* ─── Content area ──────────────────────────────────────────────────────── */
 
 .filter-sidebar__content {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 20px;
 }
+
+/* ─── Filter groups (fieldset / legend reset) ──────────────────────────── */
 
 .filter-group {
+  border: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 }
 
-.filter-group__title {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--ink);
+.filter-group__title,
+.filter-group > legend {
+  font-size: 11px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--ink-soft);
   margin: 0;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.07em;
+  padding: 0;
 }
+
+/* ─── Checkboxes (genre) ────────────────────────────────────────────────── */
 
 .filter-group__checkboxes,
 .filter-rating-radios {
@@ -80,55 +107,90 @@
 .filter-checkbox input,
 .filter-radio input {
   cursor: pointer;
+  accent-color: var(--leather);
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
 }
 
 .filter-checkbox__label,
 .filter-radio__label {
   font-size: 14px;
   color: var(--ink);
+  line-height: 1.3;
 }
+
+/* Small "Any rating" reset link inside the rating group */
+.filter-rating__clear {
+  margin-top: 2px;
+  font-size: 12px;
+  text-align: left;
+}
+
+/* ─── Price inputs ──────────────────────────────────────────────────────── */
 
 .filter-price-inputs {
   display: flex;
-  gap: 12px;
+  gap: 10px;
 }
 
 .filter-price-input {
   display: flex;
   align-items: center;
-  background: var(--paper-dim);
-  border: 1px solid var(--border);
+  background: var(--paper);
+  border: 1px solid var(--line);
   border-radius: 6px;
-  padding: 6px 12px;
+  padding: 6px 10px;
   flex: 1;
+  transition: border-color 0.15s;
+}
+
+.filter-price-input:focus-within {
+  border-color: var(--leather);
 }
 
 .filter-price-input__prefix {
-  font-size: 14px;
+  font-size: 12px;
+  font-family: var(--font-mono);
   color: var(--ink-soft);
   margin-right: 4px;
+  white-space: nowrap;
 }
 
 .filter-price-input input {
   border: none;
   background: transparent;
   width: 100%;
-  font-size: 14px;
+  font-size: 13px;
   color: var(--ink);
   outline: none;
+  font-family: var(--font-mono);
+  min-width: 0;
 }
+
+/* Remove number input spinners */
+.filter-price-input input::-webkit-inner-spin-button,
+.filter-price-input input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* ─── Mobile footer actions ─────────────────────────────────────────────── */
 
 .filter-sidebar__mobile-actions {
   display: none;
 }
 
-/* Mobile styles */
+/* ─── Responsive ────────────────────────────────────────────────────────── */
+
 @media (max-width: 960px) {
   .filter-sidebar {
     width: 100%;
     padding: 16px;
     border-radius: 8px;
-    gap: 16px;
+    position: static; /* don't stick on mobile */
+    max-height: none;
+    overflow-y: visible;
   }
 
   .filter-sidebar__header-mobile {
@@ -141,40 +203,56 @@
     background: var(--ink);
     color: var(--paper);
     border: none;
-    padding: 6px 12px;
+    padding: 6px 14px;
     border-radius: 6px;
     cursor: pointer;
-    font-size: 14px;
+    font-size: 13px;
+    font-family: var(--font-body);
+    transition: opacity 0.15s;
   }
 
+  .filter-sidebar__toggle:hover {
+    opacity: 0.8;
+  }
+
+  /* Hide desktop header on mobile */
   .filter-sidebar__header-desktop {
     display: none;
   }
 
+  /* Collapsed state — hide the filter panels */
   .filter-sidebar__content {
-    display: none; /* hidden by default on mobile */
+    display: none;
   }
 
+  /* Expanded state */
   .filter-sidebar.is-open .filter-sidebar__content {
     display: flex;
+    margin-top: 16px;
   }
-  
+
   .filter-sidebar__mobile-actions {
     display: flex;
     justify-content: space-between;
     align-items: center;
     margin-top: 12px;
     padding-top: 16px;
-    border-top: 1px solid var(--border);
+    border-top: 1px solid var(--line);
   }
 
   .filter-sidebar__apply {
     background: var(--ink);
     color: var(--paper);
     border: none;
-    padding: 8px 16px;
+    padding: 8px 20px;
     border-radius: 6px;
     cursor: pointer;
     font-weight: 600;
+    font-family: var(--font-body);
+    transition: opacity 0.15s;
+  }
+
+  .filter-sidebar__apply:hover {
+    opacity: 0.8;
   }
 }

--- a/bookshelf-frontend/src/components/FilterSidebar.jsx
+++ b/bookshelf-frontend/src/components/FilterSidebar.jsx
@@ -1,5 +1,22 @@
 import './FilterSidebar.css';
 
+/**
+ * FilterSidebar — collapsible filter panel for the book catalogue.
+ *
+ * Props:
+ *   genres           string[]   full list of genre strings (including 'All')
+ *   selectedGenres   string[]   currently checked genres
+ *   onGenreChange    (genre: string, checked: boolean) => void
+ *   minPrice         string     minimum price input value (empty string = no filter)
+ *   onMinPriceChange (value: string) => void
+ *   maxPrice         string     maximum price input value (empty string = no filter)
+ *   onMaxPriceChange (value: string) => void
+ *   minRating        number|null  minimum star rating (null = no filter)
+ *   onMinRatingChange (rating: number|null) => void
+ *   onClearFilters   () => void  resets all filter state
+ *   isOpen           boolean    controls mobile open/close state
+ *   onToggle         () => void  toggles isOpen
+ */
 export default function FilterSidebar({
   genres,
   selectedGenres,
@@ -12,27 +29,47 @@ export default function FilterSidebar({
   onMinRatingChange,
   onClearFilters,
   isOpen,
-  onToggle
+  onToggle,
 }) {
+  const hasActiveFilters =
+    selectedGenres.length > 0 ||
+    minPrice !== '' ||
+    maxPrice !== '' ||
+    minRating !== null;
+
   return (
-    <aside className={`filter-sidebar ${isOpen ? 'is-open' : ''}`}>
+    <aside className={`filter-sidebar ${isOpen ? 'is-open' : ''}`} aria-label="Filter books">
+      {/* Mobile header — always visible, toggles the panel open */}
       <div className="filter-sidebar__header-mobile">
         <h3 className="filter-sidebar__title">Filters</h3>
-        <button className="filter-sidebar__toggle" onClick={onToggle}>
-          {isOpen ? 'Close' : 'Filter'}
+        <button
+          className="filter-sidebar__toggle"
+          onClick={onToggle}
+          aria-expanded={isOpen}
+          aria-controls="filter-sidebar-content"
+        >
+          {isOpen ? 'Close ✕' : 'Filter ▼'}
         </button>
       </div>
 
-      <div className="filter-sidebar__content">
+      {/* Collapsible content */}
+      <div
+        className="filter-sidebar__content"
+        id="filter-sidebar-content"
+      >
+        {/* Desktop header — always visible on large screens */}
         <div className="filter-sidebar__header-desktop">
           <h3 className="filter-sidebar__title">Filters</h3>
-          <button className="filter-sidebar__clear" onClick={onClearFilters}>
-            Clear All
-          </button>
+          {hasActiveFilters && (
+            <button className="filter-sidebar__clear" onClick={onClearFilters}>
+              Clear All
+            </button>
+          )}
         </div>
 
-        <div className="filter-group">
-          <h4 className="filter-group__title">Category</h4>
+        {/* ── Genre ──────────────────────────────────────── */}
+        <fieldset className="filter-group">
+          <legend className="filter-group__title">Category</legend>
           <div className="filter-group__checkboxes">
             {genres.filter(g => g !== 'All').map(genre => (
               <label key={genre} className="filter-checkbox">
@@ -45,36 +82,41 @@ export default function FilterSidebar({
               </label>
             ))}
           </div>
-        </div>
+        </fieldset>
 
-        <div className="filter-group">
-          <h4 className="filter-group__title">Price</h4>
+        {/* ── Price range ────────────────────────────────── */}
+        <fieldset className="filter-group">
+          <legend className="filter-group__title">Price (₹)</legend>
           <div className="filter-price-inputs">
             <label className="filter-price-input">
-              <span className="filter-price-input__prefix">Min: $</span>
+              {/* Fixed: was '$', corrected to '₹' to match app currency */}
+              <span className="filter-price-input__prefix">Min ₹</span>
               <input
                 type="number"
                 min="0"
                 value={minPrice}
                 onChange={(e) => onMinPriceChange(e.target.value)}
                 placeholder="0"
+                aria-label="Minimum price in rupees"
               />
             </label>
             <label className="filter-price-input">
-              <span className="filter-price-input__prefix">Max: $</span>
+              <span className="filter-price-input__prefix">Max ₹</span>
               <input
                 type="number"
                 min="0"
                 value={maxPrice}
                 onChange={(e) => onMaxPriceChange(e.target.value)}
                 placeholder="Any"
+                aria-label="Maximum price in rupees"
               />
             </label>
           </div>
-        </div>
+        </fieldset>
 
-        <div className="filter-group">
-          <h4 className="filter-group__title">Minimum Rating</h4>
+        {/* ── Minimum rating ─────────────────────────────── */}
+        <fieldset className="filter-group">
+          <legend className="filter-group__title">Minimum Rating</legend>
           <div className="filter-rating-radios">
             {[4, 3, 2, 1].map(rating => (
               <label key={rating} className="filter-radio">
@@ -89,11 +131,21 @@ export default function FilterSidebar({
                 </span>
               </label>
             ))}
+            {/* Allow clearing the rating filter */}
+            {minRating !== null && (
+              <button
+                className="filter-sidebar__clear filter-rating__clear"
+                onClick={() => onMinRatingChange(null)}
+              >
+                Any rating
+              </button>
+            )}
           </div>
-        </div>
-        
+        </fieldset>
+
+        {/* ── Mobile footer actions ──────────────────────── */}
         <div className="filter-sidebar__mobile-actions">
-           <button className="filter-sidebar__clear" onClick={onClearFilters}>
+          <button className="filter-sidebar__clear" onClick={onClearFilters}>
             Clear All
           </button>
           <button className="filter-sidebar__apply" onClick={onToggle}>

--- a/bookshelf-frontend/src/pages/Home.jsx
+++ b/bookshelf-frontend/src/pages/Home.jsx
@@ -1,45 +1,89 @@
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import Hero from '../components/Hero.jsx';
-import GenreFilter from '../components/GenreFilter.jsx';
+import FilterSidebar from '../components/FilterSidebar.jsx';
 import BookCard from '../components/BookCard.jsx';
 import Pagination from '../components/Pagination.jsx';
 import SkeletonLoader from '../components/SkeletonLoader.jsx';
 
+// Genre list is static since the backend catalogue is fixed.
+// If the backend adds a GET /api/genres endpoint in the future, replace this.
+const ALL_GENRES = ['All', 'Fiction', 'Sci-Fi', 'Mystery', 'Self-Help', 'Poetry'];
+
 export default function Home({ searchQuery = '' }) {
   const { t } = useTranslation();
+
+  // ── Server-side data ──────────────────────────────────────────────────
   const [books, setBooks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [activeGenre, setActiveGenre] = useState('All');
-  const [activeSort, setActiveSort] = useState('');
-  
-  // Pagination state
+
+  // ── Pagination ────────────────────────────────────────────────────────
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [totalBooks, setTotalBooks] = useState(0);
-  const limit = 4; // Items per page
+  const limit = 4; // books per page
 
-  // Reset to page 1 when search, genre, or sort changes
+  // ── Sort (server-side) ────────────────────────────────────────────────
+  const [activeSort, setActiveSort] = useState('');
+
+  // ── FilterSidebar state ───────────────────────────────────────────────
+  const [selectedGenres, setSelectedGenres] = useState([]);  // multi-select checkboxes
+  const [minPrice, setMinPrice] = useState('');              // client-side price filter
+  const [maxPrice, setMaxPrice] = useState('');              // client-side price filter
+  const [minRating, setMinRating] = useState(null);          // client-side rating filter
+  const [sidebarOpen, setSidebarOpen] = useState(false);     // mobile toggle
+
+  // ── Derived: single genre for API (backend takes one string) ──────────
+  // If exactly one genre is selected, pass it. Otherwise fetch everything
+  // and rely on client-side filtering for multi-select or "show all" cases.
+  const apiGenre = selectedGenres.length === 1 ? selectedGenres[0] : 'All';
+
+  // ── Helpers ───────────────────────────────────────────────────────────
+
+  const handleGenreChange = useCallback((genre, checked) => {
+    setSelectedGenres(prev =>
+      checked ? [...prev, genre] : prev.filter(g => g !== genre)
+    );
+    setCurrentPage(1);
+  }, []);
+
+  const handleClearFilters = useCallback(() => {
+    setSelectedGenres([]);
+    setMinPrice('');
+    setMaxPrice('');
+    setMinRating(null);
+    setCurrentPage(1);
+  }, []);
+
+  const hasActiveFilters =
+    selectedGenres.length > 0 ||
+    minPrice !== '' ||
+    maxPrice !== '' ||
+    minRating !== null;
+
+  // ── Reset page when any upstream filter changes ───────────────────────
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchQuery, activeGenre, activeSort]);
+  }, [searchQuery, apiGenre, activeSort]);
 
+  // ── Fetch books from backend ──────────────────────────────────────────
   useEffect(() => {
     const loadBooks = async () => {
       try {
         setLoading(true);
+        setError(null);
         const params = new URLSearchParams({
-            page: currentPage,
-            limit: limit,
-            genre: activeGenre,
-            search: searchQuery,
-            ...(activeSort && { sort: activeSort }),
+          page: currentPage,
+          limit: limit,
+          genre: apiGenre,
+          search: searchQuery,
+          ...(activeSort && { sort: activeSort }),
         });
         const response = await fetch(`http://localhost:5000/api/books?${params.toString()}`);
 
         if (!response.ok) {
-          throw new Error("Failed to load books");
+          throw new Error('Failed to load books');
         }
 
         const data = await response.json();
@@ -54,62 +98,158 @@ export default function Home({ searchQuery = '' }) {
     };
 
     loadBooks();
-  }, [currentPage, activeGenre, activeSort, searchQuery]);
+  }, [currentPage, apiGenre, activeSort, searchQuery]);
 
-  const genres = useMemo(() => {
-    return ['All', 'Fiction', 'Sci-Fi', 'Mystery', 'Self-Help', 'Poetry']; // hardcoded from mock since pagination limits scope
-  }, []);
+  // ── Client-side filter on fetched page ───────────────────────────────
+  // Applied after the fetch so server pagination stays accurate for genre/search/sort.
+  // Price and rating filters narrow the displayed results within the current page.
+  const displayedBooks = useMemo(() => {
+    let result = books;
 
+    // Multi-genre: if more than one genre is checked, filter the fetched batch
+    if (selectedGenres.length > 1) {
+      result = result.filter(b => selectedGenres.includes(b.genre));
+    }
+
+    if (minPrice !== '') {
+      result = result.filter(b => b.price >= Number(minPrice));
+    }
+
+    if (maxPrice !== '') {
+      result = result.filter(b => b.price <= Number(maxPrice));
+    }
+
+    if (minRating !== null) {
+      result = result.filter(b => b.rating >= minRating);
+    }
+
+    return result;
+  }, [books, selectedGenres, minPrice, maxPrice, minRating]);
+
+  // ── Render ────────────────────────────────────────────────────────────
   return (
     <>
       <Hero />
       <main className="catalog" id="catalog">
         <div className="catalog__inner">
+
+          {/* Page title + book count */}
           <div className="catalog__header">
             <h2 className="catalog__title">{t('home.featuredTitle')}</h2>
             <p className="catalog__count">{t('home.titlesTotal', { count: totalBooks })}</p>
           </div>
 
-          <GenreFilter genres={genres} active={activeGenre} onSelect={setActiveGenre} />
+          {/* Two-column layout: sidebar | grid */}
+          <div className="catalog__layout">
 
-          <div className="catalog__controls">
-            <select
-              id="sort-select"
-              className="catalog__sort-select"
-              value={activeSort}
-              onChange={(e) => setActiveSort(e.target.value)}
-              aria-label={t('home.sortAriaLabel')}
-            >
-              <option value="">{t('home.sortDefault')}</option>
-              <option value="price_asc">{t('home.sortPriceAsc')}</option>
-              <option value="price_desc">{t('home.sortPriceDesc')}</option>
-              <option value="rating_desc">{t('home.sortRatingDesc')}</option>
-              <option value="title_asc">{t('home.sortTitleAsc')}</option>
-            </select>
-          </div>
+            {/* ── Left: filter sidebar ─────────────────────── */}
+            <FilterSidebar
+              genres={ALL_GENRES}
+              selectedGenres={selectedGenres}
+              onGenreChange={handleGenreChange}
+              minPrice={minPrice}
+              onMinPriceChange={setMinPrice}
+              maxPrice={maxPrice}
+              onMaxPriceChange={setMaxPrice}
+              minRating={minRating}
+              onMinRatingChange={setMinRating}
+              onClearFilters={handleClearFilters}
+              isOpen={sidebarOpen}
+              onToggle={() => setSidebarOpen(o => !o)}
+            />
 
-          {loading ? (
-            <div className="catalog__grid">
-              <SkeletonLoader variant="card" count={4} />
-            </div>
-          ) : error ? (
-            <p style={{ textAlign: 'center', padding: '2rem 0', color: 'var(--error)' }}>{t('home.errorLoading')}</p>
-          ) : books.length === 0 ? (
-            <p style={{ textAlign: 'center', padding: '2rem 0', color: 'var(--text-secondary)' }}>{t('home.noBooksFound')}</p>
-          ) : (
-            <>
-              <div className="catalog__grid">
-                {books.map((book) => (
-                  <BookCard key={book.id} book={book} />
-                ))}
+            {/* ── Right: sort bar + grid + pagination ─────── */}
+            <div className="catalog__grid-container">
+
+              {/* Sort dropdown */}
+              <div className="catalog__controls">
+                <select
+                  id="sort-select"
+                  className="catalog__sort-select"
+                  value={activeSort}
+                  onChange={(e) => { setActiveSort(e.target.value); setCurrentPage(1); }}
+                  aria-label={t('home.sortAriaLabel')}
+                >
+                  <option value="">{t('home.sortDefault')}</option>
+                  <option value="price_asc">{t('home.sortPriceAsc')}</option>
+                  <option value="price_desc">{t('home.sortPriceDesc')}</option>
+                  <option value="rating_desc">{t('home.sortRatingDesc')}</option>
+                  <option value="title_asc">{t('home.sortTitleAsc')}</option>
+                </select>
               </div>
-              <Pagination 
-                currentPage={currentPage}
-                totalPages={totalPages}
-                onPageChange={setCurrentPage}
-              />
-            </>
-          )}
+
+              {/* Active filter tags */}
+              {hasActiveFilters && (
+                <div className="catalog__filter-summary">
+                  <span>Active filters:</span>
+                  {selectedGenres.map(g => (
+                    <span key={g} className="catalog__filter-tag">
+                      {g}
+                      <button
+                        onClick={() => handleGenreChange(g, false)}
+                        aria-label={`Remove ${g} filter`}
+                      >✕</button>
+                    </span>
+                  ))}
+                  {minPrice !== '' && (
+                    <span className="catalog__filter-tag">
+                      Min ₹{minPrice}
+                      <button onClick={() => setMinPrice('')} aria-label="Remove min price filter">✕</button>
+                    </span>
+                  )}
+                  {maxPrice !== '' && (
+                    <span className="catalog__filter-tag">
+                      Max ₹{maxPrice}
+                      <button onClick={() => setMaxPrice('')} aria-label="Remove max price filter">✕</button>
+                    </span>
+                  )}
+                  {minRating !== null && (
+                    <span className="catalog__filter-tag">
+                      {'★'.repeat(minRating)} & up
+                      <button onClick={() => setMinRating(null)} aria-label="Remove rating filter">✕</button>
+                    </span>
+                  )}
+                  <button className="catalog__filter-tag" onClick={handleClearFilters}>
+                    Clear all ✕
+                  </button>
+                </div>
+              )}
+
+              {/* Books grid */}
+              {loading ? (
+                <div className="catalog__grid">
+                  <SkeletonLoader variant="card" count={4} />
+                </div>
+              ) : error ? (
+                <p style={{ textAlign: 'center', padding: '2rem 0', color: 'var(--leather)' }}>
+                  {t('home.errorLoading')}
+                </p>
+              ) : displayedBooks.length === 0 ? (
+                <div className="catalog__empty">
+                  <h3>{t('home.noBooksFound')}</h3>
+                  {hasActiveFilters && (
+                    <button className="catalog__empty-btn" onClick={handleClearFilters}>
+                      Clear filters
+                    </button>
+                  )}
+                </div>
+              ) : (
+                <>
+                  <div className="catalog__grid">
+                    {displayedBooks.map((book) => (
+                      <BookCard key={book.id} book={book} />
+                    ))}
+                  </div>
+                  <Pagination
+                    currentPage={currentPage}
+                    totalPages={totalPages}
+                    onPageChange={setCurrentPage}
+                  />
+                </>
+              )}
+
+            </div>{/* end .catalog__grid-container */}
+          </div>{/* end .catalog__layout */}
         </div>
       </main>
     </>


### PR DESCRIPTION
closes #179 

FilterSidebar.css — Full rewrite 
position: sticky; top: 96px — sidebar follows scroll on desktop
accent-color: var(--leather) on checkboxes/radios
fieldset/legend browser defaults reset (border, padding, margin)
focus-within highlight on price inputs
Number spinner removal
All colours use project CSS tokens
App.css — Fixed + restructured
Fixed broken CSS — .catalog__empty-btn was missing its closing }, which silently invalidated all rules after it (.catalog__controls, .catalog__sort-select)
Added .catalog__filter-summary and .catalog__filter-tag styles for the active filter tag row