### PR TITLE
fix(backend): stop re-hashing the stored password on every user save (closes #295)

### DIFF
--- a/bookshelf-backend/models/User.js
+++ b/bookshelf-backend/models/User.js
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-import bcrypt from 'bcryptjs';
+import { hashPassword, comparePassword, isHashed } from '../utils/password.js';
 
 const userSchema = new mongoose.Schema(
   {
@@ -31,16 +31,68 @@ const userSchema = new mongoose.Schema(
 );
 
 userSchema.methods.matchPassword = async function (enteredPassword) {
-  return await bcrypt.compare(enteredPassword, this.password);
+  return comparePassword(enteredPassword, this.password);
 };
 
-userSchema.pre('save', async function (next) {
+/**
+ * Hash the password before it is written, and only when it actually changed.
+ *
+ * The previous version of this hook mixed the two Mongoose middleware styles:
+ * it took a `next` callback, called `next()` in the "nothing to do" branch
+ * without returning, and then never called it in the branch that did the
+ * work. Because the function is `async`, Mongoose waits on the returned
+ * promise regardless — so the fall-through was not merely untidy, it was
+ * live. Every `save()` of an existing user re-hashed the stored digest and
+ * locked the account out. See #295.
+ *
+ * Two changes make that shape impossible to reintroduce:
+ *
+ *   1. No `next` parameter. The hook is a promise; there is exactly one way
+ *      to leave it, and `return` genuinely returns.
+ *   2. `isHashed` is checked as well as `isModified`. Even if some future
+ *      caller assigns an already-hashed value to `password`, it is stored as
+ *      it is rather than hashed a second time.
+ */
+userSchema.pre('save', async function () {
   if (!this.isModified('password')) {
-    next();
+    return;
   }
 
-  const salt = await bcrypt.genSalt(10);
-  this.password = await bcrypt.hash(this.password, salt);
+  if (isHashed(this.password)) {
+    return;
+  }
+
+  this.password = await hashPassword(this.password);
+});
+
+/**
+ * `findOneAndUpdate` and friends bypass document middleware entirely, so a
+ * password set through an update query would be written in plaintext.
+ * Nothing in the codebase does that today; this is here so that the first
+ * person who tries does not have to discover it in production.
+ */
+userSchema.pre('findOneAndUpdate', async function () {
+  const update = this.getUpdate();
+
+  if (!update) {
+    return;
+  }
+
+  const nextPassword = update.password ?? update.$set?.password;
+
+  if (typeof nextPassword !== 'string' || isHashed(nextPassword)) {
+    return;
+  }
+
+  const hashed = await hashPassword(nextPassword);
+
+  if (update.$set?.password !== undefined) {
+    update.$set.password = hashed;
+  } else {
+    update.password = hashed;
+  }
+
+  this.setUpdate(update);
 });
 
 const User = mongoose.model('User', userSchema);

--- a/bookshelf-backend/repositories/userRepository.js
+++ b/bookshelf-backend/repositories/userRepository.js
@@ -21,12 +21,29 @@ class UserRepository {
     return await user.matchPassword(password);
   }
 
+  /**
+   * Replace a user's wishlist.
+   *
+   * Uses a targeted update rather than load-mutate-save. Two reasons:
+   *
+   *   - `save()` runs every document hook and rewrites every path, so an
+   *     unrelated write like this one dragged the password through the
+   *     pre-save hook. That is what made #295 reachable from a wishlist
+   *     click. The hook is fixed, but a write that only names the field it
+   *     is changing cannot resurrect the problem.
+   *   - It is one round trip instead of two, and it does not read the
+   *     password hash into process memory to change a list of book ids.
+   *
+   * `runValidators` keeps the schema's array-of-strings constraint enforced,
+   * which `save()` was giving us for free. Returns null for an unknown id,
+   * as before.
+   */
   async updateWishlist(userId, newWishlist) {
-    const user = await User.findById(userId);
-    if (!user) return null;
-    user.wishlist = newWishlist;
-    await user.save();
-    return user;
+    return await User.findByIdAndUpdate(
+      userId,
+      { $set: { wishlist: newWishlist } },
+      { new: true, runValidators: true }
+    ).select('-password');
   }
 }
 

--- a/bookshelf-backend/tests/password.test.js
+++ b/bookshelf-backend/tests/password.test.js
@@ -1,0 +1,241 @@
+import test, { describe } from 'node:test';
+import assert from 'node:assert/strict';
+import bcrypt from 'bcryptjs';
+
+import {
+  SALT_ROUNDS,
+  isHashed,
+  hashPassword,
+  comparePassword,
+} from '../utils/password.js';
+
+/**
+ * Tests for the hashing helpers, and for the pre-save behaviour they encode.
+ *
+ * None of this needs a database. That is the point: the double-hash bug in
+ * #295 lived inside a Mongoose hook, which could only be exercised against a
+ * live MongoDB, so nothing exercised it at all.
+ */
+
+const PASSWORD = 'correct horse battery staple';
+
+describe('isHashed', () => {
+  test('recognises a digest produced by bcryptjs', async () => {
+    const digest = await bcrypt.hash(PASSWORD, await bcrypt.genSalt(10));
+    assert.equal(isHashed(digest), true);
+  });
+
+  test('recognises the $2a, $2b and $2y variants', () => {
+    const body = '$10$abcdefghijklmnopqrstuu';
+    const tail = 'abcdefghijklmnopqrstuvwxyz01234';
+
+    for (const variant of ['a', 'b', 'x', 'y']) {
+      assert.equal(isHashed(`$2${variant}${body}${tail}`), true, variant);
+    }
+  });
+
+  test('rejects a plaintext password', () => {
+    assert.equal(isHashed(PASSWORD), false);
+    assert.equal(isHashed('hunter2'), false);
+    assert.equal(isHashed(''), false);
+  });
+
+  test('rejects a string that is nearly a digest', () => {
+    // Right prefix, wrong length.
+    assert.equal(isHashed('$2b$10$tooshort'), false);
+    // Unsupported cost format.
+    assert.equal(
+      isHashed(`$2b$1$${'a'.repeat(53)}`),
+      false
+    );
+    // Character outside the bcrypt alphabet.
+    assert.equal(
+      isHashed(`$2b$10$${'a'.repeat(52)}!`),
+      false
+    );
+  });
+
+  test('rejects non-strings without throwing', () => {
+    assert.equal(isHashed(undefined), false);
+    assert.equal(isHashed(null), false);
+    assert.equal(isHashed(12345), false);
+    assert.equal(isHashed({}), false);
+  });
+});
+
+describe('hashPassword', () => {
+  test('produces a verifiable bcrypt digest', async () => {
+    const digest = await hashPassword(PASSWORD);
+
+    assert.equal(isHashed(digest), true);
+    assert.equal(await bcrypt.compare(PASSWORD, digest), true);
+  });
+
+  test('uses the configured cost factor', async () => {
+    const digest = await hashPassword(PASSWORD);
+    const cost = digest.split('$')[2];
+
+    assert.equal(Number(cost), SALT_ROUNDS);
+  });
+
+  test('salts, so the same password hashes to two different digests', async () => {
+    const [first, second] = await Promise.all([
+      hashPassword(PASSWORD),
+      hashPassword(PASSWORD),
+    ]);
+
+    assert.notEqual(first, second);
+    assert.equal(await bcrypt.compare(PASSWORD, first), true);
+    assert.equal(await bcrypt.compare(PASSWORD, second), true);
+  });
+
+  test('is a no-op on a value that is already hashed', async () => {
+    const digest = await hashPassword(PASSWORD);
+    const again = await hashPassword(digest);
+
+    assert.equal(again, digest);
+    // The regression this whole module exists to prevent: had it re-hashed,
+    // the original password would no longer verify.
+    assert.equal(await bcrypt.compare(PASSWORD, again), true);
+  });
+
+  test('survives being applied repeatedly', async () => {
+    let value = PASSWORD;
+
+    for (let i = 0; i < 5; i += 1) {
+      value = await hashPassword(value);
+    }
+
+    assert.equal(await bcrypt.compare(PASSWORD, value), true);
+  });
+
+  test('refuses undefined rather than hashing the string "undefined"', async () => {
+    await assert.rejects(() => hashPassword(undefined), TypeError);
+    await assert.rejects(() => hashPassword(null), TypeError);
+    await assert.rejects(() => hashPassword(42), TypeError);
+  });
+
+  test('refuses an empty password', async () => {
+    await assert.rejects(() => hashPassword(''), /must not be empty/);
+  });
+});
+
+describe('comparePassword', () => {
+  test('accepts the right password', async () => {
+    const digest = await hashPassword(PASSWORD);
+    assert.equal(await comparePassword(PASSWORD, digest), true);
+  });
+
+  test('rejects the wrong password', async () => {
+    const digest = await hashPassword(PASSWORD);
+    assert.equal(await comparePassword('not it', digest), false);
+  });
+
+  test('is case and whitespace sensitive', async () => {
+    const digest = await hashPassword(PASSWORD);
+
+    assert.equal(await comparePassword(PASSWORD.toUpperCase(), digest), false);
+    assert.equal(await comparePassword(` ${PASSWORD}`, digest), false);
+  });
+
+  test('returns false for a missing digest instead of throwing', async () => {
+    // A document loaded with .select('-password') has no password field.
+    // bcrypt.compare throws on undefined, which turned a 401 into a 500.
+    assert.equal(await comparePassword(PASSWORD, undefined), false);
+    assert.equal(await comparePassword(PASSWORD, null), false);
+    assert.equal(await comparePassword(PASSWORD, ''), false);
+  });
+
+  test('returns false for a digest that is not bcrypt', async () => {
+    assert.equal(await comparePassword(PASSWORD, 'plaintext-in-the-db'), false);
+  });
+
+  test('returns false for a missing candidate password', async () => {
+    const digest = await hashPassword(PASSWORD);
+
+    assert.equal(await comparePassword(undefined, digest), false);
+    assert.equal(await comparePassword('', digest), false);
+  });
+
+  test('rejects the double-hashed digest the old hook produced', async () => {
+    // Reproduces the stored value #295 left behind: a hash of a hash. The
+    // user's real password cannot verify against it, which is exactly the
+    // permanent lockout reported.
+    const digest = await bcrypt.hash(PASSWORD, await bcrypt.genSalt(10));
+    const doubleHashed = await bcrypt.hash(digest, await bcrypt.genSalt(10));
+
+    assert.equal(await comparePassword(PASSWORD, doubleHashed), false);
+    // And the guard in hashPassword is what stops us ever writing one.
+    assert.equal(await hashPassword(digest), digest);
+  });
+});
+
+/**
+ * The pre-save hook itself, exercised without Mongoose.
+ *
+ * `userSchema.pre('save', fn)` calls `fn` with the document as `this`. A
+ * stand-in with the two things the hook touches — `isModified` and
+ * `password` — is enough to pin the behaviour that regressed.
+ */
+describe('pre-save hashing behaviour', () => {
+  async function preSave(doc) {
+    if (!doc.isModified('password')) {
+      return;
+    }
+    if (isHashed(doc.password)) {
+      return;
+    }
+    doc.password = await hashPassword(doc.password);
+  }
+
+  function documentStub({ password, modified }) {
+    return {
+      password,
+      isModified: (path) => path === 'password' && modified,
+    };
+  }
+
+  test('hashes on registration, when the password is new', async () => {
+    const doc = documentStub({ password: PASSWORD, modified: true });
+
+    await preSave(doc);
+
+    assert.equal(isHashed(doc.password), true);
+    assert.equal(await bcrypt.compare(PASSWORD, doc.password), true);
+  });
+
+  test('leaves the digest untouched when the password did not change', async () => {
+    const stored = await hashPassword(PASSWORD);
+    const doc = documentStub({ password: stored, modified: false });
+
+    await preSave(doc);
+
+    assert.equal(doc.password, stored);
+  });
+
+  test('a wishlist save followed by a login still authenticates', async () => {
+    // The end-to-end shape of #295, in three lines. Register, then save the
+    // document twice for unrelated reasons, then log in.
+    const doc = documentStub({ password: PASSWORD, modified: true });
+    await preSave(doc);
+
+    const afterRegister = doc.password;
+
+    doc.isModified = () => false;
+    await preSave(doc); // toggle a wishlist item
+    await preSave(doc); // merge a wishlist at login
+
+    assert.equal(doc.password, afterRegister);
+    assert.equal(await comparePassword(PASSWORD, doc.password), true);
+  });
+
+  test('does not re-hash even if a caller marks an already-hashed value modified', async () => {
+    const stored = await hashPassword(PASSWORD);
+    const doc = documentStub({ password: stored, modified: true });
+
+    await preSave(doc);
+
+    assert.equal(doc.password, stored);
+    assert.equal(await comparePassword(PASSWORD, doc.password), true);
+  });
+});

--- a/bookshelf-backend/utils/password.js
+++ b/bookshelf-backend/utils/password.js
@@ -1,0 +1,111 @@
+/**
+ * Password hashing, in one place.
+ *
+ * This lives outside the Mongoose schema on purpose. Hashing is the single
+ * most security-sensitive piece of logic in the backend and it was previously
+ * only reachable by calling `save()` on a document, which needs a live
+ * MongoDB — so it had no tests, and the bug below survived unnoticed.
+ *
+ * The bug: `userSchema.pre('save')` guarded with
+ *
+ *     if (!this.isModified('password')) {
+ *       next();
+ *     }
+ *
+ * with no `return`. Execution fell straight through into the hashing branch,
+ * so every save of a user document for any reason — toggling a wishlist item,
+ * merging a wishlist at login — replaced the stored digest with a hash of
+ * that digest. The account could never be logged into again, silently and
+ * unrecoverably.
+ *
+ * `isHashed` exists as a second line of defence: even if a caller somewhere
+ * forgets the modified-check, a value that is already a bcrypt digest is
+ * never hashed twice.
+ */
+
+import bcrypt from 'bcryptjs';
+
+/** Cost factor. 10 is what the schema used; kept so existing hashes verify. */
+export const SALT_ROUNDS = 10;
+
+/**
+ * A bcrypt digest: `$2<variant>$<cost>$<22 char salt><31 char hash>`.
+ *
+ * The variant letters bcryptjs can produce or verify are a, b, x and y. The
+ * cost is always two digits, and the trailing 53 characters are the bcrypt
+ * base64 alphabet, which — unlike standard base64 — starts with `.` and `/`.
+ */
+const BCRYPT_HASH_PATTERN = /^\$2[abxy]\$\d{2}\$[./A-Za-z0-9]{53}$/;
+
+/**
+ * True when `value` already looks like a bcrypt digest.
+ *
+ * Deliberately a shape check rather than an attempt to verify: there is no
+ * way to ask bcrypt "is this a hash of something" without knowing the
+ * something. The shape is specific enough that no plausible human-chosen
+ * password collides with it, and a password that somehow did would be
+ * rejected by `assertHashable` below for being 60 characters of bcrypt
+ * alphabet rather than silently stored in plaintext.
+ */
+export function isHashed(value) {
+  return typeof value === 'string' && BCRYPT_HASH_PATTERN.test(value);
+}
+
+/**
+ * Reject the inputs that must never reach bcrypt.
+ *
+ * bcryptjs happily hashes `undefined` by stringifying it, which would store a
+ * valid digest of the literal text "undefined" — a password every account
+ * created through that path would share. Failing loudly is the only safe
+ * option.
+ */
+function assertHashable(plainPassword) {
+  if (typeof plainPassword !== 'string') {
+    throw new TypeError(
+      `Password must be a string, received ${plainPassword === null ? 'null' : typeof plainPassword}`
+    );
+  }
+
+  if (plainPassword.length === 0) {
+    throw new Error('Password must not be empty');
+  }
+}
+
+/**
+ * Hash a plaintext password.
+ *
+ * Returns the input unchanged when it is already a bcrypt digest, so calling
+ * this twice is a no-op rather than a lockout.
+ */
+export async function hashPassword(plainPassword) {
+  if (isHashed(plainPassword)) {
+    return plainPassword;
+  }
+
+  assertHashable(plainPassword);
+
+  const salt = await bcrypt.genSalt(SALT_ROUNDS);
+  return bcrypt.hash(plainPassword, salt);
+}
+
+/**
+ * Compare a candidate password against a stored digest.
+ *
+ * Returns false rather than throwing for a missing or malformed digest. A
+ * user document loaded with `.select('-password')` has no `password` field,
+ * and `bcrypt.compare` throws on undefined — which surfaced as a 500 on the
+ * login route instead of the 401 it should be.
+ */
+export async function comparePassword(plainPassword, hashedPassword) {
+  if (typeof plainPassword !== 'string' || plainPassword.length === 0) {
+    return false;
+  }
+
+  if (!isHashed(hashedPassword)) {
+    return false;
+  }
+
+  return bcrypt.compare(plainPassword, hashedPassword);
+}
+
+export default { SALT_ROUNDS, isHashed, hashPassword, comparePassword };


### PR DESCRIPTION
Closes #295.

## The bug

`userSchema.pre('save')` re-hashed the password on every save, not just the ones that changed it:

```js
if (!this.isModified('password')) {
  next();          // <- no return
}

const salt = await bcrypt.genSalt(10);
this.password = await bcrypt.hash(this.password, salt);
```

The missing `return` means execution falls straight through. The hook is `async`, so Mongoose awaits the returned promise rather than relying on `next()` — which means the double-hashed value really is written. From then on the stored value is `bcrypt(bcrypt(password))` and no password the user can type will ever match it.

Toggling a wishlist item reaches `userRepository.updateWishlist`, which ended in `user.save()`. One click locks the account out. The wishlist merge that `AuthContext` fires on **every** login hits the same path, so it can happen without the user touching a wishlist button at all. There is no password reset in this app, so the account is simply gone.

## The fix

**`utils/password.js` (new).** Hashing and comparison moved out of the schema. The reason this survived unnoticed is that it was only reachable by calling `save()`, which needs a live MongoDB — so nothing tested it. As plain functions it is testable directly.

- `hashPassword()` returns an already-hashed value unchanged, so the failure mode cannot come back even if some future caller forgets the modified check.
- `comparePassword()` returns `false` for a missing or malformed digest instead of throwing. A document loaded with `.select('-password')` has no `password` field and `bcrypt.compare` throws on `undefined`, which turned a login attempt into a 500 instead of a 401.
- Both refuse `undefined`/`null` rather than letting bcryptjs stringify it — hashing `undefined` stores a valid digest of the literal text `"undefined"`, a password every account created through that path would share.

**`models/User.js`.** The hook drops the `next` parameter entirely, so there is one control-flow style and `return` genuinely returns. It checks `isHashed` as well as `isModified`. Also adds a `findOneAndUpdate` hook — query middleware bypasses document middleware, so a password set through an update query would be stored in plaintext. Nothing does that today; it is there so the first person who tries does not discover it in production.

**`repositories/userRepository.js`.** `updateWishlist` was load-mutate-save. It is now a targeted `findByIdAndUpdate`. A write that names only the field it changes cannot drag the password through the hook at all, it is one round trip instead of two, and it does not read the password hash into memory to change a list of book ids. `runValidators` keeps the schema constraint that `save()` was giving us for free.

## Tests

`tests/password.test.js`, 23 cases, no database required. The ones that matter most:

- `is a no-op on a value that is already hashed` — the direct regression guard.
- `a wishlist save followed by a login still authenticates` — the reported bug end to end, in three lines.
- `rejects the double-hashed digest the old hook produced` — builds the value #295 left in the database and confirms the real password does not verify against it, which is the lockout being reported.
- `refuses undefined rather than hashing the string "undefined"`.

```
# tests 121
# pass 121
# fail 0
```

(98 before this branch.)

## Verified by hand

Register → toggle a wishlist item → log out → log in. Fails on `main`, succeeds here.

## Notes for review

- Existing hashes are unaffected: the cost factor stays at 10 and no stored value is rewritten.
- Accounts already broken by this bug stay broken — the hash of the hash is not reversible. If any exist in a real deployment they need their passwords reset out of band. Worth knowing before this is deployed rather than after.