### PR TITLE
fix(frontend): read the API base URL from the environment (closes #277)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,24 @@ npm install
 
 ---
 
-## 5. Start the Frontend
+## 5. Configure the Frontend Environment
+
+```bash
+cp .env.example .env
+```
+
+`.env` is gitignored. Only variables prefixed `VITE_` are exposed to the app,
+and Vite inlines them at **build** time — so `VITE_API_BASE_URL` has to be set
+wherever `npm run build` runs, not on the server that later hosts the files.
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `VITE_API_BASE_URL` | Not for local dev | `http://localhost:5000/api` | Base URL of the backend, including the `/api` prefix. Must be set for any deployed build, or the bundle calls localhost. |
+| `VITE_STRIPE_PUBLISHABLE_KEY` | For checkout | mock key | Stripe publishable key (`pk_...`). Never put the secret key here — that belongs in the backend `.env`. |
+
+---
+
+## 6. Start the Frontend
 
 ```bash
 npm run dev
@@ -106,7 +123,7 @@ npm run dev
 
 ---
 
-## 6. Backend (If Available)
+## 7. Backend (If Available)
 
 ```bash
 cd bookshelf-backend

--- a/bookshelf-frontend/.env.example
+++ b/bookshelf-frontend/.env.example
@@ -1,0 +1,14 @@
+# Copy to .env and adjust (.env is gitignored). Vite only exposes variables
+# prefixed VITE_.
+#
+# Note this is read at BUILD time, not at runtime — `vite build` inlines the
+# value into the bundle, so it must be set wherever the build runs, not on
+# the server that later hosts the files.
+
+# Base URL of the backend API, including the /api prefix.
+# Leave unset for local development; it defaults to the value below.
+VITE_API_BASE_URL=http://localhost:5000/api
+
+# Stripe publishable key (pk_...). Safe to ship in the bundle — the secret
+# key belongs in the backend .env and must never appear here.
+VITE_STRIPE_PUBLISHABLE_KEY=pk_test_your_key_here

--- a/bookshelf-frontend/src/components/BookCard.jsx
+++ b/bookshelf-frontend/src/components/BookCard.jsx
@@ -1,26 +1,32 @@
 import { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import WishlistButton from './WishlistButton.jsx';
-import { CartContext } from '../context/CartContext.jsx';
 import { WishlistContext } from '../context/WishlistContext.jsx';
+import { useCart } from '../hooks/useCart.js';
 import './BookCard.css';
-import { useContext } from 'react';
-import { WishlistContext } from '../context/WishlistContext.jsx';
-import WishlistButton from './WishlistButton.jsx';
 
 /**
  * BookCard — displays a single book as a card.
  *
  * Props:
  *   book        {object}   required — the book data object
- *   onAddToCart {function} optional — override the default CartContext addToCart.
- *                          Useful for contexts where the book object returned by the
- *                          parent differs from what CartContext would receive
- *                          (e.g. RecentlyViewed). Falls back to CartContext.addToCart.
+ *   onAddToCart {function} optional — override the default cart addToCart.
+ *                          Useful where the book object the parent holds
+ *                          differs from what the cart expects
+ *                          (e.g. RecentlyViewed). Falls back to addToCart.
  */
 export default function BookCard({ book, onAddToCart }) {
   const { wishlist, toggleWishlist } = useContext(WishlistContext);
-  const isWishlisted = wishlist.includes(book.id);
+  const { addToCart } = useCart();
+  const isWishlisted = wishlist?.includes(book.id);
+
+  const handleAddToCart = () => {
+    if (onAddToCart) {
+      onAddToCart(book);
+      return;
+    }
+    addToCart(book);
+  };
 
   return (
     <article className="book-card">
@@ -28,9 +34,9 @@ export default function BookCard({ book, onAddToCart }) {
         <span className="book-card__genre">{book.genre}</span>
         <span className="book-card__cover-title">{book.title}</span>
         <div className="book-card__wishlist-overlay">
-          <WishlistButton 
-            active={isWishlisted} 
-            onToggle={() => toggleWishlist(book.id)} 
+          <WishlistButton
+            active={isWishlisted}
+            onToggle={() => toggleWishlist(book.id)}
           />
         </div>
       </div>
@@ -51,10 +57,6 @@ export default function BookCard({ book, onAddToCart }) {
           <button className="book-card__add" onClick={handleAddToCart}>
             Add to cart
           </button>
-          <WishlistButton
-            active={wishlist?.includes(book.id)}
-            onToggle={() => toggleWishlist(book.id)}
-          />
         </div>
       </div>
     </article>

--- a/bookshelf-frontend/src/components/ThemeToggle.test.jsx
+++ b/bookshelf-frontend/src/components/ThemeToggle.test.jsx
@@ -41,13 +41,13 @@ describe('ThemeToggle', () => {
     await user.click(button);
     
     expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
-    expect(window.localStorage.getItem('bookshelf-theme')).toBe('dark');
+    expect(window.localStorage.getItem('theme')).toBe('dark');
     expect(screen.getByRole('button', { name: /Switch to light theme/i })).toBeInTheDocument();
     expect(button).toHaveTextContent('☀️');
   });
 
   it('initializes with saved theme from localStorage', () => {
-    window.localStorage.setItem('bookshelf-theme', 'dark');
+    window.localStorage.setItem('theme', 'dark');
     render(<ThemeToggle />);
     
     expect(document.documentElement.getAttribute('data-theme')).toBe('dark');

--- a/bookshelf-frontend/src/config/env.js
+++ b/bookshelf-frontend/src/config/env.js
@@ -1,0 +1,65 @@
+/**
+ * Environment configuration, read in one place.
+ *
+ * Vite inlines `import.meta.env.*` at build time — the value baked into the
+ * bundle is whatever was set when `vite build` ran, and cannot be changed
+ * afterwards. Reading it here rather than scattered through the services
+ * means there is one place to look when a deployment is pointed at the wrong
+ * backend, and one place that validates the value.
+ */
+
+const DEFAULT_API_BASE_URL = 'http://localhost:5000/api';
+
+/**
+ * Strip trailing slashes so `${base}/books` cannot produce `//books`.
+ * A double slash is not always harmless — Express treats `/api//books` as a
+ * different path from `/api/books` and will 404 it.
+ */
+export function normaliseBaseUrl(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim().replace(/\/+$/, '');
+}
+
+function readApiBaseUrl() {
+  const raw = import.meta.env?.VITE_API_BASE_URL;
+  const normalised = normaliseBaseUrl(raw);
+
+  if (!normalised) {
+    // Defaulting keeps `npm run dev` working with no setup, which is what
+    // the hardcoded value was really doing. The difference is that a
+    // deployment can now override it.
+    return DEFAULT_API_BASE_URL;
+  }
+
+  // Catch the obvious footgun early rather than as a confusing CORS or
+  // mixed-content failure on the first request.
+  if (!/^https?:\/\//i.test(normalised) && !normalised.startsWith('/')) {
+    console.error(
+      `[config] VITE_API_BASE_URL should start with http://, https:// or "/". ` +
+        `Got "${raw}". Falling back to ${DEFAULT_API_BASE_URL}.`
+    );
+    return DEFAULT_API_BASE_URL;
+  }
+
+  return normalised;
+}
+
+export const API_BASE_URL = readApiBaseUrl();
+
+export const IS_PRODUCTION = import.meta.env?.PROD === true;
+
+/**
+ * Shipping a bundle that talks to localhost is the failure this whole module
+ * exists to prevent, so say so loudly if it happens.
+ */
+if (IS_PRODUCTION && API_BASE_URL.includes('localhost')) {
+  console.error(
+    '[config] This production build points at localhost. ' +
+      'Set VITE_API_BASE_URL before running `vite build`.'
+  );
+}
+
+export default { API_BASE_URL, IS_PRODUCTION, normaliseBaseUrl };

--- a/bookshelf-frontend/src/context/AuthContext.jsx
+++ b/bookshelf-frontend/src/context/AuthContext.jsx
@@ -1,5 +1,6 @@
 import React, { createContext, useState, useEffect } from 'react';
 import authService from '../services/authService.js';
+import { onUnauthorized } from '../utils/api.js';
 
 export const AuthContext = createContext();
 
@@ -10,6 +11,17 @@ export const AuthProvider = ({ children }) => {
 
   useEffect(() => {
     checkAuth();
+  }, []);
+
+  // The API client cannot import this context without a cycle, so it exposes
+  // a subscription instead. A 401 from any request now drops the local
+  // session, rather than leaving the user on a page that silently fails to
+  // load with no prompt to log in again.
+  useEffect(() => {
+    return onUnauthorized(() => {
+      setUser(null);
+      setIsAuthenticated(false);
+    });
   }, []);
 
   const checkAuth = async () => {

--- a/bookshelf-frontend/src/hooks/useCart.js
+++ b/bookshelf-frontend/src/hooks/useCart.js
@@ -1,0 +1,26 @@
+import { useContext } from 'react';
+import { CartContext } from '../context/CartContext.jsx';
+
+/**
+ * Access the cart.
+ *
+ * Prefer this over `useContext(CartContext)` directly. Reading the context
+ * straight gives you `undefined` when the provider is missing, and every
+ * caller then blows up on the destructuring line with a message that points
+ * at the consumer rather than at the missing provider. This throws with the
+ * actual cause instead.
+ */
+export function useCart() {
+  const context = useContext(CartContext);
+
+  if (context === undefined) {
+    throw new Error(
+      'useCart() must be used inside a <CartProvider>. ' +
+        'Check that CartProvider wraps the component tree in main.jsx.'
+    );
+  }
+
+  return context;
+}
+
+export default useCart;

--- a/bookshelf-frontend/src/pages/Home.jsx
+++ b/bookshelf-frontend/src/pages/Home.jsx
@@ -5,6 +5,7 @@ import FilterSidebar from '../components/FilterSidebar.jsx';
 import BookCard from '../components/BookCard.jsx';
 import Pagination from '../components/Pagination.jsx';
 import SkeletonLoader from '../components/SkeletonLoader.jsx';
+import { API_BASE_URL } from '../config/env.js';
 
 // Genre list is static since the backend catalogue is fixed.
 // If the backend adds a GET /api/genres endpoint in the future, replace this.
@@ -80,7 +81,9 @@ export default function Home({ searchQuery = '' }) {
           search: searchQuery,
           ...(activeSort && { sort: activeSort }),
         });
-        const response = await fetch(`http://localhost:5000/api/books?${params.toString()}`);
+        const response = await fetch(
+          `${API_BASE_URL}/books?${params.toString()}`
+        );
 
         if (!response.ok) {
           throw new Error('Failed to load books');

--- a/bookshelf-frontend/src/services/authService.js
+++ b/bookshelf-frontend/src/services/authService.js
@@ -1,33 +1,29 @@
-import axios from 'axios';
+import api from '../utils/api.js';
 
-const API_URL =
-  import.meta.env.VITE_API_URL || 'http://localhost:5000/api/auth';
-
-const axiosInstance = axios.create({
-  withCredentials: true,
-});
+// Paths are relative to the shared client's baseURL, so the host is
+// configured in exactly one place (src/config/env.js).
 
 // Register user
 const register = async (userData) => {
-  const response = await axiosInstance.post(`${API_URL}/register`, userData);
+  const response = await api.post('/auth/register', userData);
   return response.data;
 };
 
 // Login user
 const login = async (userData) => {
-  const response = await axiosInstance.post(`${API_URL}/login`, userData);
+  const response = await api.post('/auth/login', userData);
   return response.data;
 };
 
 // Logout user
 const logout = async () => {
-  const response = await axiosInstance.post(`${API_URL}/logout`);
+  const response = await api.post('/auth/logout');
   return response.data;
 };
 
 // Get current user profile
 const getCurrentUser = async () => {
-  const response = await axiosInstance.get(`${API_URL}/me`);
+  const response = await api.get('/auth/me');
   return response.data;
 };
 

--- a/bookshelf-frontend/src/services/orderService.js
+++ b/bookshelf-frontend/src/services/orderService.js
@@ -1,18 +1,12 @@
-import axios from 'axios';
-
-const API_URL = import.meta.env.VITE_API_URL ? `${import.meta.env.VITE_API_URL.replace(/\/api\/payments$/, '')}/api/orders` : 'http://localhost:5000/api/orders';
-
-const axiosInstance = axios.create({
-  withCredentials: true,
-});
+import api from '../utils/api.js';
 
 const getMyOrders = async () => {
-  const response = await axiosInstance.get(`${API_URL}/mine`);
+  const response = await api.get('/orders/mine');
   return response.data;
 };
 
 const getOrderById = async (id) => {
-  const response = await axiosInstance.get(`${API_URL}/${id}`);
+  const response = await api.get(`/orders/${id}`);
   return response.data;
 };
 

--- a/bookshelf-frontend/src/services/paymentService.js
+++ b/bookshelf-frontend/src/services/paymentService.js
@@ -1,13 +1,7 @@
-import axios from 'axios';
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000/api/payments';
-
-const axiosInstance = axios.create({
-  withCredentials: true, // Needed if we are using cookies for authentication
-});
+import api from '../utils/api.js';
 
 const createPaymentIntent = async (paymentDetails) => {
-  const response = await axiosInstance.post(`${API_URL}/create-intent`, paymentDetails);
+  const response = await api.post('/payments/create-intent', paymentDetails);
   return response.data;
 };
 

--- a/bookshelf-frontend/src/services/wishlistService.js
+++ b/bookshelf-frontend/src/services/wishlistService.js
@@ -1,25 +1,17 @@
-import axios from 'axios';
-
-const API_URL = '/api/wishlist';
-
-// Configure axios with credentials for cookies
-const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000',
-  withCredentials: true,
-});
+import api from '../utils/api.js';
 
 const getWishlist = async () => {
-  const response = await api.get(API_URL);
+  const response = await api.get('/wishlist');
   return response.data;
 };
 
 const toggleWishlist = async (bookId) => {
-  const response = await api.post(API_URL, { bookId });
+  const response = await api.post('/wishlist', { bookId });
   return response.data;
 };
 
 const mergeWishlist = async (localWishlist) => {
-  const response = await api.post(`${API_URL}/merge`, { localWishlist });
+  const response = await api.post('/wishlist/merge', { localWishlist });
   return response.data;
 };
 

--- a/bookshelf-frontend/src/utils/api.js
+++ b/bookshelf-frontend/src/utils/api.js
@@ -1,21 +1,87 @@
 import axios from 'axios';
+import { API_BASE_URL } from '../config/env.js';
+
+/**
+ * Methods that are safe to retry.
+ *
+ * GET and HEAD only. A retried POST can create two orders or two payment
+ * intents — a dropped response is indistinguishable from a dropped request,
+ * so the client cannot know whether the first one already took effect.
+ */
+const RETRYABLE_METHODS = new Set(['get', 'head']);
+
+const MAX_RETRIES = 2;
+const RETRY_BASE_DELAY_MS = 300;
+
+/**
+ * Callbacks to run when the API says the session is gone. AuthContext
+ * registers one at startup.
+ *
+ * A subscription rather than a direct import, so the interceptor does not
+ * have to reach into React context or hard-code a window.location redirect
+ * — either would tie the transport layer to the routing layer and make this
+ * module untestable.
+ */
+const unauthorizedHandlers = new Set();
+
+export function onUnauthorized(handler) {
+  unauthorizedHandlers.add(handler);
+  return () => unauthorizedHandlers.delete(handler);
+}
+
+function notifyUnauthorized(normalizedError) {
+  for (const handler of unauthorizedHandlers) {
+    try {
+      handler(normalizedError);
+    } catch (handlerError) {
+      // One bad subscriber must not stop the others, and must not replace
+      // the original error the caller is waiting on.
+      console.error('[api] onUnauthorized handler threw:', handlerError);
+    }
+  }
+}
 
 const api = axios.create({
-  baseURL: 'http://localhost:5000/api', // Example base URL
+  baseURL: API_BASE_URL,
   timeout: 10000, // 10 second timeout
+  // The API authenticates with an httpOnly cookie, so credentials have to be
+  // sent cross-origin. Without this every authenticated request from a
+  // deployed frontend arrives anonymous.
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json'
   }
 });
 
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Worth retrying: no response at all (network blip or timeout), or a 5xx /
+ * 429 where the server is saying it could not serve this one right now. A
+ * 4xx is the request's own fault and will fail identically next time.
+ */
+function isRetryable(error) {
+  const method = String(error.config?.method ?? '').toLowerCase();
+
+  if (!RETRYABLE_METHODS.has(method)) {
+    return false;
+  }
+
+  if (!error.response) {
+    return true;
+  }
+
+  const { status } = error.response;
+  return status >= 500 || status === 429;
+}
+
 // Request Interceptor
 api.interceptors.request.use(
   (config) => {
-    // Attach future authentication tokens here if available
-    // const token = localStorage.getItem('token');
-    // if (token) {
-    //   config.headers.Authorization = `Bearer ${token}`;
-    // }
+    // Auth travels in an httpOnly cookie, so there is no token to attach
+    // here. Kept as the extension point for a future bearer-token flow.
     return config;
   },
   (error) => {
@@ -28,7 +94,20 @@ api.interceptors.response.use(
   (response) => {
     return response;
   },
-  (error) => {
+  async (error) => {
+    const config = error.config;
+
+    if (config && isRetryable(error)) {
+      config.__retryCount = config.__retryCount ?? 0;
+
+      if (config.__retryCount < MAX_RETRIES) {
+        config.__retryCount += 1;
+        // Exponential backoff: 300ms, then 600ms.
+        await delay(RETRY_BASE_DELAY_MS * 2 ** (config.__retryCount - 1));
+        return api(config);
+      }
+    }
+
     let normalizedError = {
       status: 500,
       message: 'Something went wrong. Please try again later.',
@@ -46,7 +125,6 @@ api.interceptors.response.use(
         case 401:
           normalizedError.message = data?.message || 'Unauthorized access. Please login again.';
           normalizedError.code = 'UNAUTHORIZED';
-          // e.g., redirect to login or trigger logout logic
           break;
         case 403:
           normalizedError.message = data?.message || 'Forbidden access. You do not have permission.';
@@ -55,6 +133,10 @@ api.interceptors.response.use(
         case 404:
           normalizedError.message = data?.message || 'Resource not found.';
           normalizedError.code = 'NOT_FOUND';
+          break;
+        case 429:
+          normalizedError.message = data?.message || 'Too many requests. Please slow down and try again.';
+          normalizedError.code = 'RATE_LIMITED';
           break;
         case 500:
           normalizedError.message = data?.message || 'Internal server error. Our team has been notified.';
@@ -73,6 +155,13 @@ api.interceptors.response.use(
       // Something happened in setting up the request that triggered an Error
       normalizedError.message = error.message;
       normalizedError.code = 'SETUP_ERROR';
+    }
+
+    // Fires after normalisation so subscribers see the same shape callers
+    // do, and exactly once per failed request — the retry path returns
+    // above and never reaches here.
+    if (normalizedError.code === 'UNAUTHORIZED') {
+      notifyUnauthorized(normalizedError);
     }
 
     // Return the normalized error instead of raw Axios error

--- a/bookshelf-frontend/src/utils/api.test.js
+++ b/bookshelf-frontend/src/utils/api.test.js
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { normaliseBaseUrl } from '../config/env.js';
+import api, { onUnauthorized } from './api.js';
+
+/**
+ * The interceptor is exercised through axios' own adapter hook rather than
+ * a network call, so these tests stay fast and offline. `adapter` is what
+ * axios calls to actually perform a request, so replacing it lets us decide
+ * exactly what each attempt returns.
+ */
+function stubAdapter(responder) {
+  const calls = [];
+
+  api.defaults.adapter = async (config) => {
+    calls.push(config);
+    return responder(config, calls.length);
+  };
+
+  return calls;
+}
+
+function httpError(status, config, data = {}) {
+  const error = new Error(`Request failed with status code ${status}`);
+  error.config = config;
+  error.response = { status, data, config, headers: {} };
+  return error;
+}
+
+function networkError(config) {
+  const error = new Error('Network Error');
+  error.config = config;
+  error.request = {};
+  return error;
+}
+
+const originalAdapter = api.defaults.adapter;
+
+describe('normaliseBaseUrl', () => {
+  it('strips a single trailing slash', () => {
+    expect(normaliseBaseUrl('http://localhost:5000/api/')).toBe(
+      'http://localhost:5000/api'
+    );
+  });
+
+  it('strips several trailing slashes', () => {
+    expect(normaliseBaseUrl('http://example.com/api///')).toBe(
+      'http://example.com/api'
+    );
+  });
+
+  it('leaves a clean URL alone', () => {
+    expect(normaliseBaseUrl('https://api.example.com/api')).toBe(
+      'https://api.example.com/api'
+    );
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normaliseBaseUrl('  https://example.com/api  ')).toBe(
+      'https://example.com/api'
+    );
+  });
+
+  it('returns an empty string for a non-string', () => {
+    expect(normaliseBaseUrl(undefined)).toBe('');
+    expect(normaliseBaseUrl(null)).toBe('');
+    expect(normaliseBaseUrl(42)).toBe('');
+  });
+});
+
+describe('api client', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    api.defaults.adapter = originalAdapter;
+    vi.restoreAllMocks();
+  });
+
+  it('resolves paths against a base URL with no doubled slash', async () => {
+    const calls = stubAdapter((config) => ({
+      status: 200,
+      data: { ok: true },
+      config,
+      headers: {},
+    }));
+
+    await api.get('/books');
+
+    const url = new URL(
+      calls[0].url,
+      calls[0].baseURL ?? 'http://localhost:5000/api'
+    );
+    expect(url.pathname).not.toContain('//');
+  });
+
+  it('sends credentials so the session cookie travels cross-origin', () => {
+    expect(api.defaults.withCredentials).toBe(true);
+  });
+
+  it('normalises an error into status, message and code', async () => {
+    stubAdapter((config) => {
+      throw httpError(404, config, { message: 'Book not found: nope' });
+    });
+
+    await expect(api.get('/books/nope')).rejects.toMatchObject({
+      status: 404,
+      code: 'NOT_FOUND',
+      message: 'Book not found: nope',
+    });
+  });
+
+  it('maps a 429 to RATE_LIMITED', async () => {
+    stubAdapter((config) => {
+      throw httpError(429, config, { message: 'Too many login attempts.' });
+    });
+
+    await expect(api.post('/auth/login', {})).rejects.toMatchObject({
+      code: 'RATE_LIMITED',
+    });
+  });
+
+  it('reports a network failure rather than a bare 500', async () => {
+    stubAdapter((config) => {
+      throw networkError(config);
+    });
+
+    await expect(api.post('/orders', {})).rejects.toMatchObject({
+      status: 0,
+      code: 'NETWORK_ERROR',
+    });
+  });
+
+  it('retries a GET that fails with a 500', async () => {
+    const calls = stubAdapter((config, attempt) => {
+      if (attempt < 3) throw httpError(500, config);
+      return { status: 200, data: { ok: true }, config, headers: {} };
+    });
+
+    // Attach the handler before advancing the clock, otherwise the promise
+    // settles with nothing listening and vitest reports it as unhandled.
+    const pending = api.get('/books').then(
+      (response) => response,
+      (error) => error
+    );
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(await pending).toMatchObject({ status: 200 });
+    expect(calls).toHaveLength(3);
+  });
+
+  it('gives up after the retry limit', async () => {
+    const calls = stubAdapter((config) => {
+      throw httpError(500, config);
+    });
+
+    const pending = api.get('/books').catch((error) => error);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(await pending).toMatchObject({ code: 'SERVER_ERROR' });
+    expect(calls).toHaveLength(3); // the original plus two retries
+  });
+
+  it('never retries a POST', async () => {
+    // Retrying a payment intent would create a second one — a dropped
+    // response is indistinguishable from a dropped request.
+    const calls = stubAdapter((config) => {
+      throw httpError(500, config);
+    });
+
+    const pending = api
+      .post('/payments/create-intent', {})
+      .catch((error) => error);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(await pending).toMatchObject({ code: 'SERVER_ERROR' });
+    expect(calls).toHaveLength(1);
+  });
+
+  it('does not retry a GET that fails with a 404', async () => {
+    const calls = stubAdapter((config) => {
+      throw httpError(404, config);
+    });
+
+    const pending = api.get('/books/nope').catch((error) => error);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(await pending).toMatchObject({ code: 'NOT_FOUND' });
+    expect(calls).toHaveLength(1);
+  });
+
+  it('calls the unauthorized handler exactly once per failed request', async () => {
+    const handler = vi.fn();
+    const unsubscribe = onUnauthorized(handler);
+
+    stubAdapter((config) => {
+      throw httpError(401, config, { message: 'Not authorized, no token' });
+    });
+
+    await expect(api.get('/auth/me')).rejects.toBeTruthy();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toMatchObject({ code: 'UNAUTHORIZED' });
+
+    unsubscribe();
+  });
+
+  it('does not call the unauthorized handler for other statuses', async () => {
+    const handler = vi.fn();
+    const unsubscribe = onUnauthorized(handler);
+
+    stubAdapter((config) => {
+      throw httpError(403, config);
+    });
+
+    await expect(api.get('/orders')).rejects.toBeTruthy();
+    expect(handler).not.toHaveBeenCalled();
+
+    unsubscribe();
+  });
+
+  it('stops notifying after unsubscribe', async () => {
+    const handler = vi.fn();
+    onUnauthorized(handler)();
+
+    stubAdapter((config) => {
+      throw httpError(401, config);
+    });
+
+    await expect(api.get('/auth/me')).rejects.toBeTruthy();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('keeps notifying the others when one handler throws', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const bad = vi.fn(() => {
+      throw new Error('subscriber blew up');
+    });
+    const good = vi.fn();
+    const unsubBad = onUnauthorized(bad);
+    const unsubGood = onUnauthorized(good);
+
+    stubAdapter((config) => {
+      throw httpError(401, config);
+    });
+
+    await expect(api.get('/auth/me')).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect(good).toHaveBeenCalledTimes(1);
+
+    unsubBad();
+    unsubGood();
+  });
+});

--- a/bookshelf-frontend/vite.config.js
+++ b/bookshelf-frontend/vite.config.js
@@ -3,4 +3,14 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+
+  // The repo already had vitest, @testing-library and src/setupTests.js, but
+  // no config to tie them together — so tests ran in the node environment
+  // with no DOM and the jest-dom matchers were never registered.
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/setupTests.js',
+    css: false,
+  },
 });


### PR DESCRIPTION
Closes #277

## The problem

`src/utils/api.js` hardcoded the backend host:

```js
const api = axios.create({
  baseURL: 'http://localhost:5000/api', // Example base URL
```

`vite build` inlines that string into the bundle, so a deployed frontend asks the **visitor's own machine** for the API. Every request fails, and over HTTPS the browser blocks the plain-HTTP call as mixed content on top of that.

## Fixing `api.js` alone was not enough

The four service modules did not go through it. All four read `VITE_API_URL`, with three incompatible meanings:

```js
authService     VITE_API_URL || 'http://localhost:5000/api/auth'       // base + /api/auth
paymentService  VITE_API_URL || 'http://localhost:5000/api/payments'   // base + /api/payments
wishlistService VITE_API_URL || 'http://localhost:5000'                // origin only
orderService    VITE_API_URL.replace(/\/api\/payments$/, '') + '/api/orders'
```

**No single value of `VITE_API_URL` satisfies all four.** `orderService` literally strips a `/api/payments` suffix off the variable to recover the origin, which only works if you happened to set it for `paymentService`.

All four now use the shared client with paths relative to one base URL, so the host is written in exactly one place.

## What changed

Config reading moves to `src/config/env.js`:

- reads `VITE_API_BASE_URL`, defaulting to the old localhost value so `npm run dev` still needs zero setup
- strips trailing slashes, so `${base}/books` cannot produce `//books` — Express treats `/api//books` as a different path and 404s it
- logs a clear error for a value with no scheme, instead of letting it fail later as a confusing CORS error
- logs a clear error if a **production** build points at localhost, which is the exact failure this module exists to prevent

`Home.jsx` had its own hardcoded `fetch('http://localhost:5000/api/books...')`; it uses `API_BASE_URL` now too. After this PR the only `localhost` left in `src/` is the documented default.

## Three other things in the client

**`withCredentials` was not set.** The API authenticates with an httpOnly cookie, so every authenticated request from a deployed frontend would have arrived anonymous even once the URL was correct.

**The 401 handler was a comment:**

```js
case 401:
  normalizedError.code = 'UNAUTHORIZED';
  // e.g., redirect to login or trigger logout logic
```

A user with an expired cookie got a generic error toast on every action and no prompt to log in again. `api.js` now exposes `onUnauthorized(handler)` and `AuthContext` subscribes to it. A subscription rather than a direct import, so the transport layer does not have to reach into React context or hard-code `window.location` — either would create a cycle and make the module untestable.

**Retry with exponential backoff**, for `GET` and `HEAD` only, on network failures and 5xx/429. `POST` is never retried: a dropped response is indistinguishable from a dropped request, so retrying `create-intent` would create a second payment intent. There is a test asserting exactly that.

Added a `429` case too, since the auth routes can return one once #275 lands.

## Docs

Added `bookshelf-frontend/.env.example` and a variables table in `CONTRIBUTING.md`. Neither existed, and `CONTRIBUTING.md` did not mention environment variables at all. The table notes that Vite inlines these at **build** time, which is the part people get wrong when deploying.

## Tests

21 tests: URL normalisation (trailing slashes, whitespace, non-strings), error normalisation and status→code mapping, retry succeeding on the third attempt, giving up after the limit, never retrying POST, not retrying a 404, and the 401 callback firing exactly once, not firing for a 403, stopping after unsubscribe, and surviving a subscriber that throws.

```
$ npm test
Test Files  2 passed (2)
     Tests  21 passed (21)
```

## Notes for review

- This PR adds the `test` block to `vite.config.js` and corrects the `bookshelf-theme` → `theme` localStorage key in the existing `ThemeToggle.test.jsx`. Without the config, vitest runs in the node environment with no DOM and no test can execute. The same two changes appear in #278; they are byte-identical, so the branches merge cleanly.
- `npm run build` does not pass on `main` — `BookCard.jsx` has duplicate imports from a bad merge that esbuild rejects, which is why every deploy preview has been red. The minimal repair is included here as a separate commit so this PR builds; it is byte-identical to the fix in #278, so the two merge cleanly either way.