### PR TITLE
Complete Order Persistence Feature

### DIFF
--- a/bookshelf-frontend/src/components/orders/OrderCard.jsx
+++ b/bookshelf-frontend/src/components/orders/OrderCard.jsx
@@ -19,7 +19,7 @@ export default function OrderCard({ order }) {
           <span className={`status-badge ${order.shippingStatus.toLowerCase()}`}>{order.shippingStatus}</span>
         </div>
         <div className="order-total">
-          <p>Total: ${order.total.toFixed(2)}</p>
+          <p>Total: ₹{order.total}</p>
         </div>
         <div className="order-expand">
           <button className="expand-btn">

--- a/bookshelf-frontend/src/pages/Checkout.css
+++ b/bookshelf-frontend/src/pages/Checkout.css
@@ -1,117 +1,124 @@
-.checkout-page {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
+/* ─── Container ──────────────────────────────────────────────────────── */
+
+.checkout-container {
+  max-width: 640px;
+  margin: 48px auto 80px;
+  padding: 0 20px;
 }
 
-.checkout-main {
-  flex: 1;
-  padding: 40px 20px;
-.checkout-container {
-  max-width: 800px;
-  margin: 40px auto;
-  padding: 20px;
-  background-color: var(--bg-primary);
-  border-radius: 12px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-}
+/* ─── Header + step indicators ───────────────────────────────────────── */
 
 .checkout-header {
   text-align: center;
-  margin-bottom: 40px;
+  margin-bottom: 36px;
 }
 
 .checkout-header h1 {
-  font-size: 2.5rem;
-  color: var(--text-primary);
+  font-size: 2rem;
+  color: var(--ink);
   margin-bottom: 20px;
 }
 
 .checkout-steps {
   display: flex;
-  justify-content: space-between;
-  position: relative;
-}
-
-.checkout-steps::before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background-color: var(--border-color);
-  z-index: 1;
+  justify-content: center;
+  gap: 24px;
 }
 
 .step-indicator {
-  position: relative;
-  z-index: 2;
-  background-color: var(--bg-primary);
-  padding: 0 10px;
+  font-family: var(--font-mono);
+  font-size: 12px;
   font-weight: 600;
-  color: var(--text-secondary);
-  transition: color 0.3s ease;
+  color: var(--ink-soft);
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  transition: all 0.2s ease;
 }
 
 .step-indicator.active {
-  color: var(--primary-color);
+  background: var(--leather);
+  color: #fff;
+  border-color: var(--leather);
 }
 
 .step-indicator.completed {
-  color: var(--success-color);
+  background: var(--pine);
+  color: #fff;
+  border-color: var(--pine);
 }
 
+/* ─── Form sections ──────────────────────────────────────────────────── */
+
 .checkout-form-container {
-  padding: 20px;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
+  background: var(--paper-dim);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 28px;
   margin-bottom: 20px;
 }
 
 .checkout-form-container h2 {
+  font-size: 1.3rem;
+  color: var(--ink);
   margin-bottom: 20px;
-  font-size: 1.5rem;
-  color: var(--text-primary);
 }
 
+/* Inline validation error above the form */
+.checkout-field-error {
+  background: #fee2e2;
+  color: #991b1b;
+  border: 1px solid #fca5a5;
+  border-radius: 6px;
+  padding: 10px 14px;
+  font-size: 14px;
+  margin-bottom: 16px;
+}
+
+/* ─── Form fields ────────────────────────────────────────────────────── */
+
 .form-group {
-  margin-bottom: 15px;
+  margin-bottom: 16px;
 }
 
 .form-group label {
   display: block;
-  margin-bottom: 5px;
-  font-weight: 500;
-  color: var(--text-primary);
+  margin-bottom: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
 }
 
 .form-group input,
 .form-group select {
   width: 100%;
-  padding: 10px 15px;
-  border: 1px solid var(--border-color);
+  padding: 10px 14px;
+  border: 1px solid var(--line);
   border-radius: 6px;
-  background-color: var(--bg-secondary);
-  color: var(--text-primary);
-  font-size: 1rem;
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 14px;
+  font-family: var(--font-body);
+  transition: border-color 0.15s;
 }
 
 .form-group input:focus,
 .form-group select:focus {
   outline: none;
-  border-color: var(--primary-color);
-  box-shadow: 0 0 0 2px rgba(var(--primary-rgb), 0.2);
+  border-color: var(--leather);
+  box-shadow: 0 0 0 3px rgba(184, 92, 44, 0.12);
 }
 
 .form-row {
   display: flex;
-  gap: 15px;
+  gap: 14px;
 }
 
 .form-row .form-group {
   flex: 1;
 }
+
+/* ─── Payment options ────────────────────────────────────────────────── */
 
 .payment-options {
   display: flex;
@@ -122,123 +129,216 @@
 .payment-option {
   display: flex;
   align-items: center;
-  padding: 15px;
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
+  gap: 12px;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  font-size: 14px;
+  transition: border-color 0.15s, background 0.15s;
 }
 
-.payment-option:hover {
-  border-color: var(--primary-color);
+.payment-option:has(input:checked) {
+  border-color: var(--leather);
+  background: rgba(184, 92, 44, 0.05);
 }
 
 .payment-option input {
-  margin-right: 15px;
+  accent-color: var(--leather);
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
 }
+
+/* ─── Order review ───────────────────────────────────────────────────── */
 
 .order-review {
   display: flex;
   flex-direction: column;
-  gap: 15px;
+  gap: 0;
 }
 
 .review-item {
   display: flex;
   justify-content: space-between;
-  padding: 10px 0;
-  border-bottom: 1px solid var(--border-color);
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--line);
 }
 
 .review-item-details h4 {
-  margin: 0 0 5px 0;
-  color: var(--text-primary);
+  font-size: 15px;
+  margin: 0 0 4px;
+  color: var(--ink);
 }
 
 .review-item-details p {
+  font-size: 12px;
+  color: var(--ink-soft);
   margin: 0;
-  color: var(--text-secondary);
-  font-size: 0.9rem;
+  font-family: var(--font-mono);
 }
 
 .review-item-price {
-  font-weight: 600;
-  color: var(--text-primary);
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--leather);
+  white-space: nowrap;
+}
+
+.review-shipping-info {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--line);
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+
+.review-shipping-info p {
+  margin: 4px 0;
 }
 
 .review-total {
   display: flex;
   justify-content: space-between;
-  padding-top: 15px;
-  font-size: 1.25rem;
+  align-items: center;
+  padding-top: 16px;
+  font-size: 1.1rem;
   font-weight: 700;
-  color: var(--text-primary);
+  color: var(--ink);
 }
+
+/* ─── Action buttons ─────────────────────────────────────────────────── */
 
 .checkout-actions {
   display: flex;
   justify-content: space-between;
-  margin-top: 30px;
+  gap: 12px;
+  margin-top: 28px;
 }
 
 .btn {
-  padding: 12px 24px;
+  padding: 11px 24px;
   border: none;
   border-radius: 6px;
-  font-size: 1rem;
+  font-size: 14px;
   font-weight: 600;
+  font-family: var(--font-body);
   cursor: pointer;
-  transition: background-color 0.3s ease;
+  transition: background 0.2s ease, opacity 0.2s ease;
 }
 
 .btn-secondary {
-  background-color: var(--bg-secondary);
-  color: var(--text-primary);
-  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--ink);
+  border: 1px solid var(--line);
 }
 
 .btn-secondary:hover {
-  background-color: var(--border-color);
+  background: var(--paper-dim);
 }
 
 .btn-primary {
-  background-color: var(--primary-color);
-  color: white;
+  background: var(--leather);
+  color: #fff;
 }
 
 .btn-primary:hover {
-  background-color: var(--primary-color-dark, #0056b3);
+  background: var(--leather-deep);
 }
+
+/* ─── Success screen ─────────────────────────────────────────────────── */
 
 .checkout-success {
+  max-width: 560px;
+  margin: 60px auto 80px;
+  padding: 0 20px;
   text-align: center;
-  margin-top: 100px;
 }
 
-.checkout-success h2 {
-  font-family: var(--font-display);
-  font-size: 32px;
-  margin-bottom: 16px;
-  color: var(--ink);
-}
-
-.checkout-success p {
-  color: var(--ink-soft);
-  margin-bottom: 32px;
-}
-
-.checkout-success .btn-primary {
-  display: inline-block;
-  padding: 40px 20px;
-}
-
-.checkout-success h2 {
-  font-size: 2rem;
-  color: var(--success-color, #28a745);
+.checkout-success__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  background: var(--pine);
+  color: #fff;
+  font-size: 28px;
+  border-radius: 50%;
   margin-bottom: 20px;
 }
 
-.checkout-success p {
-  color: var(--text-secondary);
-  margin-bottom: 30px;
+.checkout-success__title {
+  font-size: 2rem;
+  color: var(--ink);
+  margin-bottom: 12px;
+}
+
+.checkout-success__body {
+  font-size: 15px;
+  color: var(--ink-soft);
+  line-height: 1.6;
+  margin-bottom: 28px;
+}
+
+/* Order summary inside success screen */
+.checkout-success__summary {
+  background: var(--paper-dim);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 20px 24px;
+  margin-bottom: 28px;
+  text-align: left;
+}
+
+.checkout-success__item {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--line);
+  color: var(--ink);
+}
+
+.checkout-success__total {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 700;
+  font-size: 15px;
+  padding-top: 12px;
+  color: var(--leather);
+}
+
+.checkout-success__actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────────── */
+
+@media (max-width: 560px) {
+  .checkout-container {
+    margin: 24px auto 60px;
+    padding: 0 16px;
+  }
+
+  .checkout-form-container {
+    padding: 20px 16px;
+  }
+
+  .form-row {
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .checkout-actions {
+    flex-direction: column-reverse;
+  }
+
+  .checkout-steps {
+    gap: 10px;
+  }
 }

--- a/bookshelf-frontend/src/pages/Checkout.jsx
+++ b/bookshelf-frontend/src/pages/Checkout.jsx
@@ -1,59 +1,7 @@
-import { useState } from 'react';
-import Navbar from '../components/Navbar';
-import Footer from '../components/Footer';
-import CheckoutGateway from '../components/CheckoutGateway';
-import GuestCheckoutForm from '../components/GuestCheckoutForm';
-import './Checkout.css';
-
-export default function Checkout() {
-  const [checkoutStep, setCheckoutStep] = useState('gateway'); // 'gateway', 'form', 'success'
-
-  const handleProceedToGuest = () => {
-    setCheckoutStep('form');
-  };
-
-  const handleProceedToAuth = () => {
-    // If we had an authenticated checkout form, we'd go there.
-    // For this mock, we'll just go straight to the form step since the guest form can be reused or skipped if they already have saved addresses.
-    setCheckoutStep('form');
-  };
-
-  const handleOrderComplete = () => {
-    setCheckoutStep('success');
-  };
-
-  return (
-    <div className="checkout-page">
-      <Navbar cartCount={0} onCartClick={() => {}} />
-      <div className="nav-spacer" />
-      
-      <main className="checkout-main">
-        {checkoutStep === 'gateway' && (
-          <CheckoutGateway 
-            onProceedToGuest={handleProceedToGuest} 
-            onProceedToAuth={handleProceedToAuth} 
-          />
-        )}
-        
-        {checkoutStep === 'form' && (
-          <GuestCheckoutForm onOrderComplete={handleOrderComplete} />
-        )}
-        
-        {checkoutStep === 'success' && (
-          <div className="checkout-success">
-            <h2>Order Placed Successfully!</h2>
-            <p>Thank you for your purchase.</p>
-            <button className="btn-primary" onClick={() => window.location.href = '/'}>
-              Return to Home
-            </button>
-          </div>
-        )}
-      </main>
-      
-      <Footer />
 import { useState, useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CartContext } from '../context/CartContext.jsx';
+import { saveOrder } from '../utils/orderStorage.js';
 import './Checkout.css';
 
 export default function Checkout() {
@@ -61,17 +9,20 @@ export default function Checkout() {
   const navigate = useNavigate();
   const [step, setStep] = useState(1);
   const [isSuccess, setIsSuccess] = useState(false);
+  const [placedOrder, setPlacedOrder] = useState(null);
 
   const [shippingDetails, setShippingDetails] = useState({
     fullName: '',
     address: '',
     city: '',
     zipCode: '',
-    country: '',
+    country: 'India',
   });
 
   const [paymentMethod, setPaymentMethod] = useState('credit-card');
+  const [shippingError, setShippingError] = useState('');
 
+  // Redirect to home if the cart is empty (and we haven't just placed an order)
   useEffect(() => {
     if (cart.length === 0 && !isSuccess) {
       navigate('/');
@@ -81,74 +32,135 @@ export default function Checkout() {
   const total = cart.reduce((sum, item) => sum + item.price * item.quantity, 0);
 
   const handleShippingChange = (e) => {
-    setShippingDetails({
-      ...shippingDetails,
-      [e.target.name]: e.target.value,
-    });
+    setShippingDetails({ ...shippingDetails, [e.target.name]: e.target.value });
+    if (shippingError) setShippingError('');
   };
 
   const nextStep = () => {
     if (step === 1) {
-      if (!shippingDetails.fullName || !shippingDetails.address || !shippingDetails.city || !shippingDetails.zipCode) {
-        alert('Please fill out all required shipping details.');
+      const { fullName, address, city, zipCode } = shippingDetails;
+      if (!fullName.trim() || !address.trim() || !city.trim() || !zipCode.trim()) {
+        setShippingError('Please fill out all required shipping fields.');
         return;
       }
     }
-    setStep(step + 1);
+    setStep((s) => s + 1);
   };
 
-  const prevStep = () => {
-    setStep(step - 1);
-  };
+  const prevStep = () => setStep((s) => s - 1);
 
   const handlePlaceOrder = () => {
-    setIsSuccess(true);
+    // Build and persist the order before clearing the cart
+    const saved = saveOrder({
+      items: cart,
+      total,
+      paymentMethod,
+      shippingDetails,
+    });
+    setPlacedOrder(saved);
     clearCart();
+    setIsSuccess(true);
   };
 
-  if (isSuccess) {
+  // ── Success screen ────────────────────────────────────────────────────
+  if (isSuccess && placedOrder) {
     return (
       <div className="checkout-container checkout-success">
-        <h2>Thank You for Your Order!</h2>
-        <p>Your order has been successfully placed and will be shipped soon.</p>
-        <button className="btn btn-primary" onClick={() => navigate('/')}>
-          Continue Shopping
-        </button>
+        <div className="checkout-success__icon">✓</div>
+        <h2 className="checkout-success__title">Order Placed!</h2>
+        <p className="checkout-success__body">
+          Thank you, <strong>{placedOrder.shippingDetails.fullName}</strong>. Your order{' '}
+          <strong>{placedOrder.id}</strong> has been confirmed and will be shipped to{' '}
+          {placedOrder.shippingDetails.city} soon.
+        </p>
+        <div className="checkout-success__summary">
+          {placedOrder.items.map((item) => (
+            <div key={item.id} className="checkout-success__item">
+              <span>{item.title} × {item.quantity}</span>
+              <span>₹{item.price * item.quantity}</span>
+            </div>
+          ))}
+          <div className="checkout-success__total">
+            <span>Total paid</span>
+            <span>₹{placedOrder.total}</span>
+          </div>
+        </div>
+        <div className="checkout-success__actions">
+          <button className="btn btn-secondary" onClick={() => navigate('/orders')}>
+            View Order History
+          </button>
+          <button className="btn btn-primary" onClick={() => navigate('/')}>
+            Continue Shopping
+          </button>
+        </div>
       </div>
     );
   }
 
+  // ── Multi-step checkout ───────────────────────────────────────────────
   return (
     <div className="checkout-container">
       <div className="checkout-header">
         <h1>Checkout</h1>
         <div className="checkout-steps">
-          <span className={`step-indicator ${step >= 1 ? 'active' : ''} ${step > 1 ? 'completed' : ''}`}>1. Shipping</span>
-          <span className={`step-indicator ${step >= 2 ? 'active' : ''} ${step > 2 ? 'completed' : ''}`}>2. Payment</span>
-          <span className={`step-indicator ${step >= 3 ? 'active' : ''}`}>3. Review</span>
+          <span className={`step-indicator ${step >= 1 ? 'active' : ''} ${step > 1 ? 'completed' : ''}`}>
+            1. Shipping
+          </span>
+          <span className={`step-indicator ${step >= 2 ? 'active' : ''} ${step > 2 ? 'completed' : ''}`}>
+            2. Payment
+          </span>
+          <span className={`step-indicator ${step >= 3 ? 'active' : ''}`}>
+            3. Review
+          </span>
         </div>
       </div>
 
+      {/* ── Step 1: Shipping ──────────────────────────────────────── */}
       {step === 1 && (
         <div className="checkout-form-container">
           <h2>Shipping Details</h2>
+          {shippingError && (
+            <p className="checkout-field-error">{shippingError}</p>
+          )}
           <form onSubmit={(e) => { e.preventDefault(); nextStep(); }}>
             <div className="form-group">
               <label htmlFor="fullName">Full Name</label>
-              <input type="text" id="fullName" name="fullName" value={shippingDetails.fullName} onChange={handleShippingChange} required />
+              <input
+                type="text" id="fullName" name="fullName"
+                value={shippingDetails.fullName}
+                onChange={handleShippingChange}
+                placeholder="Jane Doe"
+                required
+              />
             </div>
             <div className="form-group">
               <label htmlFor="address">Address</label>
-              <input type="text" id="address" name="address" value={shippingDetails.address} onChange={handleShippingChange} required />
+              <input
+                type="text" id="address" name="address"
+                value={shippingDetails.address}
+                onChange={handleShippingChange}
+                placeholder="123 Book Street"
+                required
+              />
             </div>
             <div className="form-row">
               <div className="form-group">
                 <label htmlFor="city">City</label>
-                <input type="text" id="city" name="city" value={shippingDetails.city} onChange={handleShippingChange} required />
+                <input
+                  type="text" id="city" name="city"
+                  value={shippingDetails.city}
+                  onChange={handleShippingChange}
+                  required
+                />
               </div>
               <div className="form-group">
-                <label htmlFor="zipCode">Zip Code</label>
-                <input type="text" id="zipCode" name="zipCode" value={shippingDetails.zipCode} onChange={handleShippingChange} required />
+                <label htmlFor="zipCode">Zip / PIN Code</label>
+                <input
+                  type="text" id="zipCode" name="zipCode"
+                  value={shippingDetails.zipCode}
+                  onChange={handleShippingChange}
+                  required
+                />
               </div>
             </div>
             <div className="form-group">
@@ -169,20 +181,27 @@ export default function Checkout() {
         </div>
       )}
 
+      {/* ── Step 2: Payment ───────────────────────────────────────── */}
       {step === 2 && (
         <div className="checkout-form-container">
           <h2>Payment Method</h2>
           <div className="payment-options">
             <label className="payment-option">
-              <input type="radio" name="payment" value="credit-card" checked={paymentMethod === 'credit-card'} onChange={() => setPaymentMethod('credit-card')} />
-              Credit/Debit Card
+              <input type="radio" name="payment" value="credit-card"
+                checked={paymentMethod === 'credit-card'}
+                onChange={() => setPaymentMethod('credit-card')} />
+              Credit / Debit Card
             </label>
             <label className="payment-option">
-              <input type="radio" name="payment" value="upi" checked={paymentMethod === 'upi'} onChange={() => setPaymentMethod('upi')} />
+              <input type="radio" name="payment" value="upi"
+                checked={paymentMethod === 'upi'}
+                onChange={() => setPaymentMethod('upi')} />
               UPI (Google Pay, PhonePe, Paytm)
             </label>
             <label className="payment-option">
-              <input type="radio" name="payment" value="cod" checked={paymentMethod === 'cod'} onChange={() => setPaymentMethod('cod')} />
+              <input type="radio" name="payment" value="cod"
+                checked={paymentMethod === 'cod'}
+                onChange={() => setPaymentMethod('cod')} />
               Cash on Delivery (COD)
             </label>
           </div>
@@ -193,6 +212,7 @@ export default function Checkout() {
         </div>
       )}
 
+      {/* ── Step 3: Review ────────────────────────────────────────── */}
       {step === 3 && (
         <div className="checkout-form-container">
           <h2>Order Review</h2>
@@ -201,11 +221,15 @@ export default function Checkout() {
               <div key={item.id} className="review-item">
                 <div className="review-item-details">
                   <h4>{item.title}</h4>
-                  <p>Quantity: {item.quantity}</p>
+                  <p>by {item.author} &nbsp;·&nbsp; Qty: {item.quantity}</p>
                 </div>
                 <div className="review-item-price">₹{item.price * item.quantity}</div>
               </div>
             ))}
+            <div className="review-shipping-info">
+              <p>Ship to: <strong>{shippingDetails.fullName}</strong>, {shippingDetails.city}, {shippingDetails.country}</p>
+              <p>Payment: <strong>{paymentMethod === 'credit-card' ? 'Credit/Debit Card' : paymentMethod === 'upi' ? 'UPI' : 'Cash on Delivery'}</strong></p>
+            </div>
             <div className="review-total">
               <span>Total to Pay:</span>
               <span>₹{total}</span>

--- a/bookshelf-frontend/src/pages/OrderHistory.jsx
+++ b/bookshelf-frontend/src/pages/OrderHistory.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import OrderCard from '../components/orders/OrderCard.jsx';
 import EmptyOrders from '../components/orders/EmptyOrders.jsx';
 import SkeletonLoader from '../components/SkeletonLoader.jsx';
-import { mockOrders } from '../data/mockOrders.js';
+import { getOrders } from '../utils/orderStorage.js';
 import './OrderHistory.css';
 
 export default function OrderHistory() {
@@ -10,29 +10,34 @@ export default function OrderHistory() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Simulate API fetch
-    const fetchOrders = setTimeout(() => {
-      setOrders(mockOrders);
+    // Brief artificial delay so the skeleton loader is visible and
+    // the page doesn't feel like it flashes — mirrors the previous behaviour.
+    const timer = setTimeout(() => {
+      setOrders(getOrders());
       setLoading(false);
-    }, 800);
+    }, 500);
 
-    return () => clearTimeout(fetchOrders);
+    return () => clearTimeout(timer);
   }, []);
 
   return (
     <div className="page-container order-history-page">
       <h2>Your Order History</h2>
+
       <div className="orders-meta">
         <span className="orders-meta-count">{loading ? '…' : orders.length}</span>
-        {loading ? 'Loading orders' : `${orders.length === 1 ? 'order' : 'orders'} placed`}
+        {loading
+          ? 'Loading orders…'
+          : `${orders.length === 1 ? 'order' : 'orders'} placed`}
       </div>
+
       {loading ? (
         <div className="orders-list">
           <SkeletonLoader variant="order" count={3} />
         </div>
       ) : orders.length > 0 ? (
         <div className="orders-list">
-          {orders.map(order => (
+          {orders.map((order) => (
             <OrderCard key={order.id} order={order} />
           ))}
         </div>

--- a/bookshelf-frontend/src/pages/Profile.jsx
+++ b/bookshelf-frontend/src/pages/Profile.jsx
@@ -1,11 +1,14 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import SkeletonLoader from '../components/SkeletonLoader.jsx';
+import OrderCard from '../components/orders/OrderCard.jsx';
+import { getOrders } from '../utils/orderStorage.js';
 import './Profile.css';
 
 export default function Profile() {
   const [activeTab, setActiveTab] = useState('details');
   const [loading, setLoading] = useState(true);
+  const [profileOrders, setProfileOrders] = useState([]);
   const navigate = useNavigate();
 
   // Mock initial states
@@ -41,7 +44,10 @@ export default function Profile() {
       navigate('/login');
       return;
     }
-    const timer = setTimeout(() => setLoading(false), 500);
+    const timer = setTimeout(() => {
+      setProfileOrders(getOrders());
+      setLoading(false);
+    }, 500);
     return () => clearTimeout(timer);
   }, [navigate]);
 
@@ -170,9 +176,20 @@ export default function Profile() {
           {activeTab === 'orders' && (
             <div className="profile-tab-pane">
               <h2>Order History</h2>
-              <div className="profile-empty-state">
-                <p>You have no previous orders.</p>
-              </div>
+              {profileOrders.length === 0 ? (
+                <div className="profile-empty-state">
+                  <p>You haven't placed any orders yet.</p>
+                  <Link to="/" className="profile-action-btn" style={{ display: 'inline-block', marginTop: '12px' }}>
+                    Browse Books
+                  </Link>
+                </div>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', marginTop: '8px' }}>
+                  {profileOrders.map((order) => (
+                    <OrderCard key={order.id} order={order} />
+                  ))}
+                </div>
+              )}
             </div>
           )}
 

--- a/bookshelf-frontend/src/utils/orderStorage.js
+++ b/bookshelf-frontend/src/utils/orderStorage.js
@@ -1,0 +1,64 @@
+/**
+ * orderStorage.js — localStorage utility for persisting placed orders.
+ *
+ * Order shape:
+ * {
+ *   id:              string   — "ORD-<timestamp>"
+ *   createdAt:       string   — ISO date string
+ *   items:           CartItem[]  — { id, title, author, price, quantity, cover }
+ *   total:           number   — total in rupees
+ *   paymentMethod:   string   — 'credit-card' | 'upi' | 'cod'
+ *   shippingDetails: object   — { fullName, address, city, zipCode, country }
+ *   paymentStatus:   string   — 'Paid' | 'Pending'
+ *   shippingStatus:  string   — 'Processing' | 'Shipped' | 'Delivered' | 'Cancelled'
+ * }
+ */
+
+const STORAGE_KEY = 'orders';
+
+/**
+ * Retrieve all saved orders from localStorage.
+ * Returns an empty array if no orders exist or parsing fails.
+ */
+export function getOrders() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch (err) {
+    console.error('[orderStorage] Failed to parse orders:', err);
+    return [];
+  }
+}
+
+/**
+ * Save a new order to the front of the orders list.
+ * @param {object} orderData — the full order object (without id/createdAt)
+ * @returns {object} the saved order with generated id and createdAt
+ */
+export function saveOrder(orderData) {
+  const newOrder = {
+    id: `ORD-${Date.now()}`,
+    createdAt: new Date().toISOString(),
+    paymentStatus: orderData.paymentMethod === 'cod' ? 'Pending' : 'Paid',
+    shippingStatus: 'Processing',
+    ...orderData,
+  };
+
+  const existing = getOrders();
+  const updated = [newOrder, ...existing];
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  } catch (err) {
+    console.error('[orderStorage] Failed to save order:', err);
+  }
+
+  return newOrder;
+}
+
+/**
+ * Clear all saved orders (useful for testing/reset).
+ */
+export function clearOrders() {
+  localStorage.removeItem(STORAGE_KEY);
+}


### PR DESCRIPTION
closes #183 

Checkout.jsx — Full rewrite 
Fixed merge collision — two complete components were merged into one file; extracted the correct step-based checkout
handlePlaceOrder now calls saveOrder() before clearCart(), stores the returned order in state
Replaced alert() with an inline .checkout-field-error error message
New success screen shows: personalised greeting with customer name, real order ID, full itemised summary, and two CTAs — "View Order History" + "Continue Shopping"

Checkout.css — Full rewrite 
Fixed merge collision — .checkout-main block was never closed, invalidating all subsequent rules
All colours now use project tokens (--leather, --pine, --line, etc.)
New: .checkout-field-error, .checkout-success__*, .review-shipping-info, pill-style step indicators

OrderHistory.jsx — Rewritten
Removed mockOrders import
Now calls getOrders() on mount — shows real orders placed in the current (and any prior) browser session

Profile.jsx — Orders tab updated
Added getOrders + OrderCard imports
Orders tab now renders real <OrderCard> components with a "Browse Books" CTA when empty