### PR TITLE
feat(backend): validate auth request bodies and rate limit the auth routes (closes #275)

### DIFF
--- a/bookshelf-backend/.env.example
+++ b/bookshelf-backend/.env.example
@@ -1,0 +1,29 @@
+# Copy to .env and fill in. .env is gitignored.
+
+# Port the API listens on.
+PORT=5000
+
+# Mongo connection string. Defaults to a local instance if unset.
+MONGODB_URI=mongodb://127.0.0.1:27017/bookshelf
+
+# Signing secret for the session cookie. Must be set in any deployment:
+# the code falls back to a hardcoded 'fallback_secret' when this is missing,
+# which would let anyone mint a valid token.
+JWT_SECRET=change-me
+
+# Session cookie lifetime, as accepted by jsonwebtoken. Defaults to 7d.
+JWT_EXPIRES_IN=7d
+
+# development | production
+# Leave unset or set to production outside local development. Error stacks
+# are only returned to clients when this is exactly "development".
+NODE_ENV=development
+
+# Origin allowed by CORS. Must match where the frontend is served from,
+# and credentials are sent, so it cannot be "*".
+FRONTEND_URL=http://localhost:5173
+
+# Stripe. The webhook secret comes from the Stripe dashboard, or from
+# `stripe listen` when testing locally.
+STRIPE_SECRET_KEY=sk_test_your_key_here
+STRIPE_WEBHOOK_SECRET=whsec_your_secret_here

--- a/bookshelf-backend/controllers/authController.js
+++ b/bookshelf-backend/controllers/authController.js
@@ -35,12 +35,10 @@ export const authUser = async (req, res, next) => {
 // @access  Public
 export const registerUser = async (req, res, next) => {
   try {
+    // Shape, length and email format are enforced by validateBody() on the
+    // route, and email arrives already trimmed and lowercased. This handler
+    // only has to deal with the one rule that needs a database lookup.
     const { name, email, password } = req.body;
-
-    if (password.length < 8) {
-      res.status(400);
-      throw new Error('Password must be at least 8 characters');
-    }
 
     const userExists = await userRepository.findByEmail(email);
 

--- a/bookshelf-backend/middleware/errorMiddleware.js
+++ b/bookshelf-backend/middleware/errorMiddleware.js
@@ -14,8 +14,15 @@ export const errorHandler = (err, req, res, next) => {
     message = 'Resource not found';
   }
 
-  res.status(statusCode).json({
-    message,
-    stack: process.env.NODE_ENV === 'production' ? null : err.stack,
-  });
+  const body = { message };
+
+  // Only ever include the stack when NODE_ENV says development outright.
+  // This used to be `=== 'production' ? null : err.stack`, which leaks
+  // absolute paths and internals on any deployment that forgets to set
+  // NODE_ENV at all. Fail closed instead.
+  if (process.env.NODE_ENV === 'development') {
+    body.stack = err.stack;
+  }
+
+  res.status(statusCode).json(body);
 };

--- a/bookshelf-backend/middleware/rateLimiter.js
+++ b/bookshelf-backend/middleware/rateLimiter.js
@@ -1,0 +1,124 @@
+/**
+ * A fixed-window rate limiter held in process memory.
+ *
+ * Deliberately dependency-free. The trade-off is that the counters live in
+ * one process: behind more than one instance, or on a platform that recycles
+ * the process, each instance enforces its own limit. For a single-instance
+ * deployment that is fine, and it is a great deal better than the nothing
+ * that is here today. If this ever runs on more than one instance the store
+ * needs to move to Redis — the interface below is small enough that only
+ * `hits` changes.
+ */
+
+const DEFAULT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const DEFAULT_MAX = 10;
+
+/**
+ * Express sets req.ip from the socket, or from X-Forwarded-For when the
+ * 'trust proxy' setting is on. Falling back to a constant would put every
+ * unidentifiable caller in one shared bucket, which is the safe direction to
+ * fail for a limiter.
+ */
+function defaultKeyGenerator(req) {
+  return req.ip || req.socket?.remoteAddress || 'unknown';
+}
+
+export function createRateLimiter({
+  windowMs = DEFAULT_WINDOW_MS,
+  max = DEFAULT_MAX,
+  message = 'Too many requests. Please try again later.',
+  keyGenerator = defaultKeyGenerator,
+  resetOnSuccess = false,
+  // Injectable so the tests can advance time without sleeping.
+  now = () => Date.now(),
+} = {}) {
+  const hits = new Map();
+
+  function prune(currentTime) {
+    for (const [key, entry] of hits) {
+      if (entry.expiresAt <= currentTime) {
+        hits.delete(key);
+      }
+    }
+  }
+
+  function middleware(req, res, next) {
+    const currentTime = now();
+    const key = keyGenerator(req);
+
+    let entry = hits.get(key);
+
+    if (!entry || entry.expiresAt <= currentTime) {
+      entry = { count: 0, expiresAt: currentTime + windowMs };
+      hits.set(key, entry);
+    }
+
+    entry.count += 1;
+
+    const remaining = Math.max(0, max - entry.count);
+    const resetSeconds = Math.ceil((entry.expiresAt - currentTime) / 1000);
+
+    res.setHeader('X-RateLimit-Limit', String(max));
+    res.setHeader('X-RateLimit-Remaining', String(remaining));
+    res.setHeader('X-RateLimit-Reset', String(resetSeconds));
+
+    if (entry.count > max) {
+      res.setHeader('Retry-After', String(resetSeconds));
+      return res.status(429).json({ message });
+    }
+
+    if (resetOnSuccess) {
+      // Clear the counter once the response turns out to have succeeded, so
+      // a legitimate user who mistypes a password a few times and then gets
+      // in is not still carrying those failures.
+      res.on('finish', () => {
+        if (res.statusCode < 400) {
+          hits.delete(key);
+        }
+      });
+    }
+
+    // Cheap opportunistic cleanup. Without it the map grows one entry per
+    // distinct IP forever. Doing it on a fraction of requests keeps the cost
+    // off the hot path; a setInterval would keep the event loop alive and
+    // stop the process exiting cleanly in tests.
+    if (hits.size > 1000) {
+      prune(currentTime);
+    }
+
+    next();
+  }
+
+  // Exposed for tests and for a future admin endpoint.
+  middleware.reset = () => hits.clear();
+  middleware.size = () => hits.size;
+  middleware.prune = prune;
+
+  return middleware;
+}
+
+/**
+ * Login is the endpoint worth protecting: it returns a fast, distinguishable
+ * 401 for a wrong password, so it can be brute-forced as fast as the network
+ * allows. Successful logins clear the counter.
+ */
+export const loginLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  resetOnSuccess: true,
+  message:
+    'Too many login attempts from this address. Please try again in a few minutes.',
+});
+
+/**
+ * Registration is limited more loosely — it is about stopping a script
+ * filling the users collection, not about guessing a secret.
+ */
+export const registerLimiter = createRateLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 20,
+  message:
+    'Too many accounts created from this address. Please try again later.',
+});
+
+export default createRateLimiter;

