### PR TITLE
fix(frontend): give the theme a single owner instead of five copies (closes #296)

### DIFF
--- a/bookshelf-frontend/src/App.jsx
+++ b/bookshelf-frontend/src/App.jsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 
-import ThemeToggle from './components/ThemeToggle.jsx';
 import ScrollToTop from './components/ScrollToTop.jsx';
 
 import CustomCursor from './components/CustomCursor.jsx';
@@ -29,7 +28,11 @@ export default function App() {
 
   return (
     <div className="app">
-      <ThemeToggle />
+      {/*
+        The theme toggle used to be rendered here *as well as* in the navbar,
+        as two separate components each holding their own copy of the theme.
+        It now lives only in the navbar, reading the shared ThemeContext.
+      */}
       <ScrollToTop />
       <CustomCursor />
 

--- a/bookshelf-frontend/src/components/Navbar.jsx
+++ b/bookshelf-frontend/src/components/Navbar.jsx
@@ -1,14 +1,13 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useTheme } from '../hooks/useTheme';
 import { useCart } from '../hooks/useCart.js';
 import { useTranslation } from 'react-i18next';
+import ThemeToggle from './ThemeToggle.jsx';
 import './Navbar.css';
 
 export default function Navbar({ searchQuery, setSearchQuery }) {
   const { t } = useTranslation();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const { theme, toggleTheme } = useTheme();
   const { cart, setIsCartOpen } = useCart();
 
   return (
@@ -54,30 +53,12 @@ export default function Navbar({ searchQuery, setSearchQuery }) {
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
-            <button 
-              className="nav__theme-toggle" 
-              onClick={toggleTheme} 
-              aria-label="Toggle dark mode"
-              title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
-            >
-              {theme === 'dark' ? (
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="12" cy="12" r="5"/>
-                  <line x1="12" y1="1" x2="12" y2="3"/>
-                  <line x1="12" y1="21" x2="12" y2="23"/>
-                  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
-                  <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
-                  <line x1="1" y1="12" x2="3" y2="12"/>
-                  <line x1="21" y1="12" x2="23" y2="12"/>
-                  <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
-                  <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
-                </svg>
-              ) : (
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-                </svg>
-              )}
-            </button>
+            {/*
+              The navbar used to hand-roll its own toggle button on top of its
+              own copy of the theme state, which is what put two disagreeing
+              toggles on screen. It renders the shared component now.
+            */}
+            <ThemeToggle variant="inline" className="nav__theme-toggle" />
             <button className="nav__cart" onClick={() => setIsCartOpen(true)} aria-label="Open cart">
               {t('navbar.cart') || 'Cart'}
               <span className="nav__cart-count">{cart.length}</span>

--- a/bookshelf-frontend/src/components/ThemeToggle.css
+++ b/bookshelf-frontend/src/components/ThemeToggle.css
@@ -1,7 +1,10 @@
+/*
+ * Shared button shape. The positioning used to live here, which meant the
+ * component could only ever be a floating corner button — so Navbar hand-
+ * rolled a second one rather than reuse it. Layout now belongs to the
+ * variant modifiers below. See #296.
+ */
 .theme-toggle {
-  position: fixed;
-  left: 24px;
-  bottom: 24px;
   width: 44px;
   height: 44px;
   border-radius: 50%;
@@ -13,12 +16,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: var(--shadow-card);
   cursor: pointer;
   transition:
     background 0.2s ease,
     transform 0.2s ease;
-  z-index: 900;
 }
 
 .theme-toggle:hover,
@@ -27,12 +28,49 @@
   transform: scale(1.05);
 }
 
-@media (max-width: 640px) {
+/* Pinned to the corner of the viewport. */
+.theme-toggle--floating {
+  position: fixed;
+  left: 24px;
+  bottom: 24px;
+  box-shadow: var(--shadow-card);
+  z-index: 900;
+}
+
+/* Sits in a row of controls, e.g. the navbar actions. */
+.theme-toggle--inline {
+  position: static;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 auto;
+}
+
+/*
+ * The toggle is a control, not decoration — respect a reduced-motion
+ * preference rather than scaling it under the pointer.
+ */
+@media (prefers-reduced-motion: reduce) {
   .theme-toggle {
+    transition: none;
+  }
+
+  .theme-toggle:hover,
+  .theme-toggle:focus-visible {
+    transform: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .theme-toggle--floating {
     left: 16px;
     bottom: 16px;
     width: 40px;
     height: 40px;
     font-size: 16px;
+  }
+
+  .theme-toggle--inline {
+    width: 34px;
+    height: 34px;
   }
 }

--- a/bookshelf-frontend/src/components/ThemeToggle.jsx
+++ b/bookshelf-frontend/src/components/ThemeToggle.jsx
@@ -1,41 +1,84 @@
-import { useLayoutEffect, useState } from 'react';
+import { useTheme } from '../hooks/useTheme.js';
 import './ThemeToggle.css';
 
-const STORAGE_KEY = 'theme';
+/**
+ * The theme toggle. There is one of these in the app.
+ *
+ * It no longer holds any state — the theme lives in ThemeContext, so this
+ * component and every other consumer read the same value. Previously this
+ * component owned a private copy while Navbar rendered a second, unrelated
+ * button driven by a second, unrelated copy. See #296.
+ *
+ * `variant` picks the presentation only:
+ *   'inline'   sits in a row of controls, e.g. the navbar actions
+ *   'floating' pinned to the bottom-left corner of the viewport
+ */
 
-function getInitialTheme() {
-  const saved = window.localStorage.getItem(STORAGE_KEY);
-  if (saved === 'light' || saved === 'dark') return saved;
-
-  // No saved preference yet — fall back to the user's OS/browser setting.
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  return prefersDark ? 'dark' : 'light';
+function SunIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
 }
 
-export default function ThemeToggle() {
-  const [theme, setTheme] = useState(getInitialTheme);
+function MoonIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
 
-  useLayoutEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme);
-    window.localStorage.setItem(STORAGE_KEY, theme);
-  }, [theme]);
+export default function ThemeToggle({ variant = 'floating', className = '' }) {
+  const { isDark, toggleTheme } = useTheme();
 
-  function toggleTheme() {
-    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
-  }
+  const label = isDark ? 'Switch to light theme' : 'Switch to dark theme';
 
-  const isDark = theme === 'dark';
+  const classes = ['theme-toggle', `theme-toggle--${variant}`, className]
+    .filter(Boolean)
+    .join(' ');
 
   return (
     <button
       type="button"
-      className="theme-toggle"
+      className={classes}
       onClick={toggleTheme}
-      aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      aria-label={label}
       aria-pressed={isDark}
-      title={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      title={label}
     >
-      <span aria-hidden="true">{isDark ? '☀️' : '🌙'}</span>
+      {isDark ? <SunIcon /> : <MoonIcon />}
     </button>
   );
 }

--- a/bookshelf-frontend/src/components/ThemeToggle.test.jsx
+++ b/bookshelf-frontend/src/components/ThemeToggle.test.jsx
@@ -1,57 +1,176 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
 import ThemeToggle from './ThemeToggle.jsx';
+import { ThemeProvider } from '../context/ThemeContext.jsx';
+import { useTheme } from '../hooks/useTheme.js';
+
+/**
+ * Installs a controllable matchMedia. jsdom does not implement it, and the
+ * component's behaviour depends on what it reports.
+ */
+function mockMatchMedia(initialMatches = false) {
+  const listeners = new Set();
+
+  const mediaQueryList = {
+    matches: initialMatches,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: (_event, handler) => listeners.add(handler),
+    removeEventListener: (_event, handler) => listeners.delete(handler),
+    addListener: (handler) => listeners.add(handler),
+    removeListener: (handler) => listeners.delete(handler),
+    dispatchEvent: vi.fn(),
+  };
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockReturnValue(mediaQueryList),
+  });
+
+  return mediaQueryList;
+}
+
+function renderToggle(props) {
+  return render(
+    <ThemeProvider>
+      <ThemeToggle {...props} />
+    </ThemeProvider>
+  );
+}
 
 describe('ThemeToggle', () => {
   beforeEach(() => {
-    // Clear localStorage and reset data-theme before each test
     window.localStorage.clear();
     document.documentElement.removeAttribute('data-theme');
-    
-    // Mock window.matchMedia
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: vi.fn().mockImplementation(query => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-      })),
-    });
+    document.documentElement.style.colorScheme = '';
+    mockMatchMedia(false);
   });
 
-  it('renders correctly with default theme (light)', () => {
-    render(<ThemeToggle />);
-    const button = screen.getByRole('button', { name: /Switch to dark theme/i });
-    expect(button).toBeInTheDocument();
-    expect(button).toHaveTextContent('🌙');
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('applies the light theme and offers to switch to dark', () => {
+    renderToggle();
+
+    expect(
+      screen.getByRole('button', { name: /switch to dark theme/i })
+    ).toBeInTheDocument();
     expect(document.documentElement.getAttribute('data-theme')).toBe('light');
   });
 
-  it('toggles theme to dark when clicked', async () => {
+  it('switches to dark when clicked, and persists the choice', async () => {
     const user = userEvent.setup();
-    render(<ThemeToggle />);
-    
-    const button = screen.getByRole('button');
-    await user.click(button);
-    
+    renderToggle();
+
+    await user.click(screen.getByRole('button'));
+
     expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
     expect(window.localStorage.getItem('theme')).toBe('dark');
-    expect(screen.getByRole('button', { name: /Switch to light theme/i })).toBeInTheDocument();
-    expect(button).toHaveTextContent('☀️');
+    expect(
+      screen.getByRole('button', { name: /switch to light theme/i })
+    ).toBeInTheDocument();
   });
 
-  it('initializes with saved theme from localStorage', () => {
+  it('reports its state through aria-pressed', async () => {
+    const user = userEvent.setup();
+    renderToggle();
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+
+    await user.click(button);
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('applies a saved dark preference on mount, with no click', () => {
     window.localStorage.setItem('theme', 'dark');
-    render(<ThemeToggle />);
-    
+
+    renderToggle();
+
+    // The regression from #296: the theme was resolved on mount and then
+    // never written to the document, so a saved preference did nothing
+    // until the user clicked something.
     expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
-    const button = screen.getByRole('button', { name: /Switch to light theme/i });
-    expect(button).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /switch to light theme/i })
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to the OS preference when nothing is saved', () => {
+    mockMatchMedia(true);
+
+    renderToggle();
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    // Following the OS is not an explicit choice and must not be persisted.
+    expect(window.localStorage.getItem('theme')).toBeNull();
+  });
+
+  it('defaults to the floating variant and accepts an inline one', () => {
+    const { unmount } = renderToggle();
+    expect(screen.getByRole('button')).toHaveClass('theme-toggle--floating');
+    unmount();
+
+    renderToggle({ variant: 'inline', className: 'nav__theme-toggle' });
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('theme-toggle--inline');
+    expect(button).toHaveClass('nav__theme-toggle');
+  });
+
+  it('is a submit-safe button', () => {
+    renderToggle();
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  it('throws a useful error outside the provider', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() => render(<ThemeToggle />)).toThrow(/must be used inside a/i);
+
+    consoleError.mockRestore();
+  });
+
+  /**
+   * The heart of #296: two components reading the theme used to hold two
+   * independent copies of it, so clicking one left the other stale.
+   */
+  it('stays in sync with every other consumer of the theme', async () => {
+    const user = userEvent.setup();
+
+    function ThemeReadout() {
+      const { theme } = useTheme();
+      return <span data-testid="readout">{theme}</span>;
+    }
+
+    render(
+      <ThemeProvider>
+        <ThemeToggle />
+        <ThemeToggle variant="inline" />
+        <ThemeReadout />
+      </ThemeProvider>
+    );
+
+    const [first, second] = screen.getAllByRole('button');
+
+    await user.click(first);
+
+    expect(screen.getByTestId('readout')).toHaveTextContent('dark');
+    expect(first).toHaveAttribute('aria-pressed', 'true');
+    expect(second).toHaveAttribute('aria-pressed', 'true');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+    // One click on the *other* button, one change. Previously the second
+    // button needed two clicks because its private state was a step behind.
+    await user.click(second);
+
+    expect(screen.getByTestId('readout')).toHaveTextContent('light');
+    expect(first).toHaveAttribute('aria-pressed', 'false');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
   });
 });

--- a/bookshelf-frontend/src/context/ThemeContext.jsx
+++ b/bookshelf-frontend/src/context/ThemeContext.jsx
@@ -1,0 +1,216 @@
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+/**
+ * The one owner of the theme.
+ *
+ * Before this, theme lived in two places at once: a private `useState` inside
+ * ThemeToggle, and a second, unrelated `useState` inside the `useTheme` hook
+ * that Navbar called. Both mounted on every route, both writing `data-theme`
+ * and `localStorage.theme`, neither aware of the other. Clicking one toggle
+ * left the other showing the wrong icon and believing the wrong thing, so the
+ * second button needed two clicks to do anything. See #296.
+ *
+ * Theme is global state. There is exactly one of it here.
+ */
+
+export const STORAGE_KEY = 'theme';
+export const DARK_QUERY = '(prefers-color-scheme: dark)';
+
+/** What the user has asked for, which is not the same as what is on screen. */
+export const PREFERENCE = Object.freeze({
+  SYSTEM: 'system',
+  LIGHT: 'light',
+  DARK: 'dark',
+});
+
+const THEMES = Object.freeze({ LIGHT: 'light', DARK: 'dark' });
+
+export const ThemeContext = createContext(undefined);
+
+/**
+ * localStorage throws in Safari private browsing and when a browser blocks
+ * storage for third-party frames. A theme preference is not worth crashing
+ * the app over, so every access is guarded and simply degrades to
+ * "follow the system".
+ */
+function readStoredPreference() {
+  try {
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+    return saved === THEMES.LIGHT || saved === THEMES.DARK
+      ? saved
+      : PREFERENCE.SYSTEM;
+  } catch {
+    return PREFERENCE.SYSTEM;
+  }
+}
+
+function writeStoredPreference(preference) {
+  try {
+    if (preference === PREFERENCE.SYSTEM) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, preference);
+    }
+  } catch {
+    // Preference will not survive a reload. Nothing else breaks.
+  }
+}
+
+/**
+ * matchMedia is missing in some test environments and in older browsers.
+ * Treat its absence as "the system prefers light" rather than throwing during
+ * the first render.
+ */
+function systemPrefersDark() {
+  if (typeof window.matchMedia !== 'function') {
+    return false;
+  }
+
+  return window.matchMedia(DARK_QUERY).matches;
+}
+
+/**
+ * Resolve a preference to the theme actually shown.
+ *
+ * Keeping "system" distinct from the light/dark it currently resolves to is
+ * the whole point. The old hook collapsed the two — its system-change
+ * listener called `setTheme`, which persisted to localStorage, so the first
+ * time the OS flipped, the app recorded that as an explicit user choice and
+ * stopped following the OS from then on. The listener disabled itself the
+ * first time it fired.
+ */
+export function resolveTheme(preference, prefersDark) {
+  if (preference === PREFERENCE.LIGHT || preference === PREFERENCE.DARK) {
+    return preference;
+  }
+
+  return prefersDark ? THEMES.DARK : THEMES.LIGHT;
+}
+
+export function ThemeProvider({ children }) {
+  const [preference, setPreference] = useState(readStoredPreference);
+  const [prefersDark, setPrefersDark] = useState(systemPrefersDark);
+
+  const theme = resolveTheme(preference, prefersDark);
+  const isDark = theme === THEMES.DARK;
+
+  /**
+   * Apply the theme to the document.
+   *
+   * useLayoutEffect rather than useEffect so the attribute is set before the
+   * browser paints — with useEffect a user who has chosen dark gets one
+   * frame of light first. This is also the step `useTheme` was missing
+   * entirely: it computed an initial theme in its state initialiser and then
+   * never wrote it anywhere, so a saved preference did nothing until the
+   * user clicked.
+   */
+  useLayoutEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    document.documentElement.style.colorScheme = theme;
+  }, [theme]);
+
+  /**
+   * Persist the preference, not the resolved theme. Writing "dark" here
+   * because the OS happens to be dark would silently convert "follow the
+   * system" into an explicit choice.
+   */
+  useEffect(() => {
+    writeStoredPreference(preference);
+  }, [preference]);
+
+  /**
+   * Follow the OS while the preference is "system". The listener stays
+   * subscribed regardless of preference — it only updates what the system
+   * currently says, and `resolveTheme` decides whether that matters. That
+   * way switching back to "system" is immediately correct without a reload.
+   */
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia(DARK_QUERY);
+    const handleChange = (event) => setPrefersDark(event.matches);
+
+    // Safari below 14 only has the deprecated addListener form.
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }
+
+    if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(handleChange);
+      return () => mediaQuery.removeListener(handleChange);
+    }
+
+    return undefined;
+  }, []);
+
+  /**
+   * Keep tabs in step. Without this, toggling the theme in one tab leaves
+   * every other open tab on the old theme until it is reloaded — and the
+   * next write from those tabs would clobber the choice just made.
+   */
+  useEffect(() => {
+    const handleStorage = (event) => {
+      if (event.key !== null && event.key !== STORAGE_KEY) {
+        return;
+      }
+
+      setPreference(readStoredPreference());
+    };
+
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
+  const setTheme = useCallback((next) => {
+    if (next !== THEMES.LIGHT && next !== THEMES.DARK) {
+      console.warn(
+        `[theme] setTheme expects "light" or "dark", received "${next}". Ignoring.`
+      );
+      return;
+    }
+
+    setPreference(next);
+  }, []);
+
+  const useSystemTheme = useCallback(() => {
+    setPreference(PREFERENCE.SYSTEM);
+  }, []);
+
+  /**
+   * Toggle from what is on screen, not from the preference. If the
+   * preference is "system" and the system is dark, the user clicking the
+   * toggle means "make it light" — they are reacting to what they can see.
+   */
+  const toggleTheme = useCallback(() => {
+    setPreference(isDark ? THEMES.LIGHT : THEMES.DARK);
+  }, [isDark]);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      isDark,
+      preference,
+      isSystemPreference: preference === PREFERENCE.SYSTEM,
+      setTheme,
+      toggleTheme,
+      useSystemTheme,
+    }),
+    [theme, isDark, preference, setTheme, toggleTheme, useSystemTheme]
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+}
+
+export default ThemeProvider;

