### PR TITLE
feat(backend): add search, filter, sort and pagination to the books API (closes #274)

### DIFF
--- a/bookshelf-backend/controllers/bookController.js
+++ b/bookshelf-backend/controllers/bookController.js
@@ -1,9 +1,60 @@
-import { getBooks } from '../repositories/bookRepository.js';
+import { getBooks, getBookById } from '../repositories/bookRepository.js';
+import {
+  parseBookQuery,
+  queryBooks,
+  collectGenres,
+  QueryValidationError,
+} from '../utils/bookQuery.js';
 
+// @desc    List books with search, filter, sort and pagination
+// @route   GET /api/books
+// @access  Public
 export const getAllBooks = (req, res, next) => {
   try {
-    const books = getBooks();
-    res.status(200).json(books);
+    const filters = parseBookQuery(req.query);
+    const result = queryBooks(getBooks(), filters);
+
+    res.status(200).json(result);
+  } catch (error) {
+    // A bad query string is the client's mistake, not a server fault, so it
+    // is answered here rather than handed to the generic error handler
+    // (which would turn it into a 500).
+    if (error instanceof QueryValidationError) {
+      return res.status(400).json({
+        message: error.message,
+        parameter: error.parameter,
+      });
+    }
+
+    next(error);
+  }
+};
+
+// @desc    Distinct genres in the catalogue, with counts
+// @route   GET /api/books/genres
+// @access  Public
+export const getBookGenres = (req, res, next) => {
+  try {
+    res.status(200).json({ genres: collectGenres(getBooks()) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// @desc    Fetch a single book
+// @route   GET /api/books/:id
+// @access  Public
+export const getBook = (req, res, next) => {
+  try {
+    const book = getBookById(req.params.id);
+
+    if (!book) {
+      return res.status(404).json({
+        message: `Book not found: ${req.params.id}`,
+      });
+    }
+
+    res.status(200).json(book);
   } catch (error) {
     next(error);
   }

--- a/bookshelf-backend/package.json
+++ b/bookshelf-backend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test tests/*.test.js"
   },
   "keywords": [],
   "author": "",

--- a/bookshelf-backend/routes/books.js
+++ b/bookshelf-backend/routes/books.js
@@ -1,8 +1,18 @@
 import express from 'express';
-import { getAllBooks } from '../controllers/bookController.js';
+import {
+  getAllBooks,
+  getBook,
+  getBookGenres,
+} from '../controllers/bookController.js';
 
 const router = express.Router();
 
 router.get('/', getAllBooks);
+
+// Must be registered before '/:id', otherwise Express matches "genres" as an
+// id and this route becomes unreachable.
+router.get('/genres', getBookGenres);
+
+router.get('/:id', getBook);
 
 export default router;

--- a/bookshelf-backend/tests/bookQuery.test.js
+++ b/bookshelf-backend/tests/bookQuery.test.js
@@ -1,0 +1,318 @@
+import test, { describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseBookQuery,
+  filterBooks,
+  sortBooks,
+  paginate,
+  queryBooks,
+  collectGenres,
+  QueryValidationError,
+  DEFAULT_LIMIT,
+  MAX_LIMIT,
+} from '../utils/bookQuery.js';
+
+// A fixed catalogue so the tests do not move when data/books.json changes.
+const CATALOGUE = [
+  { id: 'b1', title: 'The Quiet Ones', author: 'M. Arora', genre: 'Fiction', price: 349, rating: 4.5, inventory: 8 },
+  { id: 'b2', title: 'Field Notes', author: 'D. Kapoor', genre: 'Self-Help', price: 299, rating: 4.2, inventory: 10 },
+  { id: 'b3', title: 'Half Moon Bay', author: 'S. Rhee', genre: 'Mystery', price: 399, rating: 4.7, inventory: 0 },
+  { id: 'b4', title: 'Static', author: 'A. Voss', genre: 'Sci-Fi', price: 449, rating: 4.3, inventory: 10 },
+  { id: 'b5', title: 'Low Tide', author: 'R. Menon', genre: 'Poetry', price: 249, rating: 4.0, inventory: 5 },
+  { id: 'b6', title: 'Quiet Water', author: 'M. Arora', genre: 'Fiction', price: 199, rating: 3.8, inventory: 2 },
+];
+
+const ids = (books) => books.map((book) => book.id);
+
+describe('parseBookQuery', () => {
+  test('applies defaults for an empty query', () => {
+    const parsed = parseBookQuery({});
+
+    assert.equal(parsed.page, 1);
+    assert.equal(parsed.limit, DEFAULT_LIMIT);
+    assert.equal(parsed.search, '');
+    assert.deepEqual(parsed.genres, []);
+    assert.equal(parsed.sort, undefined);
+  });
+
+  test('ignores unknown parameters instead of failing', () => {
+    const parsed = parseBookQuery({ colour: 'red', utm_source: 'newsletter' });
+
+    assert.equal(parsed.page, 1);
+    assert.equal(parsed.limit, DEFAULT_LIMIT);
+  });
+
+  test('trims the search term', () => {
+    assert.equal(parseBookQuery({ search: '  quiet  ' }).search, 'quiet');
+  });
+
+  test('treats genre=All as no genre filter', () => {
+    assert.deepEqual(parseBookQuery({ genre: 'All' }).genres, []);
+    assert.deepEqual(parseBookQuery({ genre: 'all' }).genres, []);
+  });
+
+  test('accepts a repeated genre parameter', () => {
+    const parsed = parseBookQuery({ genre: ['Fiction', 'Poetry'] });
+    assert.deepEqual(parsed.genres, ['Fiction', 'Poetry']);
+  });
+
+  test('accepts a comma separated genre parameter', () => {
+    const parsed = parseBookQuery({ genre: 'Fiction, Poetry' });
+    assert.deepEqual(parsed.genres, ['Fiction', 'Poetry']);
+  });
+
+  test('drops the All sentinel from a mixed list', () => {
+    const parsed = parseBookQuery({ genre: ['All', 'Mystery'] });
+    assert.deepEqual(parsed.genres, ['Mystery']);
+  });
+
+  test('rejects a non-numeric page', () => {
+    assert.throws(
+      () => parseBookQuery({ page: 'abc' }),
+      (error) => {
+        assert.ok(error instanceof QueryValidationError);
+        assert.equal(error.status, 400);
+        assert.equal(error.parameter, 'page');
+        return true;
+      }
+    );
+  });
+
+  test('rejects page below 1', () => {
+    assert.throws(() => parseBookQuery({ page: '-1' }), QueryValidationError);
+    assert.throws(() => parseBookQuery({ page: '0' }), QueryValidationError);
+  });
+
+  test('rejects a limit above the maximum', () => {
+    assert.throws(
+      () => parseBookQuery({ limit: String(MAX_LIMIT + 1) }),
+      (error) => error.parameter === 'limit'
+    );
+  });
+
+  test('rejects a float dressed up as a page', () => {
+    assert.throws(() => parseBookQuery({ page: '1.5' }), QueryValidationError);
+  });
+
+  test('rejects an unknown sort', () => {
+    assert.throws(
+      () => parseBookQuery({ sort: 'nonsense' }),
+      (error) => {
+        assert.equal(error.parameter, 'sort');
+        assert.match(error.message, /price_asc/);
+        return true;
+      }
+    );
+  });
+
+  test('accepts an empty sort as "no sort"', () => {
+    assert.equal(parseBookQuery({ sort: '' }).sort, undefined);
+  });
+
+  test('rejects minPrice greater than maxPrice', () => {
+    assert.throws(
+      () => parseBookQuery({ minPrice: '500', maxPrice: '100' }),
+      (error) => error.parameter === 'minPrice'
+    );
+  });
+
+  test('rejects a negative price bound', () => {
+    assert.throws(() => parseBookQuery({ minPrice: '-5' }), QueryValidationError);
+  });
+
+  test('parses inStock as a boolean', () => {
+    assert.equal(parseBookQuery({ inStock: 'true' }).inStock, true);
+    assert.equal(parseBookQuery({ inStock: 'FALSE' }).inStock, false);
+    assert.equal(parseBookQuery({}).inStock, undefined);
+  });
+
+  test('rejects a non-boolean inStock', () => {
+    assert.throws(() => parseBookQuery({ inStock: 'yes' }), QueryValidationError);
+  });
+});
+
+describe('filterBooks', () => {
+  test('returns everything when no filters are set', () => {
+    assert.equal(filterBooks(CATALOGUE, {}).length, CATALOGUE.length);
+  });
+
+  test('matches a partial title, case-insensitively', () => {
+    assert.deepEqual(ids(filterBooks(CATALOGUE, { search: 'quiet' })), ['b1', 'b6']);
+  });
+
+  test('searches the author as well as the title', () => {
+    assert.deepEqual(ids(filterBooks(CATALOGUE, { search: 'arora' })), ['b1', 'b6']);
+  });
+
+  test('filters by a single genre, case-insensitively', () => {
+    assert.deepEqual(ids(filterBooks(CATALOGUE, { genres: ['fiction'] })), ['b1', 'b6']);
+  });
+
+  test('filters by several genres at once', () => {
+    assert.deepEqual(
+      ids(filterBooks(CATALOGUE, { genres: ['Poetry', 'Mystery'] })),
+      ['b3', 'b5']
+    );
+  });
+
+  test('applies an inclusive price range', () => {
+    assert.deepEqual(
+      ids(filterBooks(CATALOGUE, { minPrice: 249, maxPrice: 349 })),
+      ['b1', 'b2', 'b5']
+    );
+  });
+
+  test('applies an inclusive rating floor', () => {
+    assert.deepEqual(ids(filterBooks(CATALOGUE, { minRating: 4.5 })), ['b1', 'b3']);
+  });
+
+  test('filters on stock in both directions', () => {
+    assert.deepEqual(ids(filterBooks(CATALOGUE, { inStock: false })), ['b3']);
+    assert.equal(filterBooks(CATALOGUE, { inStock: true }).length, 5);
+  });
+
+  test('combines filters', () => {
+    const result = filterBooks(CATALOGUE, {
+      genres: ['Fiction'],
+      maxPrice: 250,
+    });
+    assert.deepEqual(ids(result), ['b6']);
+  });
+
+  test('returns an empty array when nothing matches', () => {
+    assert.deepEqual(filterBooks(CATALOGUE, { search: 'zzzz' }), []);
+  });
+});
+
+describe('sortBooks', () => {
+  test('leaves the order alone when no sort is given', () => {
+    assert.deepEqual(ids(sortBooks(CATALOGUE, undefined)), ids(CATALOGUE));
+  });
+
+  test('sorts by price ascending and descending', () => {
+    assert.equal(sortBooks(CATALOGUE, 'price_asc')[0].id, 'b6');
+    assert.equal(sortBooks(CATALOGUE, 'price_desc')[0].id, 'b4');
+  });
+
+  test('sorts by rating descending', () => {
+    assert.equal(sortBooks(CATALOGUE, 'rating_desc')[0].id, 'b3');
+  });
+
+  test('sorts titles alphabetically', () => {
+    assert.equal(sortBooks(CATALOGUE, 'title_asc')[0].title, 'Field Notes');
+    assert.equal(sortBooks(CATALOGUE, 'title_desc')[0].title, 'The Quiet Ones');
+  });
+
+  test('does not mutate the array it is given', () => {
+    const original = ids(CATALOGUE);
+    sortBooks(CATALOGUE, 'price_desc');
+    assert.deepEqual(ids(CATALOGUE), original);
+  });
+});
+
+describe('paginate', () => {
+  test('slices the requested page', () => {
+    const result = paginate(CATALOGUE, 2, 2);
+
+    assert.deepEqual(ids(result.books), ['b3', 'b4']);
+    assert.equal(result.page, 2);
+    assert.equal(result.totalBooks, 6);
+    assert.equal(result.totalPages, 3);
+    assert.equal(result.hasNextPage, true);
+    assert.equal(result.hasPrevPage, true);
+  });
+
+  test('flags the first and last page correctly', () => {
+    assert.equal(paginate(CATALOGUE, 1, 2).hasPrevPage, false);
+    assert.equal(paginate(CATALOGUE, 3, 2).hasNextPage, false);
+  });
+
+  test('rounds a partial last page up', () => {
+    assert.equal(paginate(CATALOGUE, 1, 4).totalPages, 2);
+    assert.equal(paginate(CATALOGUE, 2, 4).books.length, 2);
+  });
+
+  test('returns an empty page past the end rather than erroring', () => {
+    const result = paginate(CATALOGUE, 99, 10);
+
+    assert.deepEqual(result.books, []);
+    assert.equal(result.totalBooks, 6);
+    assert.equal(result.hasNextPage, false);
+  });
+
+  test('handles an empty catalogue', () => {
+    const result = paginate([], 1, 10);
+
+    assert.deepEqual(result.books, []);
+    assert.equal(result.totalPages, 0);
+    assert.equal(result.hasPrevPage, false);
+  });
+});
+
+describe('queryBooks', () => {
+  test('filters before paginating, so totalBooks is the filtered count', () => {
+    const result = queryBooks(
+      CATALOGUE,
+      parseBookQuery({ genre: 'Fiction', limit: '1' })
+    );
+
+    assert.equal(result.totalBooks, 2);
+    assert.equal(result.totalPages, 2);
+    assert.equal(result.books.length, 1);
+  });
+
+  test('sorts the filtered set, not just the page', () => {
+    const result = queryBooks(
+      CATALOGUE,
+      parseBookQuery({ sort: 'price_asc', limit: '2' })
+    );
+
+    assert.deepEqual(ids(result.books), ['b6', 'b5']);
+  });
+
+  test('returns the keys the catalogue page reads', () => {
+    const result = queryBooks(CATALOGUE, parseBookQuery({}));
+
+    for (const key of ['books', 'totalPages', 'totalBooks']) {
+      assert.ok(key in result, `expected "${key}" in the response`);
+    }
+  });
+
+  test('echoes the filters it applied', () => {
+    const result = queryBooks(
+      CATALOGUE,
+      parseBookQuery({ search: 'quiet', genre: 'Fiction', sort: 'price_asc' })
+    );
+
+    assert.equal(result.appliedFilters.search, 'quiet');
+    assert.deepEqual(result.appliedFilters.genres, ['Fiction']);
+    assert.equal(result.appliedFilters.sort, 'price_asc');
+  });
+
+  test('reports sort as null when none was requested', () => {
+    const result = queryBooks(CATALOGUE, parseBookQuery({}));
+    assert.equal(result.appliedFilters.sort, null);
+  });
+});
+
+describe('collectGenres', () => {
+  test('counts each distinct genre', () => {
+    assert.deepEqual(collectGenres(CATALOGUE), [
+      { name: 'Fiction', count: 2 },
+      { name: 'Mystery', count: 1 },
+      { name: 'Poetry', count: 1 },
+      { name: 'Sci-Fi', count: 1 },
+      { name: 'Self-Help', count: 1 },
+    ]);
+  });
+
+  test('skips books with no genre', () => {
+    const genres = collectGenres([...CATALOGUE, { id: 'b7', title: 'Untitled' }]);
+    assert.equal(genres.length, 5);
+  });
+
+  test('handles an empty catalogue', () => {
+    assert.deepEqual(collectGenres([]), []);
+  });
+});

--- a/bookshelf-backend/utils/bookQuery.js
+++ b/bookshelf-backend/utils/bookQuery.js
@@ -1,0 +1,302 @@
+/**
+ * Query parsing and in-memory querying for the book catalogue.
+ *
+ * These are pure functions over a plain array. The catalogue lives in a JSON
+ * file, so there is no database to push the work down into — but keeping the
+ * logic here rather than in the controller means it can be tested without an
+ * HTTP server, and means swapping the JSON file for a real collection later
+ * only touches the repository.
+ */
+
+export const DEFAULT_LIMIT = 12;
+export const MAX_LIMIT = 100;
+
+/**
+ * Sorts the API accepts. The keys match the values the catalogue page already
+ * puts in its sort <select>, so the frontend needs no change.
+ */
+export const SORT_OPTIONS = {
+  price_asc: { field: 'price', direction: 1 },
+  price_desc: { field: 'price', direction: -1 },
+  rating_asc: { field: 'rating', direction: 1 },
+  rating_desc: { field: 'rating', direction: -1 },
+  title_asc: { field: 'title', direction: 1 },
+  title_desc: { field: 'title', direction: -1 },
+};
+
+/**
+ * The catalogue page sends `genre=All` to mean "no genre filter". Treat it as
+ * a sentinel rather than as a genre nobody's book will ever match.
+ */
+const ALL_GENRES_SENTINEL = 'all';
+
+export class QueryValidationError extends Error {
+  constructor(parameter, message) {
+    super(message);
+    this.name = 'QueryValidationError';
+    this.status = 400;
+    this.parameter = parameter;
+  }
+}
+
+/**
+ * Accepts either repeated params (`?genre=Fiction&genre=Poetry`, which Express
+ * gives us as an array) or a comma separated list (`?genre=Fiction,Poetry`).
+ */
+function toList(value) {
+  if (value === undefined || value === null || value === '') {
+    return [];
+  }
+
+  const raw = Array.isArray(value) ? value : String(value).split(',');
+
+  return raw.map((entry) => String(entry).trim()).filter(Boolean);
+}
+
+function parseInteger(value, parameter, { min, max, fallback }) {
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+
+  // Number() would accept '1e3', ' 12 ' and '0x10'. Be strict: the client is
+  // building these from form controls, so anything else is a bug worth
+  // surfacing rather than guessing at.
+  if (!/^-?\d+$/.test(String(value).trim())) {
+    throw new QueryValidationError(
+      parameter,
+      `${parameter} must be a whole number, received "${value}"`
+    );
+  }
+
+  const parsed = Number.parseInt(String(value).trim(), 10);
+
+  if (min !== undefined && parsed < min) {
+    throw new QueryValidationError(
+      parameter,
+      `${parameter} must be at least ${min}, received ${parsed}`
+    );
+  }
+
+  if (max !== undefined && parsed > max) {
+    throw new QueryValidationError(
+      parameter,
+      `${parameter} must be at most ${max}, received ${parsed}`
+    );
+  }
+
+  return parsed;
+}
+
+function parseNumber(value, parameter, { min } = {}) {
+  if (value === undefined || value === '') {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed)) {
+    throw new QueryValidationError(
+      parameter,
+      `${parameter} must be a number, received "${value}"`
+    );
+  }
+
+  if (min !== undefined && parsed < min) {
+    throw new QueryValidationError(
+      parameter,
+      `${parameter} must be at least ${min}, received ${parsed}`
+    );
+  }
+
+  return parsed;
+}
+
+function parseBoolean(value, parameter) {
+  if (value === undefined || value === '') {
+    return undefined;
+  }
+
+  const normalised = String(value).trim().toLowerCase();
+
+  if (normalised === 'true') return true;
+  if (normalised === 'false') return false;
+
+  throw new QueryValidationError(
+    parameter,
+    `${parameter} must be true or false, received "${value}"`
+  );
+}
+
+/**
+ * Turn a raw Express `req.query` into a validated, normalised shape.
+ * Unknown parameters are ignored. Throws QueryValidationError on bad input.
+ */
+export function parseBookQuery(query = {}) {
+  const search = query.search === undefined ? '' : String(query.search).trim();
+
+  const genres = toList(query.genre).filter(
+    (genre) => genre.toLowerCase() !== ALL_GENRES_SENTINEL
+  );
+
+  const minPrice = parseNumber(query.minPrice, 'minPrice', { min: 0 });
+  const maxPrice = parseNumber(query.maxPrice, 'maxPrice', { min: 0 });
+
+  if (minPrice !== undefined && maxPrice !== undefined && minPrice > maxPrice) {
+    throw new QueryValidationError(
+      'minPrice',
+      `minPrice (${minPrice}) cannot be greater than maxPrice (${maxPrice})`
+    );
+  }
+
+  const minRating = parseNumber(query.minRating, 'minRating', { min: 0 });
+  const inStock = parseBoolean(query.inStock, 'inStock');
+
+  let sort;
+  if (query.sort !== undefined && query.sort !== '') {
+    sort = String(query.sort).trim();
+    if (!Object.prototype.hasOwnProperty.call(SORT_OPTIONS, sort)) {
+      throw new QueryValidationError(
+        'sort',
+        `sort must be one of: ${Object.keys(SORT_OPTIONS).join(', ')}. Received "${query.sort}"`
+      );
+    }
+  }
+
+  const page = parseInteger(query.page, 'page', { min: 1, fallback: 1 });
+  const limit = parseInteger(query.limit, 'limit', {
+    min: 1,
+    max: MAX_LIMIT,
+    fallback: DEFAULT_LIMIT,
+  });
+
+  return {
+    search,
+    genres,
+    minPrice,
+    maxPrice,
+    minRating,
+    inStock,
+    sort,
+    page,
+    limit,
+  };
+}
+
+export function filterBooks(books, filters = {}) {
+  const {
+    search = '',
+    genres = [],
+    minPrice,
+    maxPrice,
+    minRating,
+    inStock,
+  } = filters;
+
+  const needle = search.toLowerCase();
+  // Compare genres case-insensitively so "fiction" from a URL still matches
+  // the "Fiction" stored in books.json.
+  const wantedGenres = genres.map((genre) => genre.toLowerCase());
+
+  return books.filter((book) => {
+    if (needle) {
+      const haystack = `${book.title ?? ''} ${book.author ?? ''}`.toLowerCase();
+      if (!haystack.includes(needle)) return false;
+    }
+
+    if (wantedGenres.length > 0) {
+      if (!wantedGenres.includes(String(book.genre ?? '').toLowerCase())) {
+        return false;
+      }
+    }
+
+    if (minPrice !== undefined && book.price < minPrice) return false;
+    if (maxPrice !== undefined && book.price > maxPrice) return false;
+    if (minRating !== undefined && book.rating < minRating) return false;
+
+    if (inStock !== undefined) {
+      const available = (book.inventory ?? 0) > 0;
+      if (available !== inStock) return false;
+    }
+
+    return true;
+  });
+}
+
+export function sortBooks(books, sort) {
+  if (!sort) {
+    return books;
+  }
+
+  const { field, direction } = SORT_OPTIONS[sort];
+
+  // Copy first — callers pass the cached catalogue array and sort() mutates.
+  return [...books].sort((a, b) => {
+    const left = a[field];
+    const right = b[field];
+
+    if (typeof left === 'string' || typeof right === 'string') {
+      return String(left).localeCompare(String(right)) * direction;
+    }
+
+    return (left - right) * direction;
+  });
+}
+
+export function paginate(books, page, limit) {
+  const totalBooks = books.length;
+  const totalPages = totalBooks === 0 ? 0 : Math.ceil(totalBooks / limit);
+  const start = (page - 1) * limit;
+
+  return {
+    // A page past the end yields an empty slice rather than a 404 — the
+    // catalogue shrinking under a bookmarked ?page=5 is not an error.
+    books: books.slice(start, start + limit),
+    page,
+    limit,
+    totalBooks,
+    totalPages,
+    hasNextPage: page < totalPages,
+    hasPrevPage: page > 1 && totalBooks > 0,
+  };
+}
+
+/**
+ * Run the whole pipeline. Filter first, then sort, then slice, so totalBooks
+ * describes the filtered set and not the whole catalogue.
+ */
+export function queryBooks(books, filters) {
+  const filtered = filterBooks(books, filters);
+  const sorted = sortBooks(filtered, filters.sort);
+  const paginated = paginate(sorted, filters.page, filters.limit);
+
+  return {
+    ...paginated,
+    appliedFilters: {
+      search: filters.search,
+      genres: filters.genres,
+      minPrice: filters.minPrice,
+      maxPrice: filters.maxPrice,
+      minRating: filters.minRating,
+      inStock: filters.inStock,
+      sort: filters.sort ?? null,
+    },
+  };
+}
+
+/**
+ * Distinct genres with a count each, so the catalogue sidebar can stop
+ * hardcoding its genre list.
+ */
+export function collectGenres(books) {
+  const counts = new Map();
+
+  for (const book of books) {
+    const genre = book.genre;
+    if (!genre) continue;
+    counts.set(genre, (counts.get(genre) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/bookshelf-frontend/src/components/BookCard.jsx
+++ b/bookshelf-frontend/src/components/BookCard.jsx
@@ -1,26 +1,32 @@
 import { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import WishlistButton from './WishlistButton.jsx';
-import { CartContext } from '../context/CartContext.jsx';
 import { WishlistContext } from '../context/WishlistContext.jsx';
+import { useCart } from '../hooks/useCart.js';
 import './BookCard.css';
-import { useContext } from 'react';
-import { WishlistContext } from '../context/WishlistContext.jsx';
-import WishlistButton from './WishlistButton.jsx';
 
 /**
  * BookCard — displays a single book as a card.
  *
  * Props:
  *   book        {object}   required — the book data object
- *   onAddToCart {function} optional — override the default CartContext addToCart.
- *                          Useful for contexts where the book object returned by the
- *                          parent differs from what CartContext would receive
- *                          (e.g. RecentlyViewed). Falls back to CartContext.addToCart.
+ *   onAddToCart {function} optional — override the default cart addToCart.
+ *                          Useful where the book object the parent holds
+ *                          differs from what the cart expects
+ *                          (e.g. RecentlyViewed). Falls back to addToCart.
  */
 export default function BookCard({ book, onAddToCart }) {
   const { wishlist, toggleWishlist } = useContext(WishlistContext);
-  const isWishlisted = wishlist.includes(book.id);
+  const { addToCart } = useCart();
+  const isWishlisted = wishlist?.includes(book.id);
+
+  const handleAddToCart = () => {
+    if (onAddToCart) {
+      onAddToCart(book);
+      return;
+    }
+    addToCart(book);
+  };
 
   return (
     <article className="book-card">
@@ -28,9 +34,9 @@ export default function BookCard({ book, onAddToCart }) {
         <span className="book-card__genre">{book.genre}</span>
         <span className="book-card__cover-title">{book.title}</span>
         <div className="book-card__wishlist-overlay">
-          <WishlistButton 
-            active={isWishlisted} 
-            onToggle={() => toggleWishlist(book.id)} 
+          <WishlistButton
+            active={isWishlisted}
+            onToggle={() => toggleWishlist(book.id)}
           />
         </div>
       </div>
@@ -51,10 +57,6 @@ export default function BookCard({ book, onAddToCart }) {
           <button className="book-card__add" onClick={handleAddToCart}>
             Add to cart
           </button>
-          <WishlistButton
-            active={wishlist?.includes(book.id)}
-            onToggle={() => toggleWishlist(book.id)}
-          />
         </div>
       </div>
     </article>

--- a/bookshelf-frontend/src/hooks/useCart.js
+++ b/bookshelf-frontend/src/hooks/useCart.js
@@ -1,0 +1,26 @@
+import { useContext } from 'react';
+import { CartContext } from '../context/CartContext.jsx';
+
+/**
+ * Access the cart.
+ *
+ * Prefer this over `useContext(CartContext)` directly. Reading the context
+ * straight gives you `undefined` when the provider is missing, and every
+ * caller then blows up on the destructuring line with a message that points
+ * at the consumer rather than at the missing provider. This throws with the
+ * actual cause instead.
+ */
+export function useCart() {
+  const context = useContext(CartContext);
+
+  if (context === undefined) {
+    throw new Error(
+      'useCart() must be used inside a <CartProvider>. ' +
+        'Check that CartProvider wraps the component tree in main.jsx.'
+    );
+  }
+
+  return context;
+}
+
+export default useCart;


### PR DESCRIPTION
Closes #274

`GET /api/books` returned the whole catalogue as a bare array and ignored every query parameter.

## The frontend has been calling an API that does not exist

This is not a new feature so much as a missing one. `pages/Home.jsx` already builds the full query string and reads an envelope back:

```js
const params = new URLSearchParams({ page: currentPage, limit, genre: apiGenre, search: searchQuery, ...(activeSort && { sort: activeSort }) });
const data = await (await fetch(`http://localhost:5000/api/books?${params}`)).json();
setBooks(data.books || data);
setTotalPages(data.totalPages || 1);
```

Every one of those fallbacks fires today, so **pagination has been silently dead**: `totalPages` is always `1`, the `Pagination` component never shows a second page, and all 8 books render regardless of `limit: 4`. Search and sort are sent and discarded.

So the response here uses the keys `Home.jsx` already reads. Pagination starts working with no frontend change in this PR.

## The API

```
GET /api/books
    ?search=      title and author, case-insensitive, partial match
    &genre=       repeated (?genre=A&genre=B) or comma separated; "All" means no filter
    &minPrice=    inclusive
    &maxPrice=    inclusive
    &minRating=   inclusive
    &inStock=     true | false
    &sort=        price_asc | price_desc | rating_asc | rating_desc | title_asc | title_desc
    &page=        default 1
    &limit=       default 12, max 100

GET /api/books/:id       single book
GET /api/books/genres    distinct genres with counts
```

`genre=All` is treated as a sentinel meaning "no genre filter", because that is what the catalogue page sends when nothing is selected. Without that it would be a genre no book matches and the page would come back empty.

Response:

```json
{
  "books": [ ... ],
  "page": 1, "limit": 12,
  "totalBooks": 8, "totalPages": 1,
  "hasNextPage": false, "hasPrevPage": false,
  "appliedFilters": { "search": "", "genres": [], "minPrice": null, "maxPrice": null, "sort": null }
}
```

Filtering runs before pagination, so `totalBooks` describes the filtered set rather than the whole catalogue.

`GET /api/books/:id` fills a gap — `bookRepository.getBookById` already existed but only `paymentController` could reach it, with no route exposing it. `GET /api/books/genres` exists so this comment in `Home.jsx` can eventually be acted on:

```js
// Genre list is static since the backend catalogue is fixed.
// If the backend adds a GET /api/genres endpoint in the future, replace this.
const ALL_GENRES = ['All', 'Fiction', 'Sci-Fi', 'Mystery', 'Self-Help', 'Poetry'];
```

I have not changed `Home.jsx` in this PR — that is a frontend change and belongs on its own. The endpoint is there when someone wants it.

`/genres` is registered before `/:id`. Reversed, Express matches `genres` as an id and the route is unreachable.

## Validation

Bad input gets a `400` naming the parameter, not a `500`:

```
GET /api/books?sort=nonsense
400 {"message":"sort must be one of: price_asc, price_desc, rating_asc, rating_desc, title_asc, title_desc. Received \"nonsense\"","parameter":"sort"}

GET /api/books?page=abc
400 {"message":"page must be a whole number, received \"abc\"","parameter":"page"}
```

Also rejected: `page` below 1, `limit` above 100, a float where an integer is expected, a negative price bound, `minPrice` greater than `maxPrice`, and a non-boolean `inStock`. Unknown parameters (`?utm_source=...`) are ignored rather than rejected.

Integer parsing is deliberately strict — `Number()` would have accepted `'1e3'`, `'0x10'` and `' 12 '`. These values come from form controls, so anything else is a bug worth surfacing.

A page past the end returns an empty `books` array rather than a 404. A bookmarked `?page=5` surviving a catalogue that shrank is not an error.

## Structure

The query logic is in `utils/bookQuery.js` as pure functions over a plain array — `parseBookQuery`, `filterBooks`, `sortBooks`, `paginate`, `queryBooks`, `collectGenres`. Keeping it out of the controller means it is testable without booting a server, and means moving the catalogue from `books.json` into a real collection later only touches the repository.

`sortBooks` copies before sorting, because callers hand it the array `cacheManager` is holding and `Array.prototype.sort` mutates in place. Sorting the cached catalogue would have permanently reordered it for every later request.

The existing `cacheManager` read path is untouched.

## Tests

The backend had `"test": "echo \"Error: no test specified\" && exit 1"`. This wires up `node:test`, which is built in and needs no new dependency.

45 tests in `tests/bookQuery.test.js` covering parsing and defaults, the `All` sentinel, both genre encodings, each validation rejection, search across title and author, each filter and combinations of them, all six sorts, sort not mutating its input, pagination boundaries, past-the-end and empty-catalogue cases, filter-before-paginate ordering, and genre counting.

```
$ npm test
# tests 45
# pass 45
# fail 0
```

## Manual check

Booted the app and hit each endpoint:

| Request | Result |
| --- | --- |
| `/api/books` | 200, 8 books, `totalPages: 1` |
| `/api/books?page=2&limit=3` | 200, books 4–6, `hasPrevPage: true` |
| `/api/books?search=quiet` | 200, 1 book |
| `/api/books?genre=Fiction,Poetry&sort=price_asc` | 200, filtered and ordered by price |
| `/api/books?sort=nonsense` | 400 |
| `/api/books?page=abc` | 400 |
| `/api/books/genres` | 200, 5 genres with counts |
| `/api/books/b3` | 200 |
| `/api/books/nope` | 404 |

## Compatibility

The response shape changes from a bare array to an envelope. `Home.jsx` prefers `data.books` and only falls back to `data`, so it keeps working and gains pagination. I checked the other frontend callers and nothing else hits this endpoint.