--- a/bookshelf-backend/middleware/validateBody.js
+++ b/bookshelf-backend/middleware/validateBody.js
@@ -1,0 +1,32 @@
+import { validate } from '../utils/validators.js';
+
+/**
+ * Build a middleware that validates req.body against a field spec.
+ *
+ * On failure it answers 400 with every field-level problem at once, so the
+ * client can highlight all the bad inputs in one pass instead of playing
+ * whack-a-mole with one error per submit.
+ *
+ * On success req.body is replaced with the normalised values, and only the
+ * fields named in the spec survive. That is deliberate: it stops an
+ * unexpected key in the request body from reaching the database, so a request
+ * carrying `{"name":"x","email":"...","password":"...","role":"admin"}`
+ * cannot smuggle a role through.
+ */
+export function validateBody(spec) {
+  return (req, res, next) => {
+    const { errors, values } = validate(req.body ?? {}, spec);
+
+    if (errors.length > 0) {
+      return res.status(400).json({
+        message: 'Validation failed',
+        errors,
+      });
+    }
+
+    req.body = values;
+    next();
+  };
+}
+
+export default validateBody;

--- a/bookshelf-backend/package.json
+++ b/bookshelf-backend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test tests/*.test.js"
   },
   "keywords": [],
   "author": "",

--- a/bookshelf-backend/routes/authRoutes.js
+++ b/bookshelf-backend/routes/authRoutes.js
@@ -6,11 +6,21 @@ import {
   getUserProfile,
 } from '../controllers/authController.js';
 import { protect } from '../middleware/authMiddleware.js';
+import { validateBody } from '../middleware/validateBody.js';
+import { loginLimiter, registerLimiter } from '../middleware/rateLimiter.js';
+import { registerSchema, loginSchema } from '../validators/authValidators.js';
 
 const router = express.Router();
 
-router.post('/register', registerUser);
-router.post('/login', authUser);
+// Limit before validating: a request that is already over the limit should
+// not get to spend anything on parsing its body.
+router.post(
+  '/register',
+  registerLimiter,
+  validateBody(registerSchema),
+  registerUser
+);
+router.post('/login', loginLimiter, validateBody(loginSchema), authUser);
 router.post('/logout', logoutUser);
 router.get('/me', protect, getUserProfile);
 

--- a/bookshelf-backend/tests/authValidators.test.js
+++ b/bookshelf-backend/tests/authValidators.test.js
@@ -1,0 +1,235 @@
+import test, { describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { validate } from '../utils/validators.js';
+import { validateBody } from '../middleware/validateBody.js';
+import { registerSchema, loginSchema } from '../validators/authValidators.js';
+
+const VALID_REGISTRATION = {
+  name: 'Alice Kapoor',
+  email: 'alice@example.com',
+  password: 'correct-horse',
+};
+
+function fieldsWithErrors(errors) {
+  return errors.map((error) => error.field);
+}
+
+/** Minimal Express res double — enough for the middleware under test. */
+function makeRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function runMiddleware(middleware, body) {
+  const req = { body };
+  const res = makeRes();
+  let nextCalled = false;
+
+  middleware(req, res, () => {
+    nextCalled = true;
+  });
+
+  return { req, res, nextCalled };
+}
+
+describe('registerSchema', () => {
+  test('accepts a well formed registration', () => {
+    const { errors } = validate(VALID_REGISTRATION, registerSchema);
+    assert.deepEqual(errors, []);
+  });
+
+  test('reports a missing password rather than throwing', () => {
+    // This is the reported bug: `password.length` on undefined threw a
+    // TypeError and surfaced as a 500.
+    const { errors } = validate({ email: 'a@b.com' }, registerSchema);
+
+    assert.ok(fieldsWithErrors(errors).includes('password'));
+    assert.match(
+      errors.find((error) => error.field === 'password').message,
+      /required/
+    );
+  });
+
+  test('reports every bad field at once', () => {
+    const { errors } = validate({}, registerSchema);
+    assert.deepEqual(fieldsWithErrors(errors).sort(), [
+      'email',
+      'name',
+      'password',
+    ]);
+  });
+
+  test('rejects a password below the minimum length', () => {
+    const { errors } = validate(
+      { ...VALID_REGISTRATION, password: 'short' },
+      registerSchema
+    );
+    assert.deepEqual(fieldsWithErrors(errors), ['password']);
+  });
+
+  test('rejects an absurdly long password instead of hashing it', () => {
+    const { errors } = validate(
+      { ...VALID_REGISTRATION, password: 'a'.repeat(500) },
+      registerSchema
+    );
+    assert.deepEqual(fieldsWithErrors(errors), ['password']);
+  });
+
+  test('rejects a malformed email', () => {
+    for (const email of ['notanemail', 'no@domain', 'a b@c.com', '@example.com']) {
+      const { errors } = validate(
+        { ...VALID_REGISTRATION, email },
+        registerSchema
+      );
+      assert.deepEqual(
+        fieldsWithErrors(errors),
+        ['email'],
+        `expected "${email}" to be rejected`
+      );
+    }
+  });
+
+  test('lowercases and trims the email', () => {
+    const { values, errors } = validate(
+      { ...VALID_REGISTRATION, email: '  Alice@Example.COM ' },
+      registerSchema
+    );
+
+    assert.deepEqual(errors, []);
+    assert.equal(values.email, 'alice@example.com');
+  });
+
+  test('trims the name', () => {
+    const { values } = validate(
+      { ...VALID_REGISTRATION, name: '  Alice  ' },
+      registerSchema
+    );
+    assert.equal(values.name, 'Alice');
+  });
+
+  test('rejects a whitespace-only name', () => {
+    const { errors } = validate(
+      { ...VALID_REGISTRATION, name: '   ' },
+      registerSchema
+    );
+    assert.deepEqual(fieldsWithErrors(errors), ['name']);
+  });
+
+  test('does not trim the password', () => {
+    const { values } = validate(
+      { ...VALID_REGISTRATION, password: ' spaced out ' },
+      registerSchema
+    );
+    assert.equal(values.password, ' spaced out ');
+  });
+
+  test('rejects a non-string password', () => {
+    const { errors } = validate(
+      { ...VALID_REGISTRATION, password: 12345678 },
+      registerSchema
+    );
+    assert.deepEqual(fieldsWithErrors(errors), ['password']);
+  });
+
+  test('reports one error per field, not a pile of them', () => {
+    const { errors } = validate({ password: 'x' }, registerSchema);
+    assert.equal(
+      errors.filter((error) => error.field === 'password').length,
+      1
+    );
+  });
+});
+
+describe('loginSchema', () => {
+  test('accepts an email and password', () => {
+    const { errors } = validate(
+      { email: 'alice@example.com', password: 'anything' },
+      loginSchema
+    );
+    assert.deepEqual(errors, []);
+  });
+
+  test('rejects a missing password', () => {
+    const { errors } = validate({ email: 'alice@example.com' }, loginSchema);
+    assert.deepEqual(fieldsWithErrors(errors), ['password']);
+  });
+
+  test('does not apply the registration length rule to an existing password', () => {
+    // An account created before the 8 character rule must still be able to
+    // log in, and rejecting short passwords here would tell an attacker
+    // something about what is stored.
+    const { errors } = validate(
+      { email: 'alice@example.com', password: 'old' },
+      loginSchema
+    );
+    assert.deepEqual(errors, []);
+  });
+
+  test('normalises the login email the same way as registration', () => {
+    const { values } = validate(
+      { email: ' Alice@Example.com ', password: 'anything' },
+      loginSchema
+    );
+    assert.equal(values.email, 'alice@example.com');
+  });
+});
+
+describe('validateBody middleware', () => {
+  test('calls next and normalises the body when valid', () => {
+    const { req, nextCalled } = runMiddleware(validateBody(registerSchema), {
+      ...VALID_REGISTRATION,
+      email: 'ALICE@example.com',
+    });
+
+    assert.equal(nextCalled, true);
+    assert.equal(req.body.email, 'alice@example.com');
+  });
+
+  test('answers 400 with a field list and does not call next', () => {
+    const { res, nextCalled } = runMiddleware(validateBody(registerSchema), {
+      email: 'nope',
+    });
+
+    assert.equal(nextCalled, false);
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.body.message, 'Validation failed');
+    assert.ok(Array.isArray(res.body.errors));
+    assert.ok(res.body.errors.length >= 2);
+  });
+
+  test('drops fields the schema does not name', () => {
+    // Stops a request smuggling role:"admin" through to the repository.
+    const { req } = runMiddleware(validateBody(registerSchema), {
+      ...VALID_REGISTRATION,
+      role: 'admin',
+    });
+
+    assert.equal(req.body.role, undefined);
+    assert.deepEqual(Object.keys(req.body).sort(), [
+      'email',
+      'name',
+      'password',
+    ]);
+  });
+
+  test('handles a completely absent body', () => {
+    const { res, nextCalled } = runMiddleware(
+      validateBody(registerSchema),
+      undefined
+    );
+
+    assert.equal(nextCalled, false);
+    assert.equal(res.statusCode, 400);
+  });
+});