--- a/bookshelf-frontend/src/context/ThemeContext.test.jsx
+++ b/bookshelf-frontend/src/context/ThemeContext.test.jsx
@@ -1,0 +1,359 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+  ThemeProvider,
+  resolveTheme,
+  PREFERENCE,
+  STORAGE_KEY,
+} from './ThemeContext.jsx';
+import { useTheme } from '../hooks/useTheme.js';
+
+/**
+ * A controllable prefers-color-scheme, with a handle to fire a change the way
+ * the OS would.
+ */
+function mockMatchMedia(initialMatches = false) {
+  const listeners = new Set();
+
+  const mediaQueryList = {
+    matches: initialMatches,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: (_event, handler) => listeners.add(handler),
+    removeEventListener: (_event, handler) => listeners.delete(handler),
+    addListener: (handler) => listeners.add(handler),
+    removeListener: (handler) => listeners.delete(handler),
+    dispatchEvent: vi.fn(),
+  };
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockReturnValue(mediaQueryList),
+  });
+
+  return {
+    mediaQueryList,
+    emit(matches) {
+      mediaQueryList.matches = matches;
+      act(() => {
+        for (const handler of listeners) {
+          handler({ matches });
+        }
+      });
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+/** Renders the whole context surface so assertions read off the DOM. */
+function Probe() {
+  const {
+    theme,
+    isDark,
+    preference,
+    isSystemPreference,
+    setTheme,
+    toggleTheme,
+    useSystemTheme,
+  } = useTheme();
+
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <span data-testid="is-dark">{String(isDark)}</span>
+      <span data-testid="preference">{preference}</span>
+      <span data-testid="is-system">{String(isSystemPreference)}</span>
+      <button onClick={toggleTheme}>toggle</button>
+      <button onClick={() => setTheme('light')}>force light</button>
+      <button onClick={() => setTheme('dark')}>force dark</button>
+      <button onClick={useSystemTheme}>follow system</button>
+    </div>
+  );
+}
+
+function renderProvider() {
+  return render(
+    <ThemeProvider>
+      <Probe />
+    </ThemeProvider>
+  );
+}
+
+const themeText = () => screen.getByTestId('theme').textContent;
+const preferenceText = () => screen.getByTestId('preference').textContent;
+
+describe('resolveTheme', () => {
+  it('returns an explicit preference unchanged', () => {
+    expect(resolveTheme(PREFERENCE.DARK, false)).toBe('dark');
+    expect(resolveTheme(PREFERENCE.LIGHT, true)).toBe('light');
+  });
+
+  it('follows the system when the preference is system', () => {
+    expect(resolveTheme(PREFERENCE.SYSTEM, true)).toBe('dark');
+    expect(resolveTheme(PREFERENCE.SYSTEM, false)).toBe('light');
+  });
+});
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.style.colorScheme = '';
+    mockMatchMedia(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('applies data-theme on mount', () => {
+    renderProvider();
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(document.documentElement.style.colorScheme).toBe('light');
+  });
+
+  it('starts on the system preference when nothing is stored', () => {
+    mockMatchMedia(true);
+    renderProvider();
+
+    expect(themeText()).toBe('dark');
+    expect(preferenceText()).toBe(PREFERENCE.SYSTEM);
+    expect(screen.getByTestId('is-system')).toHaveTextContent('true');
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('restores a stored explicit preference', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'dark');
+    renderProvider();
+
+    expect(themeText()).toBe('dark');
+    expect(preferenceText()).toBe('dark');
+    expect(screen.getByTestId('is-system')).toHaveTextContent('false');
+  });
+
+  it('ignores a junk value in storage rather than applying it', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'neon');
+    renderProvider();
+
+    expect(themeText()).toBe('light');
+    expect(preferenceText()).toBe(PREFERENCE.SYSTEM);
+  });
+
+  it('persists an explicit choice', async () => {
+    const user = userEvent.setup();
+    renderProvider();
+
+    await user.click(screen.getByText('force dark'));
+
+    expect(themeText()).toBe('dark');
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('dark');
+  });
+
+  it('clears storage when the user goes back to following the system', async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(STORAGE_KEY, 'dark');
+    renderProvider();
+
+    await user.click(screen.getByText('follow system'));
+
+    expect(preferenceText()).toBe(PREFERENCE.SYSTEM);
+    expect(themeText()).toBe('light');
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('ignores an unrecognised value passed to setTheme', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    function BadCaller() {
+      const { setTheme } = useTheme();
+      return <button onClick={() => setTheme('sepia')}>bad</button>;
+    }
+
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider>
+        <Probe />
+        <BadCaller />
+      </ThemeProvider>
+    );
+
+    await user.click(screen.getByText('bad'));
+
+    expect(themeText()).toBe('light');
+    expect(warn).toHaveBeenCalled();
+  });
+
+  describe('following the OS', () => {
+    it('tracks a system change while the preference is system', () => {
+      const media = mockMatchMedia(false);
+      renderProvider();
+
+      expect(themeText()).toBe('light');
+
+      media.emit(true);
+
+      expect(themeText()).toBe('dark');
+      // Following along is not a choice, so nothing is written.
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+      expect(preferenceText()).toBe(PREFERENCE.SYSTEM);
+    });
+
+    it('keeps tracking after more than one system change', () => {
+      // The old hook stopped after the first: its handler called setTheme,
+      // which wrote to localStorage, and the handler's own guard then read
+      // that back as an explicit choice and refused to act again.
+      const media = mockMatchMedia(false);
+      renderProvider();
+
+      media.emit(true);
+      expect(themeText()).toBe('dark');
+
+      media.emit(false);
+      expect(themeText()).toBe('light');
+
+      media.emit(true);
+      expect(themeText()).toBe('dark');
+    });
+
+    it('stops following once the user chooses explicitly', async () => {
+      const user = userEvent.setup();
+      const media = mockMatchMedia(false);
+      renderProvider();
+
+      await user.click(screen.getByText('force light'));
+      media.emit(true);
+
+      expect(themeText()).toBe('light');
+      expect(preferenceText()).toBe('light');
+    });
+
+    it('picks the system theme back up when the user opts back in', async () => {
+      const user = userEvent.setup();
+      const media = mockMatchMedia(false);
+      renderProvider();
+
+      await user.click(screen.getByText('force light'));
+      media.emit(true);
+      expect(themeText()).toBe('light');
+
+      await user.click(screen.getByText('follow system'));
+
+      // No reload needed — the listener stayed subscribed throughout.
+      expect(themeText()).toBe('dark');
+    });
+
+    it('unsubscribes on unmount', () => {
+      const media = mockMatchMedia(false);
+      const { unmount } = renderProvider();
+
+      expect(media.listenerCount()).toBe(1);
+      unmount();
+      expect(media.listenerCount()).toBe(0);
+    });
+  });
+
+  describe('toggleTheme', () => {
+    it('flips what is on screen', async () => {
+      const user = userEvent.setup();
+      renderProvider();
+
+      await user.click(screen.getByText('toggle'));
+      expect(themeText()).toBe('dark');
+
+      await user.click(screen.getByText('toggle'));
+      expect(themeText()).toBe('light');
+    });
+
+    it('flips away from the system theme in one click', async () => {
+      // Preference is 'system' resolving to dark. Clicking means "make it
+      // light" — the user is reacting to what they can see, not to the
+      // preference they never set.
+      const user = userEvent.setup();
+      mockMatchMedia(true);
+      renderProvider();
+
+      expect(themeText()).toBe('dark');
+
+      await user.click(screen.getByText('toggle'));
+
+      expect(themeText()).toBe('light');
+      expect(preferenceText()).toBe('light');
+    });
+  });
+
+  describe('resilience', () => {
+    it('survives localStorage being unavailable', () => {
+      const getItem = vi
+        .spyOn(Storage.prototype, 'getItem')
+        .mockImplementation(() => {
+          throw new Error('SecurityError');
+        });
+      const setItem = vi
+        .spyOn(Storage.prototype, 'setItem')
+        .mockImplementation(() => {
+          throw new Error('SecurityError');
+        });
+
+      expect(() => renderProvider()).not.toThrow();
+      expect(themeText()).toBe('light');
+
+      getItem.mockRestore();
+      setItem.mockRestore();
+    });
+
+    it('survives matchMedia being missing', () => {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: undefined,
+      });
+
+      expect(() => renderProvider()).not.toThrow();
+      expect(themeText()).toBe('light');
+    });
+
+    it('picks up a change made in another tab', () => {
+      renderProvider();
+      expect(themeText()).toBe('light');
+
+      window.localStorage.setItem(STORAGE_KEY, 'dark');
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', { key: STORAGE_KEY, newValue: 'dark' })
+        );
+      });
+
+      expect(themeText()).toBe('dark');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    });
+
+    it('ignores storage events for unrelated keys', () => {
+      renderProvider();
+
+      window.localStorage.setItem('cart', '[]');
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', { key: 'cart', newValue: '[]' })
+        );
+      });
+
+      expect(themeText()).toBe('light');
+    });
+  });
+});
+
+describe('useTheme', () => {
+  it('throws outside a provider instead of returning undefined', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() => render(<Probe />)).toThrow(/ThemeProvider/);
+
+    consoleError.mockRestore();
+  });
+});

