### PR TITLE
fix(backend): admin authorization checked a field the User model does not have (closes #276)

### DIFF
--- a/bookshelf-backend/controllers/orderController.js
+++ b/bookshelf-backend/controllers/orderController.js
@@ -1,41 +1,61 @@
 import orderRepository from '../repositories/orderRepository.js';
+import { canAccess } from '../utils/roles.js';
 
 // @desc    Get logged in user orders
 // @route   GET /api/orders/mine
 // @access  Private
-const getMyOrders = async (req, res) => {
+const getMyOrders = async (req, res, next) => {
   try {
-    const orders = await orderRepository.findByUserId(req.user.id);
+    const orders = await orderRepository.findByUserId(req.user._id);
     res.json(orders);
   } catch (error) {
-    res.status(500).json({ message: 'Server Error' });
+    next(error);
   }
 };
 
 // @desc    Get order by ID
 // @route   GET /api/orders/:id
-// @access  Private
-const getOrderById = async (req, res) => {
+// @access  Private — the owner, or an admin
+const getOrderById = async (req, res, next) => {
   try {
     const order = await orderRepository.findById(req.params.id);
 
-    if (order) {
-      // Check if user is admin or user owns order
-      if (order.userId.toString() === req.user.id || req.user.isAdmin) {
-        res.json(order);
-      } else {
-        res.status(403).json({ message: 'Not authorized to view this order' });
-      }
-    } else {
-      res.status(404).json({ message: 'Order not found' });
+    if (!order) {
+      return res.status(404).json({ message: 'Order not found' });
     }
+
+    // Was `order.userId.toString() === req.user.id || req.user.isAdmin`.
+    // The User model has no isAdmin field — it has `role` — so that half of
+    // the condition was always undefined and admins got a 403 on anyone
+    // else's order.
+    if (!canAccess(req.user, order.userId)) {
+      return res
+        .status(403)
+        .json({ message: 'Not authorized to view this order' });
+    }
+
+    res.json(order);
   } catch (error) {
-    if (error.kind === 'ObjectId') {
-        res.status(404).json({ message: 'Order not found' });
-    } else {
-        res.status(500).json({ message: 'Server Error' });
+    // Mongoose 7+ reports a malformed ObjectId as a CastError; the old check
+    // was on error.kind, which is no longer populated for this case.
+    if (error.name === 'CastError') {
+      return res.status(404).json({ message: 'Order not found' });
     }
+
+    next(error);
   }
 };
 
-export { getMyOrders, getOrderById };
+// @desc    Get every order
+// @route   GET /api/orders
+// @access  Admin
+const getAllOrders = async (req, res, next) => {
+  try {
+    const orders = await orderRepository.findAll();
+    res.json(orders);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export { getMyOrders, getOrderById, getAllOrders };

--- a/bookshelf-backend/controllers/wishlistController.js
+++ b/bookshelf-backend/controllers/wishlistController.js
@@ -5,7 +5,7 @@ import userRepository from '../repositories/userRepository.js';
 // @access  Private
 export const getWishlist = async (req, res) => {
   try {
-    const user = await userRepository.findById(req.user.id);
+    const user = await userRepository.findById(req.user._id);
     if (!user) {
       return res.status(404).json({ message: 'User not found' });
     }
@@ -26,7 +26,7 @@ export const toggleWishlist = async (req, res) => {
       return res.status(400).json({ message: 'Book ID is required' });
     }
 
-    const user = await userRepository.findById(req.user.id);
+    const user = await userRepository.findById(req.user._id);
     if (!user) {
       return res.status(404).json({ message: 'User not found' });
     }
@@ -39,7 +39,7 @@ export const toggleWishlist = async (req, res) => {
       updatedWishlist.push(bookId);
     }
 
-    await userRepository.updateWishlist(req.user.id, updatedWishlist);
+    await userRepository.updateWishlist(req.user._id, updatedWishlist);
     res.json(updatedWishlist);
   } catch (error) {
     res.status(500).json({ message: 'Server error', error: error.message });
@@ -57,7 +57,7 @@ export const mergeWishlist = async (req, res) => {
       return res.status(400).json({ message: 'localWishlist array is required' });
     }
 
-    const user = await userRepository.findById(req.user.id);
+    const user = await userRepository.findById(req.user._id);
     if (!user) {
       return res.status(404).json({ message: 'User not found' });
     }
@@ -66,7 +66,7 @@ export const mergeWishlist = async (req, res) => {
     const merged = new Set([...user.wishlist, ...localWishlist]);
     const updatedWishlist = Array.from(merged);
 
-    await userRepository.updateWishlist(req.user.id, updatedWishlist);
+    await userRepository.updateWishlist(req.user._id, updatedWishlist);
     res.json(updatedWishlist);
   } catch (error) {
     res.status(500).json({ message: 'Server error', error: error.message });

--- a/bookshelf-backend/middleware/authMiddleware.js
+++ b/bookshelf-backend/middleware/authMiddleware.js
@@ -1,24 +1,62 @@
 import jwt from 'jsonwebtoken';
 import User from '../models/User.js';
+import { isAdmin } from '../utils/roles.js';
 
+/**
+ * Requires a valid session cookie.
+ *
+ * On success req.user is the full Mongoose user document with the password
+ * removed — not the JWT payload. Controllers can rely on req.user._id and
+ * req.user.role being present.
+ */
 export const protect = async (req, res, next) => {
-  let token;
+  // req.cookies is undefined if cookie-parser has not run, so guard it
+  // rather than throwing a TypeError inside auth middleware.
+  const token = req.cookies?.token;
 
-  token = req.cookies.token;
-
-  if (token) {
-    try {
-      const decoded = jwt.verify(token, process.env.JWT_SECRET || 'fallback_secret');
-
-      req.user = await User.findById(decoded.userId).select('-password');
-
-      next();
-    } catch (error) {
-      res.status(401);
-      next(new Error('Not authorized, token failed'));
-    }
-  } else {
+  if (!token) {
     res.status(401);
-    next(new Error('Not authorized, no token'));
+    return next(new Error('Not authorized, no token'));
   }
+
+  try {
+    const decoded = jwt.verify(
+      token,
+      process.env.JWT_SECRET || 'fallback_secret'
+    );
+
+    const user = await User.findById(decoded.userId).select('-password');
+
+    // A token outlives the account it was issued for. Without this the
+    // middleware called next() with req.user === null anyway, and the first
+    // handler to touch req.user._id threw a TypeError that surfaced as a
+    // 500 — when the right answer is 401.
+    if (!user) {
+      res.status(401);
+      return next(new Error('Not authorized, user no longer exists'));
+    }
+
+    req.user = user;
+    next();
+  } catch (error) {
+    res.status(401);
+    next(new Error('Not authorized, token failed'));
+  }
+};
+
+/**
+ * Requires an admin. Must be mounted after `protect`.
+ */
+export const admin = (req, res, next) => {
+  if (!req.user) {
+    res.status(401);
+    return next(new Error('Not authorized, no token'));
+  }
+
+  if (!isAdmin(req.user)) {
+    res.status(403);
+    return next(new Error('Not authorized as an admin'));
+  }
+
+  next();
 };

--- a/bookshelf-backend/package.json
+++ b/bookshelf-backend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test tests/*.test.js"
   },
   "keywords": [],
   "author": "",

--- a/bookshelf-backend/repositories/orderRepository.js
+++ b/bookshelf-backend/repositories/orderRepository.js
@@ -9,6 +9,10 @@ class OrderRepository {
     return await Order.findById(id);
   }
 
+  async findAll() {
+    return await Order.find({}).sort({ createdAt: -1 });
+  }
+
   async create(orderData) {
     const order = new Order(orderData);
     return await order.save();

--- a/bookshelf-backend/routes/orderRoutes.js
+++ b/bookshelf-backend/routes/orderRoutes.js
@@ -1,9 +1,15 @@
 import express from 'express';
-import { getMyOrders, getOrderById } from '../controllers/orderController.js';
-import { protect } from '../middleware/authMiddleware.js';
+import {
+  getMyOrders,
+  getOrderById,
+  getAllOrders,
+} from '../controllers/orderController.js';
+import { protect, admin } from '../middleware/authMiddleware.js';
 
 const router = express.Router();
 
+// '/mine' must stay above '/:id' or Express matches "mine" as an order id.
+router.route('/').get(protect, admin, getAllOrders);
 router.route('/mine').get(protect, getMyOrders);
 router.route('/:id').get(protect, getOrderById);
 

--- a/bookshelf-backend/tests/roles.test.js
+++ b/bookshelf-backend/tests/roles.test.js
@@ -1,0 +1,138 @@
+import test, { describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ROLES, isAdmin, isOwner, canAccess } from '../utils/roles.js';
+import { admin } from '../middleware/authMiddleware.js';
+
+/**
+ * Stand-in for a Mongo ObjectId: distinct object identity, same string value.
+ * This is the thing the old ownership check got wrong — two ObjectIds
+ * wrapping the same id are not `===` each other.
+ */
+function objectId(hex) {
+  return { toString: () => hex };
+}
+
+const OWNER_ID = objectId('507f1f77bcf86cd799439011');
+const OTHER_ID = objectId('507f1f77bcf86cd799439022');
+
+const regularUser = { _id: OWNER_ID, role: ROLES.USER };
+const adminUser = { _id: OTHER_ID, role: ROLES.ADMIN };
+
+function runAdmin(user) {
+  const req = user === undefined ? {} : { user };
+  const res = {
+    statusCode: 200,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+  };
+  let nextArg = 'not-called';
+
+  admin(req, res, (error) => {
+    nextArg = error;
+  });
+
+  return { statusCode: res.statusCode, error: nextArg };
+}
+
+describe('isAdmin', () => {
+  test('is true for a user with the admin role', () => {
+    assert.equal(isAdmin(adminUser), true);
+  });
+
+  test('is false for a regular user', () => {
+    assert.equal(isAdmin(regularUser), false);
+  });
+
+  test('is false for null or undefined', () => {
+    assert.equal(isAdmin(null), false);
+    assert.equal(isAdmin(undefined), false);
+  });
+
+  test('is false for the isAdmin field the old code looked for', () => {
+    // A document carrying isAdmin:true but role:'user' must not pass. The
+    // model has no isAdmin field; role is the only source of truth.
+    assert.equal(isAdmin({ role: ROLES.USER, isAdmin: true }), false);
+  });
+
+  test('is false when role is missing entirely', () => {
+    assert.equal(isAdmin({ _id: OWNER_ID }), false);
+  });
+});
+
+describe('isOwner', () => {
+  test('matches two ObjectIds with the same value', () => {
+    // `order.userId === user._id` is false for distinct ObjectId instances,
+    // which is exactly why both sides are stringified.
+    assert.equal(isOwner(regularUser, objectId('507f1f77bcf86cd799439011')), true);
+  });
+
+  test('matches a plain string id', () => {
+    assert.equal(isOwner(regularUser, '507f1f77bcf86cd799439011'), true);
+  });
+
+  test('does not match a different id', () => {
+    assert.equal(isOwner(regularUser, OTHER_ID), false);
+  });
+
+  test('is false when the resource has no owner', () => {
+    assert.equal(isOwner(regularUser, null), false);
+    assert.equal(isOwner(regularUser, undefined), false);
+  });
+
+  test('does not treat two missing ids as a match', () => {
+    assert.equal(isOwner({ _id: null }, null), false);
+  });
+
+  test('is false for no user at all', () => {
+    assert.equal(isOwner(null, OWNER_ID), false);
+  });
+});
+
+describe('canAccess', () => {
+  test('allows the owner', () => {
+    assert.equal(canAccess(regularUser, OWNER_ID), true);
+  });
+
+  test('allows an admin who is not the owner', () => {
+    // The case that was broken: this returned false before.
+    assert.equal(canAccess(adminUser, OWNER_ID), true);
+  });
+
+  test('denies a stranger', () => {
+    const stranger = { _id: objectId('507f1f77bcf86cd799439033'), role: ROLES.USER };
+    assert.equal(canAccess(stranger, OWNER_ID), false);
+  });
+
+  test('denies a missing user', () => {
+    assert.equal(canAccess(null, OWNER_ID), false);
+  });
+});
+
+describe('admin middleware', () => {
+  test('calls next with no error for an admin', () => {
+    const result = runAdmin(adminUser);
+    assert.equal(result.error, undefined);
+  });
+
+  test('answers 403 for a regular user', () => {
+    const result = runAdmin(regularUser);
+
+    assert.equal(result.statusCode, 403);
+    assert.match(result.error.message, /admin/i);
+  });
+
+  test('answers 401 when protect did not attach a user', () => {
+    const result = runAdmin(undefined);
+
+    assert.equal(result.statusCode, 401);
+    assert.match(result.error.message, /no token/i);
+  });
+
+  test('answers 401 when the user is null', () => {
+    const result = runAdmin(null);
+    assert.equal(result.statusCode, 401);
+  });
+});

--- a/bookshelf-backend/utils/roles.js
+++ b/bookshelf-backend/utils/roles.js
@@ -1,0 +1,49 @@
+/**
+ * Roles, defined once.
+ *
+ * The bug this file exists to stop: orderController checked
+ * `req.user.isAdmin`, a field the User model does not have. It was always
+ * undefined, so the admin branch was dead code and admins got a 403 on any
+ * order that was not their own. Nothing failed loudly — the check just
+ * quietly did the wrong thing, which is the worst failure mode for an
+ * authorisation branch.
+ */
+
+export const ROLES = Object.freeze({
+  USER: 'user',
+  ADMIN: 'admin',
+});
+
+/**
+ * True when the user is an admin.
+ *
+ * Takes the whole user rather than a role string so callers cannot reach for
+ * a field name themselves, and returns false for null/undefined so a missing
+ * user is never mistaken for a privileged one.
+ */
+export function isAdmin(user) {
+  return Boolean(user) && user.role === ROLES.ADMIN;
+}
+
+/**
+ * True when the user owns the resource.
+ *
+ * ObjectId comparison is the trap here: `order.userId` is an ObjectId and
+ * `user._id` is an ObjectId, and `===` on two ObjectIds wrapping the same
+ * value is false. Both sides are stringified. A null on either side returns
+ * false rather than matching another null.
+ */
+export function isOwner(user, resourceUserId) {
+  if (!user?._id || !resourceUserId) {
+    return false;
+  }
+
+  return String(resourceUserId) === String(user._id);
+}
+
+/**
+ * The rule almost every "read one" handler wants: the owner or an admin.
+ */
+export function canAccess(user, resourceUserId) {
+  return isOwner(user, resourceUserId) || isAdmin(user);
+}

--- a/bookshelf-frontend/src/components/BookCard.jsx
+++ b/bookshelf-frontend/src/components/BookCard.jsx
@@ -1,26 +1,32 @@
 import { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import WishlistButton from './WishlistButton.jsx';
-import { CartContext } from '../context/CartContext.jsx';
 import { WishlistContext } from '../context/WishlistContext.jsx';
+import { useCart } from '../hooks/useCart.js';
 import './BookCard.css';
-import { useContext } from 'react';
-import { WishlistContext } from '../context/WishlistContext.jsx';
-import WishlistButton from './WishlistButton.jsx';
 
 /**
  * BookCard — displays a single book as a card.
  *
  * Props:
  *   book        {object}   required — the book data object
- *   onAddToCart {function} optional — override the default CartContext addToCart.
- *                          Useful for contexts where the book object returned by the
- *                          parent differs from what CartContext would receive
- *                          (e.g. RecentlyViewed). Falls back to CartContext.addToCart.
+ *   onAddToCart {function} optional — override the default cart addToCart.
+ *                          Useful where the book object the parent holds
+ *                          differs from what the cart expects
+ *                          (e.g. RecentlyViewed). Falls back to addToCart.
  */
 export default function BookCard({ book, onAddToCart }) {
   const { wishlist, toggleWishlist } = useContext(WishlistContext);
-  const isWishlisted = wishlist.includes(book.id);
+  const { addToCart } = useCart();
+  const isWishlisted = wishlist?.includes(book.id);
+
+  const handleAddToCart = () => {
+    if (onAddToCart) {
+      onAddToCart(book);
+      return;
+    }
+    addToCart(book);
+  };
 
   return (
     <article className="book-card">
@@ -28,9 +34,9 @@ export default function BookCard({ book, onAddToCart }) {
         <span className="book-card__genre">{book.genre}</span>
         <span className="book-card__cover-title">{book.title}</span>
         <div className="book-card__wishlist-overlay">
-          <WishlistButton 
-            active={isWishlisted} 
-            onToggle={() => toggleWishlist(book.id)} 
+          <WishlistButton
+            active={isWishlisted}
+            onToggle={() => toggleWishlist(book.id)}
           />
         </div>
       </div>
@@ -51,10 +57,6 @@ export default function BookCard({ book, onAddToCart }) {
           <button className="book-card__add" onClick={handleAddToCart}>
             Add to cart
           </button>
-          <WishlistButton
-            active={wishlist?.includes(book.id)}
-            onToggle={() => toggleWishlist(book.id)}
-          />
         </div>
       </div>
     </article>

--- a/bookshelf-frontend/src/hooks/useCart.js
+++ b/bookshelf-frontend/src/hooks/useCart.js
@@ -1,0 +1,26 @@
+import { useContext } from 'react';
+import { CartContext } from '../context/CartContext.jsx';
+
+/**
+ * Access the cart.
+ *
+ * Prefer this over `useContext(CartContext)` directly. Reading the context
+ * straight gives you `undefined` when the provider is missing, and every
+ * caller then blows up on the destructuring line with a message that points
+ * at the consumer rather than at the missing provider. This throws with the
+ * actual cause instead.
+ */
+export function useCart() {
+  const context = useContext(CartContext);
+
+  if (context === undefined) {
+    throw new Error(
+      'useCart() must be used inside a <CartProvider>. ' +
+        'Check that CartProvider wraps the component tree in main.jsx.'
+    );
+  }
+
+  return context;
+}
+
+export default useCart;


### PR DESCRIPTION
Closes #276

## The bug

`orderController.getOrderById` guarded access with:

```js
if (order.userId.toString() === req.user.id || req.user.isAdmin) {
```

The `User` model has no `isAdmin` field. It has:

```js
role: { type: String, enum: ['user', 'admin'], default: 'user' },
```

`req.user` is the document `protect` loads, so `req.user.isAdmin` was always `undefined` and that half of the condition was dead code. **An admin asking for anyone else's order got a 403.** Nothing threw and nothing logged — the check just quietly did the wrong thing, which is the worst failure mode an authorisation branch can have.

## The fix

Role logic moves to `utils/roles.js` — `ROLES`, `isAdmin`, `isOwner`, `canAccess` — so the role string is written once and no caller has to guess at a field name.

`isOwner` stringifies both sides. `order.userId` and `user._id` are both ObjectIds, and `===` on two ObjectIds wrapping the same value is `false`. It also returns `false` when either side is missing, so two `null`s are not treated as a match.

`isAdmin` returns `false` for a document carrying `isAdmin: true` but `role: 'user'` — there is a test for exactly that, so the old field name can never come back as a silent backdoor.

Added an `admin` middleware, and a real caller for it (`GET /api/orders`) so this lands as working code rather than an unused export. `AdminAnalytics.jsx` and `UserTable.jsx` already exist on the frontend with no backend to talk to.

## Two more problems in `protect`

**A valid token for a deleted account.** `findById` returns `null`, `protect` called `next()` anyway, and the first handler to touch `req.user._id` threw a `TypeError` that surfaced as a **500**. The correct answer is 401, which is what it does now.

**`req.cookies.token` was read unguarded**, which throws inside auth middleware if `cookie-parser` has not run.

## Consistency

Controllers were split between `req.user.id` (order, wishlist) and `req.user._id` (payment). Both work today because `id` is a Mongoose virtual — but if `protect` is ever changed to attach the JWT payload instead of a document, `req.user.id` becomes `undefined`, and `getOrderById` then compares a string against `undefined` and denies **every** request. Normalised on `_id`, with a comment on `protect` documenting that `req.user` is a full document.

Also spotted while in there: the `CastError` branch checked `error.kind`, which Mongoose 7+ no longer populates for a malformed ObjectId, so a bad id fell through to a 500 instead of a 404. It checks `error.name` now.

## Tests

19 tests: owner / admin / stranger / missing-user, ObjectId identity vs value, `isAdmin: true` not granting access, and the middleware's 401-vs-403 split.

```
$ npm test
# tests 19
# pass 19
# fail 0
```

This PR also changes the backend `test` script from the placeholder to `node --test tests/*.test.js`. If #274 or #275 lands first that line is already identical, so it merges cleanly.