--- a/bookshelf-backend/tests/rateLimiter.test.js
+++ b/bookshelf-backend/tests/rateLimiter.test.js
@@ -1,0 +1,235 @@
+import test, { describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createRateLimiter } from '../middleware/rateLimiter.js';
+
+/**
+ * A clock the tests drive by hand, so the window can be crossed without
+ * anything sleeping for fifteen minutes.
+ */
+function makeClock(start = 1_000_000) {
+  let current = start;
+  return {
+    now: () => current,
+    advance: (ms) => {
+      current += ms;
+    },
+  };
+}
+
+/** Minimal Express res double, including the 'finish' event. */
+function makeRes() {
+  const listeners = { finish: [] };
+
+  return {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    on(event, listener) {
+      (listeners[event] ??= []).push(listener);
+    },
+    finish() {
+      for (const listener of listeners.finish) listener();
+    },
+  };
+}
+
+function call(limiter, { ip = '10.0.0.1', statusCode = 200 } = {}) {
+  const req = { ip };
+  const res = makeRes();
+  let nextCalled = false;
+
+  limiter(req, res, () => {
+    nextCalled = true;
+  });
+
+  res.statusCode = nextCalled ? statusCode : res.statusCode;
+  res.finish();
+
+  return { res, nextCalled, allowed: nextCalled };
+}
+
+describe('createRateLimiter', () => {
+  test('allows requests up to the limit', () => {
+    const limiter = createRateLimiter({ max: 3, windowMs: 1000 });
+
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      assert.equal(call(limiter).allowed, true, `attempt ${attempt}`);
+    }
+  });
+
+  test('answers 429 once the limit is passed', () => {
+    const limiter = createRateLimiter({ max: 2, windowMs: 1000 });
+
+    call(limiter);
+    call(limiter);
+    const third = call(limiter);
+
+    assert.equal(third.allowed, false);
+    assert.equal(third.res.statusCode, 429);
+    assert.match(third.res.body.message, /too many/i);
+  });
+
+  test('sets Retry-After on the rejection', () => {
+    const clock = makeClock();
+    const limiter = createRateLimiter({
+      max: 1,
+      windowMs: 60_000,
+      now: clock.now,
+    });
+
+    call(limiter);
+    const blocked = call(limiter);
+
+    assert.equal(blocked.res.headers['Retry-After'], '60');
+  });
+
+  test('reports limit and remaining on every response', () => {
+    const limiter = createRateLimiter({ max: 3, windowMs: 1000 });
+
+    const first = call(limiter);
+    assert.equal(first.res.headers['X-RateLimit-Limit'], '3');
+    assert.equal(first.res.headers['X-RateLimit-Remaining'], '2');
+
+    const second = call(limiter);
+    assert.equal(second.res.headers['X-RateLimit-Remaining'], '1');
+  });
+
+  test('never reports negative remaining', () => {
+    const limiter = createRateLimiter({ max: 1, windowMs: 1000 });
+
+    call(limiter);
+    call(limiter);
+    const third = call(limiter);
+
+    assert.equal(third.res.headers['X-RateLimit-Remaining'], '0');
+  });
+
+  test('counts each address separately', () => {
+    const limiter = createRateLimiter({ max: 1, windowMs: 1000 });
+
+    assert.equal(call(limiter, { ip: '10.0.0.1' }).allowed, true);
+    assert.equal(call(limiter, { ip: '10.0.0.2' }).allowed, true);
+    assert.equal(call(limiter, { ip: '10.0.0.1' }).allowed, false);
+  });
+
+  test('starts a fresh window once the old one expires', () => {
+    const clock = makeClock();
+    const limiter = createRateLimiter({
+      max: 1,
+      windowMs: 1000,
+      now: clock.now,
+    });
+
+    assert.equal(call(limiter).allowed, true);
+    assert.equal(call(limiter).allowed, false);
+
+    clock.advance(1001);
+
+    assert.equal(call(limiter).allowed, true);
+  });
+
+  test('does not expire the window early', () => {
+    const clock = makeClock();
+    const limiter = createRateLimiter({
+      max: 1,
+      windowMs: 1000,
+      now: clock.now,
+    });
+
+    call(limiter);
+    clock.advance(999);
+
+    assert.equal(call(limiter).allowed, false);
+  });
+
+  test('clears the counter after a success when resetOnSuccess is set', () => {
+    const limiter = createRateLimiter({
+      max: 2,
+      windowMs: 60_000,
+      resetOnSuccess: true,
+    });
+
+    call(limiter, { statusCode: 401 }); // failed login
+    call(limiter, { statusCode: 200 }); // succeeded, counter clears
+
+    // Two more failures should still be allowed through.
+    assert.equal(call(limiter, { statusCode: 401 }).allowed, true);
+    assert.equal(call(limiter, { statusCode: 401 }).allowed, true);
+  });
+
+  test('leaves the counter alone after a failure', () => {
+    const limiter = createRateLimiter({
+      max: 2,
+      windowMs: 60_000,
+      resetOnSuccess: true,
+    });
+
+    call(limiter, { statusCode: 401 });
+    call(limiter, { statusCode: 401 });
+
+    assert.equal(call(limiter, { statusCode: 401 }).allowed, false);
+  });
+
+  test('does not clear the counter when resetOnSuccess is off', () => {
+    const limiter = createRateLimiter({ max: 2, windowMs: 60_000 });
+
+    call(limiter, { statusCode: 200 });
+    call(limiter, { statusCode: 200 });
+
+    assert.equal(call(limiter).allowed, false);
+  });
+
+  test('falls back to a shared key when the address is unknown', () => {
+    const limiter = createRateLimiter({ max: 1, windowMs: 1000 });
+
+    const req = {};
+    const res = makeRes();
+    let allowed = false;
+    limiter(req, res, () => {
+      allowed = true;
+    });
+
+    assert.equal(allowed, true);
+  });
+
+  test('prune drops expired entries', () => {
+    const clock = makeClock();
+    const limiter = createRateLimiter({
+      max: 5,
+      windowMs: 1000,
+      now: clock.now,
+    });
+
+    call(limiter, { ip: '10.0.0.1' });
+    call(limiter, { ip: '10.0.0.2' });
+    assert.equal(limiter.size(), 2);
+
+    clock.advance(1001);
+    limiter.prune(clock.now());
+
+    assert.equal(limiter.size(), 0);
+  });
+
+  test('reset clears everything', () => {
+    const limiter = createRateLimiter({ max: 1, windowMs: 60_000 });
+
+    call(limiter);
+    assert.equal(call(limiter).allowed, false);
+
+    limiter.reset();
+
+    assert.equal(call(limiter).allowed, true);
+  });
+});