--- a/bookshelf-frontend/src/hooks/useTheme.js
+++ b/bookshelf-frontend/src/hooks/useTheme.js
@@ -1,36 +1,39 @@
-import { useState, useEffect } from 'react';
+import { useContext } from 'react';
+import { ThemeContext } from '../context/ThemeContext.jsx';
 
+/**
+ * Read the current theme.
+ *
+ * This used to be a full implementation — its own `useState`, its own
+ * `localStorage` writes, its own `matchMedia` listener — which meant every
+ * component that called it got a *private* copy of the theme. Navbar had one,
+ * ThemeToggle had another, and the two disagreed the moment either was
+ * clicked. It is now a consumer of the single ThemeContext. See #296.
+ *
+ * Throws when used outside the provider rather than handing back `undefined`
+ * and letting the caller blow up on the destructuring line, matching the
+ * pattern `useCart` already established.
+ *
+ * Returns:
+ *   theme               'light' | 'dark' — what is on screen right now
+ *   isDark              convenience boolean
+ *   preference          'system' | 'light' | 'dark' — what the user asked for
+ *   isSystemPreference  true while the app is following the OS
+ *   setTheme(next)      pick 'light' or 'dark' explicitly
+ *   toggleTheme()       flip whatever is currently on screen
+ *   useSystemTheme()    go back to following the OS
+ */
 export function useTheme() {
-  const [theme, setThemeState] = useState(() => {
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-      return savedTheme;
-    }
-    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    return systemPrefersDark ? 'dark' : 'light';
-  });
+  const context = useContext(ThemeContext);
 
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    const handleChange = (e) => {
-      if (!localStorage.getItem('theme')) {
-        setTheme(e.matches ? 'dark' : 'light');
-      }
-    };
-    
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
-  }, []);
+  if (context === undefined) {
+    throw new Error(
+      'useTheme() must be used inside a <ThemeProvider>. ' +
+        'Check that ThemeProvider wraps the component tree in main.jsx.'
+    );
+  }
 
