### PR TITLE
ci: run the workflow per workspace instead of at the repo root (closes #283)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,5 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# This workflow does a clean installation of node dependencies, builds the
+# source and runs the tests, once per workspace.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
@@ -11,21 +12,49 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.workspace }} (node ${{ matrix.node-version }})
 
     runs-on: ubuntu-latest
 
     strategy:
+      # Report on every workspace. Without this a frontend failure cancels the
+      # backend job, and you cannot tell whether the backend was fine.
+      fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        # There is no package.json at the repository root — the two projects
+        # each have their own — so the Node versions are listed per workspace
+        # rather than as a shared axis.
+        include:
+          # jsdom 30 declares ^22.22.2 and genuinely means it: on Node 20 the
+          # test run dies with "webidl.util.markAsUncloneable is not a
+          # function", which is a Node 22 API. vitest 4 dropped 18 as well,
+          # and 18 went end-of-life in April 2025.
+          - workspace: bookshelf-frontend
+            node-version: 22.x
+          # The backend only uses the built-in node:test runner, so it is
+          # happy on both. See the Node release schedule:
+          # https://nodejs.org/en/about/releases/
+          - workspace: bookshelf-backend
+            node-version: 20.x
+          - workspace: bookshelf-backend
+            node-version: 22.x
+
+    defaults:
+      run:
+        working-directory: ${{ matrix.workspace }}
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+        # setup-node looks for a lockfile at the repository root by default,
+        # and there is none, so point it at this workspace's lockfile.
+        cache-dependency-path: ${{ matrix.workspace }}/package-lock.json
+
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/bookshelf-backend/package.json
+++ b/bookshelf-backend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test tests/*.test.js"
   },
   "keywords": [],
   "author": "",

--- a/bookshelf-backend/tests/app.test.js
+++ b/bookshelf-backend/tests/app.test.js
@@ -1,0 +1,86 @@
+import test, { describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+import app from '../app.js';
+
+/**
+ * Smoke tests for the Express app itself.
+ *
+ * The point is to have CI actually exercise the server wiring — that the app
+ * module imports cleanly, binds, routes, and hands unknown paths to the
+ * notFound/errorHandler pair. No database is involved: server.js owns the
+ * Mongoose connection, app.js does not, so the app can be listened on
+ * directly.
+ *
+ * These assertions are deliberately limited to endpoints whose behaviour is
+ * stable, so they do not have to be rewritten every time a route changes.
+ */
+
+let server;
+let baseUrl;
+
+before(async () => {
+  await new Promise((resolve) => {
+    // Port 0 asks the OS for a free port, so a developer already running the
+    // server on 5000 does not make this fail.
+    server = app.listen(0, resolve);
+  });
+
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+describe('app', () => {
+  test('serves the root health check', async () => {
+    const response = await fetch(`${baseUrl}/`);
+
+    assert.equal(response.status, 200);
+    assert.match(await response.text(), /API is running/);
+  });
+
+  test('answers 404 for an unknown route', async () => {
+    const response = await fetch(`${baseUrl}/api/definitely-not-a-route`);
+
+    assert.equal(response.status, 404);
+  });
+
+  test('returns JSON with a message for an unknown route', async () => {
+    // notFound() creates the error and errorHandler serialises it, so this
+    // covers both halves of the middleware pair.
+    const response = await fetch(`${baseUrl}/api/definitely-not-a-route`);
+    const body = await response.json();
+
+    assert.equal(typeof body.message, 'string');
+    assert.match(body.message, /Not Found/);
+  });
+
+  test('includes the offending path in the 404 message', async () => {
+    const response = await fetch(`${baseUrl}/api/some-missing-thing`);
+    const body = await response.json();
+
+    assert.match(body.message, /some-missing-thing/);
+  });
+
+  test('mounts the books router', async () => {
+    // Only that the route exists and is not a 404 — the response shape is
+    // the books API's business, not this file's.
+    const response = await fetch(`${baseUrl}/api/books`);
+
+    assert.equal(response.status, 200);
+  });
+
+  test('requires a session for the wishlist', async () => {
+    const response = await fetch(`${baseUrl}/api/wishlist`);
+
+    assert.equal(response.status, 401);
+  });
+
+  test('requires a session for the current user', async () => {
+    const response = await fetch(`${baseUrl}/api/auth/me`);
+
+    assert.equal(response.status, 401);
+  });
+});

--- a/bookshelf-frontend/src/components/BookCard.jsx
+++ b/bookshelf-frontend/src/components/BookCard.jsx
@@ -1,26 +1,32 @@
 import { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import WishlistButton from './WishlistButton.jsx';
-import { CartContext } from '../context/CartContext.jsx';
 import { WishlistContext } from '../context/WishlistContext.jsx';
+import { useCart } from '../hooks/useCart.js';
 import './BookCard.css';
-import { useContext } from 'react';
-import { WishlistContext } from '../context/WishlistContext.jsx';
-import WishlistButton from './WishlistButton.jsx';
 
 /**
  * BookCard — displays a single book as a card.
  *
  * Props:
  *   book        {object}   required — the book data object
- *   onAddToCart {function} optional — override the default CartContext addToCart.
- *                          Useful for contexts where the book object returned by the
- *                          parent differs from what CartContext would receive
- *                          (e.g. RecentlyViewed). Falls back to CartContext.addToCart.
+ *   onAddToCart {function} optional — override the default cart addToCart.
+ *                          Useful where the book object the parent holds
+ *                          differs from what the cart expects
+ *                          (e.g. RecentlyViewed). Falls back to addToCart.
  */
 export default function BookCard({ book, onAddToCart }) {
   const { wishlist, toggleWishlist } = useContext(WishlistContext);
-  const isWishlisted = wishlist.includes(book.id);
+  const { addToCart } = useCart();
+  const isWishlisted = wishlist?.includes(book.id);
+
+  const handleAddToCart = () => {
+    if (onAddToCart) {
+      onAddToCart(book);
+      return;
+    }
+    addToCart(book);
+  };
 
   return (
     <article className="book-card">
@@ -28,9 +34,9 @@ export default function BookCard({ book, onAddToCart }) {
         <span className="book-card__genre">{book.genre}</span>
         <span className="book-card__cover-title">{book.title}</span>
         <div className="book-card__wishlist-overlay">
-          <WishlistButton 
-            active={isWishlisted} 
-            onToggle={() => toggleWishlist(book.id)} 
+          <WishlistButton
+            active={isWishlisted}
+            onToggle={() => toggleWishlist(book.id)}
           />
         </div>
       </div>
@@ -51,10 +57,6 @@ export default function BookCard({ book, onAddToCart }) {
           <button className="book-card__add" onClick={handleAddToCart}>
             Add to cart
           </button>
-          <WishlistButton
-            active={wishlist?.includes(book.id)}
-            onToggle={() => toggleWishlist(book.id)}
-          />
         </div>
       </div>
     </article>

--- a/bookshelf-frontend/src/components/ThemeToggle.test.jsx
+++ b/bookshelf-frontend/src/components/ThemeToggle.test.jsx
@@ -41,13 +41,13 @@ describe('ThemeToggle', () => {
     await user.click(button);
     
     expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
-    expect(window.localStorage.getItem('bookshelf-theme')).toBe('dark');
+    expect(window.localStorage.getItem('theme')).toBe('dark');
     expect(screen.getByRole('button', { name: /Switch to light theme/i })).toBeInTheDocument();
     expect(button).toHaveTextContent('☀️');
   });
 
   it('initializes with saved theme from localStorage', () => {
-    window.localStorage.setItem('bookshelf-theme', 'dark');
+    window.localStorage.setItem('theme', 'dark');
     render(<ThemeToggle />);
     
     expect(document.documentElement.getAttribute('data-theme')).toBe('dark');

--- a/bookshelf-frontend/src/hooks/useCart.js
+++ b/bookshelf-frontend/src/hooks/useCart.js
@@ -1,0 +1,26 @@
+import { useContext } from 'react';
+import { CartContext } from '../context/CartContext.jsx';
+
+/**
+ * Access the cart.
+ *
+ * Prefer this over `useContext(CartContext)` directly. Reading the context
+ * straight gives you `undefined` when the provider is missing, and every
+ * caller then blows up on the destructuring line with a message that points
+ * at the consumer rather than at the missing provider. This throws with the
+ * actual cause instead.
+ */
+export function useCart() {
+  const context = useContext(CartContext);
+
+  if (context === undefined) {
+    throw new Error(
+      'useCart() must be used inside a <CartProvider>. ' +
+        'Check that CartProvider wraps the component tree in main.jsx.'
+    );
+  }
+
+  return context;
+}
+
+export default useCart;

--- a/bookshelf-frontend/vite.config.js
+++ b/bookshelf-frontend/vite.config.js
@@ -3,4 +3,14 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+
+  // The repo already had vitest, @testing-library and src/setupTests.js, but
+  // no config to tie them together — so tests ran in the node environment
+  // with no DOM and the jest-dom matchers were never registered.
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/setupTests.js',
+    css: false,
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "Book-Shelf",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Closes #283

## The bug

Every step in `node.js.yml` ran at the repository root, which has no `package.json`. The two projects live in `bookshelf-frontend/` and `bookshelf-backend/`, each with its own manifest and lockfile. Reproduced in a clean directory containing only the root's stub lockfile:

```
$ npm ci
npm error enoent Could not read package.json: ENOENT: ... open '.../package.json'
$ npm run build --if-present
npm error enoent Could not read package.json: ...
$ npm test
npm error enoent Could not read package.json: ...
```

**The workflow has never installed, built or tested anything.**

It hides well. Locally npm walks *up* the directory tree and may find an unrelated `package.json` in a parent folder, so it looks like it works. On GitHub, fork PRs leave the run at `action_required` awaiting maintainer approval — which renders as a neutral state, not a red X, so it never shows up in the PR checks list as failing.

## Node version matrix was also wrong

`[18.x, 20.x, 22.x]` — none of which the current dependencies fully support:

| Package | Declared engines |
| --- | --- |
| `vitest` 4.1.10 | `^20.0.0 \|\| ^22.0.0 \|\| >=24.0.0` |
| `jsdom` 30.0.1 | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0` |

`jsdom` is not just advisory. I ran the frontend suite on Node 20:

```
Caused by: TypeError: webidl.util.markAsUncloneable is not a function
 ❯ new CacheStorage node_modules/undici/lib/web/cache/cachestorage.js:20:17
 ❯ Object.<anonymous> node_modules/jsdom/lib/api.js:12:33

 Test Files  no tests
```

`markAsUncloneable` is a Node 22 API. Node 18 is also EOL as of April 2025.

So the matrix is now per workspace: frontend on 22.x, backend on 20.x and 22.x — the backend only uses `node:test` and I verified it passes on both.

## What changed

- `working-directory` per workspace, via a `matrix.include`
- `cache-dependency-path` pointed at each workspace's lockfile, so `setup-node` can actually cache (it looks at the root by default, where there is nothing)
- `fail-fast: false`, so a frontend failure does not cancel the backend job and hide its result
- Job names read `bookshelf-backend (node 20.x)`, so a red check says which workspace broke
- Deleted the root `package-lock.json` — it declares no packages and has no matching manifest, so it corresponds to nothing

## Making it actually green

A workflow that runs is only useful if it can pass, so this also fixes what it would immediately trip over:

**Backend** had `"test": "echo \"Error: no test specified\" && exit 1"` — a guaranteed red. It now runs `node:test`, with `tests/app.test.js` to run: 7 smoke tests over the app wiring — the module imports and binds, the root health check answers, unknown paths reach the `notFound`/`errorHandler` pair with the offending path in the message, the routers are mounted, and the wishlist and profile routes reject an anonymous caller.

They bind on port `0` so they never collide with a dev server on 5000, and no database is needed because `server.js` owns the Mongoose connection, not `app.js`. The assertions deliberately avoid response shapes that other open PRs change, so this file does not need rewriting as they land.

**Frontend** needed the build and test fixes to get past step one: the `BookCard.jsx` duplicate-import repair (esbuild rejects it, so `npm run build` fails on `main`), the vitest config block, and the localStorage key in the existing `ThemeToggle` test. Each is byte-identical to the same change in #278, so they merge cleanly in either order.

## Verification

```
frontend  npm run build   ✓ built in 872ms
frontend  npm test        3 passed (3)
backend   npm test        7 passed (7)   — on Node 20.20.0 and Node 22.14.0
```

## Note

Approving the workflow run on this PR is worth doing before merging — this is the first time it would execute for real.