--- a/bookshelf-backend/utils/validators.js
+++ b/bookshelf-backend/utils/validators.js
@@ -1,0 +1,123 @@
+/**
+ * Small validation primitives.
+ *
+ * Each rule takes the raw value and returns either an error string or null.
+ * They are plain functions rather than a schema library so they can be unit
+ * tested directly and so the backend gains no new dependency.
+ */
+
+// Deliberately permissive. The point is to catch "notanemail" and obvious
+// typos, not to adjudicate RFC 5322 — the only real proof an address works is
+// sending mail to it.
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const MIN_PASSWORD_LENGTH = 8;
+export const MAX_PASSWORD_LENGTH = 128;
+export const MAX_NAME_LENGTH = 100;
+export const MAX_EMAIL_LENGTH = 254; // the practical limit for an address
+
+export function isMissing(value) {
+  return value === undefined || value === null;
+}
+
+export function required(field) {
+  return (value) => {
+    if (isMissing(value)) {
+      return `${field} is required`;
+    }
+    if (typeof value === 'string' && value.trim() === '') {
+      return `${field} cannot be empty`;
+    }
+    return null;
+  };
+}
+
+export function isString(field) {
+  return (value) => {
+    if (isMissing(value)) return null; // `required` reports this
+    if (typeof value !== 'string') {
+      return `${field} must be a string`;
+    }
+    return null;
+  };
+}
+
+export function maxLength(field, max) {
+  return (value) => {
+    if (typeof value !== 'string') return null;
+    if (value.length > max) {
+      return `${field} must be at most ${max} characters`;
+    }
+    return null;
+  };
+}
+
+export function minLength(field, min) {
+  return (value) => {
+    if (typeof value !== 'string') return null;
+    if (value.length < min) {
+      return `${field} must be at least ${min} characters`;
+    }
+    return null;
+  };
+}
+
+export function isEmail(field = 'email') {
+  return (value) => {
+    if (typeof value !== 'string' || value.trim() === '') return null;
+    if (!EMAIL_PATTERN.test(value.trim())) {
+      return `${field} must be a valid email address`;
+    }
+    return null;
+  };
+}
+
+/**
+ * Normalisers run before the rules, so a rule never has to think about
+ * surrounding whitespace.
+ */
+export function trim(value) {
+  return typeof value === 'string' ? value.trim() : value;
+}
+
+export function lowercase(value) {
+  return typeof value === 'string' ? value.toLowerCase() : value;
+}
+
+export function normaliseEmail(value) {
+  return lowercase(trim(value));
+}
+
+/**
+ * Run a field spec against a body.
+ *
+ * spec is `{ [field]: { normalise?: fn, rules: [fn] } }`. Returns the errors
+ * found and the normalised values, so the caller decides what to do with
+ * either. Only fields named in the spec end up in `values` — an unexpected
+ * key in the request body is dropped rather than passed through to the
+ * database.
+ */
+export function validate(body = {}, spec = {}) {
+  const errors = [];
+  const values = {};
+
+  for (const [field, config] of Object.entries(spec)) {
+    const raw = body[field];
+    const normalise = config.normalise;
+    const value = normalise ? normalise(raw) : raw;
+
+    values[field] = value;
+
+    for (const rule of config.rules ?? []) {
+      const message = rule(value);
+      if (message) {
+        errors.push({ field, message });
+        // One error per field. Reporting "password is required" and
+        // "password must be at least 8 characters" together is noise.
+        break;
+      }
+    }
+  }
+
+  return { errors, values };
+}