-  const setTheme = (newTheme) => {
-    setThemeState(newTheme);
-    document.documentElement.setAttribute('data-theme', newTheme);
-    localStorage.setItem('theme', newTheme);
-  };
-
-  const toggleTheme = () => {
-    setTheme(theme === 'dark' ? 'light' : 'dark');
-  };
-
-  return { theme, setTheme, toggleTheme };
+  return context;
 }
+
+export default useTheme;

--- a/bookshelf-frontend/src/main.jsx
+++ b/bookshelf-frontend/src/main.jsx
@@ -6,6 +6,7 @@ import AppRoutes from './routes/AppRoutes.jsx';
 import { AuthProvider } from './context/AuthContext.jsx';
 import { WishlistProvider } from './context/WishlistContext.jsx';
 import { CartProvider } from './context/CartContext.jsx';
+import { ThemeProvider } from './context/ThemeContext.jsx';
 
 // Side-effect import: this is what actually calls i18n.init(). Nothing
 // imported it before, so every useTranslation() call in the app was running
@@ -22,17 +23,23 @@ import './index.css';
  * CartProvider is independent of both — it only touches localStorage — but it
  * has to be above the router, because Navbar and CartDrawer both consume it
  * and they are rendered by the App layout on every route.
+ *
+ * ThemeProvider is outermost. It depends on nothing, and it writes
+ * data-theme in a layout effect, so mounting it first means the attribute is
+ * on <html> before anything below it paints.
  */
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <AuthProvider>
-      <WishlistProvider>
-        <CartProvider>
-          <BrowserRouter>
-            <AppRoutes />
-          </BrowserRouter>
-        </CartProvider>
-      </WishlistProvider>
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <WishlistProvider>
+          <CartProvider>
+            <BrowserRouter>
+              <AppRoutes />
+            </BrowserRouter>
+          </CartProvider>
+        </WishlistProvider>
+      </AuthProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/bookshelf-frontend/src/pages/AboutUs.jsx
+++ b/bookshelf-frontend/src/pages/AboutUs.jsx
@@ -1,19 +1,15 @@
 import { Link } from 'react-router-dom';
-import Navbar from '../components/Navbar.jsx';
-import Footer from '../components/Footer.jsx';
-import ThemeToggle from '../components/ThemeToggle.jsx';
 import './AboutUs.css';
 
+/*
+ * Renders page content only. The theme toggle, navbar and spacer used to be
+ * repeated here as well as in the App layout, so /about carried a second
+ * navbar and a third theme toggle — each with its own copy of the theme
+ * state. Footer was imported but never rendered. See #296.
+ */
 export default function AboutUs() {
   return (
     <div className="about-page">
-      {/* ── Theme toggle (same as landing page) ── */}
-      <ThemeToggle />
-
-      {/* ── Navbar (same as landing page) ── */}
-      <Navbar cartCount={0} onCartClick={() => {}} />
-      <div className="nav-spacer" />
-
       {/* ── Hero section ── */}
       <section className="about-hero">
         <div className="about-hero__inner">
@@ -224,8 +220,7 @@ export default function AboutUs() {
         </div>
       </section>
 
-      {/* ── Footer (same as landing page) ── */}
-      {/* <Footer /> */}
+      {/* The footer comes from the App layout. */}
     </div>
   );
 }

--- a/bookshelf-frontend/src/pages/PrivacyPolicy.jsx
+++ b/bookshelf-frontend/src/pages/PrivacyPolicy.jsx
@@ -1,10 +1,12 @@
 import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import Navbar from '../components/Navbar.jsx';
-import Footer from '../components/Footer.jsx';
-import ThemeToggle from '../components/ThemeToggle.jsx';
 import './PrivacyPolicy.css';
 
+/*
+ * Renders page content only — the theme toggle, navbar and footer come from
+ * the App layout. Repeating them here put a second navbar and a third theme
+ * toggle on the page, each with its own copy of the theme state. See #296.
+ */
 export default function PrivacyPolicy() {
   /* Scroll to top on mount */
   useEffect(() => {
@@ -15,13 +17,6 @@ export default function PrivacyPolicy() {
 
   return (
     <div className="privacy-page">
-      {/* ── Theme toggle (same as landing page) ── */}
-      <ThemeToggle />
-
-      {/* ── Navbar (same as landing page) ── */}
-      <Navbar cartCount={0} onCartClick={() => {}} />
-      <div className="nav-spacer" />
-
       {/* ── Hero ── */}
       <section className="privacy-hero">
         <div className="privacy-hero__inner">

--- a/bookshelf-frontend/src/pages/TermsOfService.jsx
+++ b/bookshelf-frontend/src/pages/TermsOfService.jsx
@@ -1,10 +1,12 @@
 import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import Navbar from '../components/Navbar.jsx';
-import Footer from '../components/Footer.jsx';
-import ThemeToggle from '../components/ThemeToggle.jsx';
 import './TermsOfService.css';
 
+/*
+ * Renders page content only — the theme toggle, navbar and footer come from
+ * the App layout. Repeating them here put a second navbar and a third theme
+ * toggle on the page, each with its own copy of the theme state. See #296.
+ */
 export default function TermsOfService() {
   /* Scroll to top on mount */
   useEffect(() => {
@@ -16,13 +18,6 @@ export default function TermsOfService() {
 
   return (
     <div className="tos-page">
-      {/* ── Theme toggle ── */}
-      <ThemeToggle />
-
-      {/* ── Navbar ── */}
-      <Navbar cartCount={0} onCartClick={() => {}} />
-      <div className="nav-spacer" />
-
       {/* ── Hero Section ── */}
       <section className="tos-hero">
         <div className="tos-hero__inner">


### PR DESCRIPTION
Closes #296.

## The bug

Theme was implemented twice, independently, and both implementations were mounted at the same time:

| | owns state | writes `data-theme` | writes `localStorage` |
|---|---|---|---|
| `components/ThemeToggle.jsx` | `useState` | yes | yes |
| `hooks/useTheme.js` (used by `Navbar`) | `useState` | yes, on click only | yes |

Neither knew about the other. `App` rendered `<ThemeToggle />`, `Navbar` rendered its own hand-rolled button, and both were on every route.

Three separate failures fell out of that:

**`useTheme` never applied the theme.** It computed an initial value in its state initialiser and then only ever wrote `data-theme` inside `setTheme`, which runs on a click. The computed value was thrown away. A saved dark preference did nothing until the user toggled something.

**The two toggles desynchronised on the first click.** Click the navbar button → the page goes dark, but `ThemeToggle`'s state is still `light`, so it still shows 🌙 and its effect has no reason to re-run. Clicking it now sets its state to `dark` — which the page already is — so **nothing visibly happens**. The second button needs two clicks to produce one change, and the icons contradict each other for the rest of the session.

**The system-preference listener disabled itself the first time it fired:**

```js
const handleChange = (e) => {
  if (!localStorage.getItem('theme')) {   // "only while there's no explicit choice"
    setTheme(e.matches ? 'dark' : 'light');  // ...and setTheme writes localStorage
  }
};
```

The first OS change was recorded as an explicit user choice, and the app stopped following the OS from then on.

While fixing this I found it was worse than two: **`AboutUs`, `PrivacyPolicy` and `TermsOfService` each render their own `<ThemeToggle />` and their own `<Navbar />`** on top of the layout's. `/about` was carrying two navbars and three theme toggles, each with a private copy of the theme.

## The fix

**`context/ThemeContext.jsx` (new).** One owner, mounted outermost in `main.jsx`.

The key modelling change is keeping **preference** (`system` | `light` | `dark`) separate from the **resolved theme** (`light` | `dark`). Collapsing the two is what made the OS listener self-destruct. Only explicit choices are persisted; `system` removes the key. The listener stays subscribed regardless of preference, so switching back to "follow the system" is correct immediately rather than after a reload.

`data-theme` is written in a `useLayoutEffect`, so it lands before the browser paints instead of a frame late — a user who chose dark no longer gets one white frame. `color-scheme` is set alongside it so form controls and scrollbars match.

Also handles some things neither original did: syncing across tabs via the `storage` event (toggling in one tab left every other tab stale, and their next write clobbered the choice), `localStorage` throwing in Safari private browsing, `matchMedia` being absent, and Safari <14's `addListener`-only API.

**`hooks/useTheme.js`.** Now a consumer of the context. Throws outside the provider rather than returning `undefined` and letting the caller blow up on the destructuring line — same pattern `useCart` already uses.

**`components/ThemeToggle.jsx`.** Holds no state. Takes a `variant` so it can be inline or floating; `position: fixed` living on the shared `.theme-toggle` class is precisely why Navbar hand-rolled a second button instead of reusing this one. The SVG icons move over from Navbar, so the navbar looks the same as before. `aria-pressed` now reflects real shared state.

**The three static pages** render page content only, matching what `WishlistPage` already does. Their `Footer` imports were dead — imported, never rendered.

## Tests

`context/ThemeContext.test.jsx` (new, 20 cases) and a rewritten `ThemeToggle.test.jsx` (9 cases).

The ones tied directly to the report:

- `applies a saved dark preference on mount, with no click`
- `stays in sync with every other consumer of the theme` — two toggles plus a readout; one click on either produces exactly one change everywhere
- `keeps tracking after more than one system change` — the listener that used to switch itself off
- `picks the system theme back up when the user opts back in`
- `falls back to the OS preference when nothing is saved` — and asserts nothing is written to storage

Plus the resilience cases: storage throwing, `matchMedia` missing, another tab changing the theme, junk in storage.

```
Test Files  5 passed (5)
     Tests  73 passed (73)
```

(46 before this branch.)

`npx vite build` succeeds. ESLint is clean on every file this touches; the 39 pre-existing `react/no-unescaped-entities` errors in the two policy pages are untouched by this branch — the branch removes 3 unused-variable warnings and adds none.

## Verified by hand

Toggle from the navbar, reload, navigate to `/about` and `/terms`, and change the OS appearance setting with and without an explicit preference set. One toggle, one theme, no flash.

## Notes for review

- Storage format is unchanged (`theme` = `"light"` | `"dark"`), so an existing saved preference carries over. The difference is that *absence* of the key now means "follow the system" rather than being indistinguishable from it.
- The floating variant is retained and tested but nothing renders it today. Left in because it is one CSS block and the corner placement may still be wanted on a page with no navbar — say so if you would rather it went.