--- a/bookshelf-backend/validators/authValidators.js
+++ b/bookshelf-backend/validators/authValidators.js
@@ -1,0 +1,69 @@
+import {
+  required,
+  isString,
+  isEmail,
+  minLength,
+  maxLength,
+  trim,
+  normaliseEmail,
+  MIN_PASSWORD_LENGTH,
+  MAX_PASSWORD_LENGTH,
+  MAX_NAME_LENGTH,
+  MAX_EMAIL_LENGTH,
+} from '../utils/validators.js';
+
+/**
+ * POST /api/auth/register
+ *
+ * Emails are lowercased and trimmed here rather than in the controller so
+ * that the uniqueness lookup and the stored value always agree. Without it
+ * "Alice@Example.com " and "alice@example.com" register as two accounts and
+ * only one of them can ever log in with the address the user typed.
+ */
+export const registerSchema = {
+  name: {
+    normalise: trim,
+    rules: [
+      required('name'),
+      isString('name'),
+      maxLength('name', MAX_NAME_LENGTH),
+    ],
+  },
+  email: {
+    normalise: normaliseEmail,
+    rules: [
+      required('email'),
+      isString('email'),
+      maxLength('email', MAX_EMAIL_LENGTH),
+      isEmail('email'),
+    ],
+  },
+  password: {
+    // Not trimmed: leading and trailing spaces are legitimate password
+    // characters, and silently stripping them means the password the user
+    // set is not the password they can log in with.
+    rules: [
+      required('password'),
+      isString('password'),
+      minLength('password', MIN_PASSWORD_LENGTH),
+      maxLength('password', MAX_PASSWORD_LENGTH),
+    ],
+  },
+};
+
+/**
+ * POST /api/auth/login
+ *
+ * Only presence and shape are checked. Applying the registration password
+ * rules here would tell an attacker which stored passwords are too short,
+ * and would lock out any account created before those rules existed.
+ */
+export const loginSchema = {
+  email: {
+    normalise: normaliseEmail,
+    rules: [required('email'), isString('email'), isEmail('email')],
+  },
+  password: {
+    rules: [required('password'), isString('password')],
+  },
+};

--- a/bookshelf-frontend/src/components/BookCard.jsx
+++ b/bookshelf-frontend/src/components/BookCard.jsx
@@ -1,26 +1,32 @@
 import { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import WishlistButton from './WishlistButton.jsx';
-import { CartContext } from '../context/CartContext.jsx';
 import { WishlistContext } from '../context/WishlistContext.jsx';
+import { useCart } from '../hooks/useCart.js';
 import './BookCard.css';
-import { useContext } from 'react';
-import { WishlistContext } from '../context/WishlistContext.jsx';
-import WishlistButton from './WishlistButton.jsx';
 
 /**
  * BookCard — displays a single book as a card.
  *
  * Props:
  *   book        {object}   required — the book data object
- *   onAddToCart {function} optional — override the default CartContext addToCart.
- *                          Useful for contexts where the book object returned by the
- *                          parent differs from what CartContext would receive
- *                          (e.g. RecentlyViewed). Falls back to CartContext.addToCart.
+ *   onAddToCart {function} optional — override the default cart addToCart.
+ *                          Useful where the book object the parent holds
+ *                          differs from what the cart expects
+ *                          (e.g. RecentlyViewed). Falls back to addToCart.
  */
 export default function BookCard({ book, onAddToCart }) {
   const { wishlist, toggleWishlist } = useContext(WishlistContext);
-  const isWishlisted = wishlist.includes(book.id);
+  const { addToCart } = useCart();
+  const isWishlisted = wishlist?.includes(book.id);
+
+  const handleAddToCart = () => {
+    if (onAddToCart) {
+      onAddToCart(book);
+      return;
+    }
+    addToCart(book);
+  };
 
   return (
     <article className="book-card">
@@ -28,9 +34,9 @@ export default function BookCard({ book, onAddToCart }) {
         <span className="book-card__genre">{book.genre}</span>
         <span className="book-card__cover-title">{book.title}</span>
         <div className="book-card__wishlist-overlay">
-          <WishlistButton 
-            active={isWishlisted} 
-            onToggle={() => toggleWishlist(book.id)} 
+          <WishlistButton
+            active={isWishlisted}
+            onToggle={() => toggleWishlist(book.id)}
           />
         </div>
       </div>
@@ -51,10 +57,6 @@ export default function BookCard({ book, onAddToCart }) {
           <button className="book-card__add" onClick={handleAddToCart}>
             Add to cart
           </button>
-          <WishlistButton
-            active={wishlist?.includes(book.id)}
-            onToggle={() => toggleWishlist(book.id)}
-          />
         </div>
       </div>
     </article>

--- a/bookshelf-frontend/src/hooks/useCart.js
+++ b/bookshelf-frontend/src/hooks/useCart.js
@@ -1,0 +1,26 @@
+import { useContext } from 'react';
+import { CartContext } from '../context/CartContext.jsx';
+
+/**
+ * Access the cart.
+ *
+ * Prefer this over `useContext(CartContext)` directly. Reading the context
+ * straight gives you `undefined` when the provider is missing, and every
+ * caller then blows up on the destructuring line with a message that points
+ * at the consumer rather than at the missing provider. This throws with the
+ * actual cause instead.
+ */
+export function useCart() {
+  const context = useContext(CartContext);
+
+  if (context === undefined) {
+    throw new Error(
+      'useCart() must be used inside a <CartProvider>. ' +
+        'Check that CartProvider wraps the component tree in main.jsx.'
+    );
+  }
+
+  return context;
+}
+
+export default useCart;


### PR DESCRIPTION
Closes #275

## The 500

`registerUser` did `password.length < 8` on whatever arrived in the body. With no password that throws a `TypeError`, the `catch` forwards it, and `errorHandler` sees `res.statusCode === 200` and answers **500** with a raw JS message and a stack trace:

```bash
$ curl -X POST /api/auth/register -d '{"email":"a@b.com"}'
500 {"message":"Cannot read properties of undefined (reading 'length')","stack":"..."}
```

Now:

```bash
$ curl -X POST /api/auth/register -d '{"email":"a@b.com"}'
400 {"message":"Validation failed","errors":[
      {"field":"name","message":"name is required"},
      {"field":"password","message":"password is required"}]}
```

All bad fields come back together so the client can highlight them in one pass.

## Email normalisation

Nothing checked the email format, so `"notanemail"` was stored happily. Nothing normalised it either, so `"Alice@Example.com "` and `"alice@example.com"` registered as two accounts and only one could log in with the address the user typed. Emails are now trimmed and lowercased **before** the uniqueness lookup, so the check and the stored value always agree.

Passwords are deliberately *not* trimmed — spaces are legitimate password characters, and stripping them means the password you set is not the one that works.

Login validates presence and shape only. Applying the registration length rule there would lock out accounts created before that rule existed, and would tell an attacker which stored passwords are short.

`validateBody` also drops any field the schema does not name, so a body carrying `role: "admin"` cannot smuggle it through to the repository.

## Rate limiting

There was none, anywhere. Login returns a fast, distinguishable 401 for a wrong password, so it could be brute-forced as fast as the network allowed.

- `POST /api/auth/login` — 10 per IP per 15 min, **counter cleared on a successful login** so someone who mistypes twice and then gets in is not still carrying it
- `POST /api/auth/register` — 20 per IP per hour

Over the limit gets `429` with `Retry-After`, and every response carries `X-RateLimit-Limit/Remaining/Reset`.

The store is a `Map` in process memory. That is honest for a single instance and called out in a comment in the file: behind more than one instance each enforces its own limit, and only the `Map` needs to become Redis. No new dependency.

Verified live — attempts 11 and 12 against a wrong password:

```
--- login attempt 11 -> 429 Retry-After 810
--- login attempt 12 -> 429 Retry-After 810
```

## Stack trace leak

`errorHandler` returned `err.stack` unless `NODE_ENV === 'production'`. A deployment that never sets `NODE_ENV` therefore leaked absolute paths and internals on every error. It now fails closed — the stack is included only when `NODE_ENV` is exactly `development`.

Added `bookshelf-backend/.env.example`, which did not exist. Worth noting while writing it: `JWT_SECRET` silently falls back to a hardcoded `'fallback_secret'` in both `authMiddleware` and `generateToken`, so an unset secret lets anyone mint a valid token. Documented rather than changed here, since making it throw is a deploy-breaking change that deserves its own PR.

## Structure and tests

Validation primitives are plain functions in `utils/validators.js`; per-route field specs are in `validators/authValidators.js`; `middleware/validateBody.js` is a thin factory over them. No schema library, so no new dependency, and every piece is directly testable.

34 tests. The limiter takes an injectable clock, so the tests cross a 15-minute window without sleeping.

```
$ npm test
# tests 34
# pass 34
# fail 0
```

Note this PR also changes the backend `test` script from the placeholder `echo "Error: no test specified" && exit 1` to `node --test tests/*.test.js`. If #274 lands first that line will already be identical and the two merge cleanly.
