### PR TITLE
fix(backend): validate the checkout cart and release stock when payment fails (closes #297)

### DIFF
--- a/bookshelf-backend/controllers/paymentController.js
+++ b/bookshelf-backend/controllers/paymentController.js
@@ -1,67 +1,102 @@
 import orderRepository from '../repositories/orderRepository.js';
 import { createPaymentIntent } from '../services/stripeService.js';
-import { getBookById, updateInventoryWithOCC } from '../repositories/bookRepository.js';
+import {
+  getBookById,
+  updateInventoryWithOCC,
+  restoreInventory,
+} from '../repositories/bookRepository.js';
+import { prepareCheckout, CheckoutValidationError } from '../utils/checkout.js';
+import { format } from '../utils/money.js';
 
+/**
+ * @desc    Create a payment intent for a cart
+ * @route   POST /api/payments/create-intent
+ * @access  Public — guests can check out
+ *
+ * The route is unauthenticated, so every value in the body is hostile until
+ * proved otherwise. Previously `items` was iterated straight off the request:
+ * a missing array was a 500, and a negative quantity passed the stock check,
+ * *added* inventory to books.json and produced an order with a negative
+ * total. See #297.
+ *
+ * Order of operations, and why:
+ *
+ *   1. Validate and price. Nothing is written until the whole cart is known
+ *      to be good — a request that fails here has touched nothing.
+ *   2. Reserve inventory. Before the payment, because the alternative is
+ *      overselling in the window between charging and reserving.
+ *   3. Create the order and the payment intent. Anything that fails from
+ *      here on releases the reservation before returning.
+ */
 export const createIntent = async (req, res, next) => {
+  const { items, shippingAddress } = req.body ?? {};
+
+  let checkout;
+
   try {
-    const { items, shippingAddress, couponCode } = req.body;
-    
-    // Server-side calculation of total to prevent client-side tampering
-    // In a real application, we would fetch book prices from the database based on bookIds
-    // For this demonstration, we'll calculate based on the passed prices, but 
-    // ideally, this needs DB validation.
-    let subtotal = 0;
-    const orderItems = [];
-    const itemVersions = [];
-
-    for (const item of items) {
-      const bookId = item.bookId || item.id;
-      const bookRecord = getBookById(bookId);
-
-      if (!bookRecord) {
-        return res.status(404).json({ message: `Book not found: ${bookId}` });
-      }
-
-      itemVersions.push({
-        bookId,
-        quantity: item.quantity,
-        expectedVersion: bookRecord.__v,
-      });
-
-      subtotal += bookRecord.price * item.quantity;
-      
-      orderItems.push({
-        bookId: bookRecord.id,
-        title: bookRecord.title,
-        price: bookRecord.price,
-        quantity: item.quantity,
+    checkout = prepareCheckout(items, getBookById);
+  } catch (error) {
+    if (error instanceof CheckoutValidationError) {
+      return res.status(400).json({
+        message: 'Invalid checkout request',
+        errors: error.errors,
       });
     }
 
-    // Attempt OCC Inventory Update
-    try {
-      updateInventoryWithOCC(itemVersions);
-    } catch (error) {
-      return res.status(error.status || 500).json({ message: error.message });
+    return next(error);
+  }
+
+  // Reserve stock. A version mismatch or insufficient stock is the client's
+  // answer (409), not a server fault.
+  try {
+    updateInventoryWithOCC(checkout.reservation);
+  } catch (error) {
+    return res.status(error.status || 500).json({ message: error.message });
+  }
+
+  let reservationHeld = true;
+
+  const release = (reason) => {
+    if (!reservationHeld) {
+      return;
     }
 
-    const tax = subtotal * 0.05; // 5% mock tax
-    const shipping = 5.99; // Mock flat shipping rate
-    const total = subtotal + tax + shipping;
+    reservationHeld = false;
 
-    const savedOrder = await orderRepository.create({
+    const { failed } = restoreInventory(checkout.reservation);
+
+    if (failed.length > 0) {
+      // Worth a loud log: the shop's stock is now understated and only a
+      // human can reconcile it.
+      console.error(
+        `[checkout] released reservation after ${reason}, but ${failed.length} ` +
+          'line(s) could not be restored:',
+        failed
+      );
+    }
+  };
+
+  let savedOrder;
+
+  try {
+    savedOrder = await orderRepository.create({
       userId: req.user ? req.user._id : null,
-      items: orderItems,
+      items: checkout.orderItems,
       shippingAddress: shippingAddress || {},
-      subtotal,
-      tax,
-      shipping,
-      total,
+      subtotal: checkout.subtotal,
+      tax: checkout.tax,
+      shipping: checkout.shipping,
+      total: checkout.total,
       status: 'pending',
       paymentStatus: 'pending',
     });
+  } catch (error) {
+    release('the order could not be saved');
+    return next(error);
+  }
 
-    const paymentIntent = await createPaymentIntent(total, 'usd', {
+  try {
+    const paymentIntent = await createPaymentIntent(checkout.total, 'usd', {
       orderId: savedOrder._id.toString(),
       userId: req.user ? req.user._id.toString() : 'guest',
     });
@@ -69,11 +104,43 @@ export const createIntent = async (req, res, next) => {
     savedOrder.stripePaymentIntentId = paymentIntent.id;
     await orderRepository.save(savedOrder);
 
-    res.status(200).json({
+    // Past this point the reservation belongs to the order, and the webhook
+    // is responsible for it: payment_intent.payment_failed and
+    // payment_intent.canceled are where it gets released.
+    reservationHeld = false;
+
+    return res.status(200).json({
       clientSecret: paymentIntent.client_secret,
       orderId: savedOrder._id,
+      amount: {
+        subtotal: checkout.subtotal,
+        tax: checkout.tax,
+        shipping: checkout.shipping,
+        total: checkout.total,
+      },
     });
   } catch (error) {
-    next(error);
+    release('the payment intent could not be created');
+
+    // Leave a trace rather than an order stuck at 'pending' forever with no
+    // payment intent attached to it.
+    try {
+      savedOrder.status = 'payment_failed';
+      savedOrder.paymentStatus = 'failed';
+      await orderRepository.save(savedOrder);
+    } catch (saveError) {
+      console.error(
+        `[checkout] could not mark order ${savedOrder._id} as failed:`,
+        saveError
+      );
+    }
+
+    console.error(
+      `[checkout] payment intent failed for order ${savedOrder._id} ` +
+        `(total ${format(checkout.minorUnits.total)}):`,
+      error.message
+    );
+
+    return next(error);
   }
 };

--- a/bookshelf-backend/repositories/bookRepository.js
+++ b/bookshelf-backend/repositories/bookRepository.js
@@ -58,13 +58,30 @@ export const updateInventoryWithOCC = (itemsToUpdate) => {
                 throw error;
             }
 
-            // Inventory Check
-            if (book.inventory < item.quantity) {
-                const error = new Error(`Insufficient inventory for book ${item.bookId}.`);
+            // Quantity check.
+            //
+            // The inventory check below is `book.inventory < item.quantity`,
+            // which a negative quantity passes trivially — `8 < -5` is false.
+            // The mutation phase then ran `inventory -= -5` and *added* five
+            // units to the catalogue on disk. The controller validates its
+            // input now, but a repository that can be talked into minting
+            // stock should not be one refactor away from being reachable
+            // again. See #297.
+            if (!Number.isInteger(item.quantity) || item.quantity < 1) {
+                const error = new Error(
+                    `Quantity for book ${item.bookId} must be a positive integer, received ${item.quantity}.`
+                );
                 error.status = 400;
                 throw error;
             }
-            
+
+            // Inventory Check
+            if (book.inventory < item.quantity) {
+                const error = new Error(`Insufficient inventory for book ${item.bookId}.`);
+                error.status = 409;
+                throw error;
+            }
+
             bookIndices.push({ index: bookIndex, quantity: item.quantity });
         }
 
@@ -83,5 +100,74 @@ export const updateInventoryWithOCC = (itemsToUpdate) => {
         return true;
     } catch (error) {
         throw error;
+    }
+};
+
+/**
+ * Put reserved stock back.
+ *
+ * Inventory is taken before the payment intent exists, because the alternative
+ * is overselling between the two steps. The consequence is that every failure
+ * after the reservation has to hand the units back, or a failed checkout
+ * silently destroys stock — with inventories of 8 to 10, a handful of Stripe
+ * errors took the shop to zero. See #297.
+ *
+ * Deliberately *not* version-checked. This is a compensating action for a
+ * reservation that already happened; refusing to run because someone else
+ * bought a copy in between would leave the units lost, which is the outcome
+ * it exists to prevent. Unknown ids are skipped rather than thrown on, for
+ * the same reason.
+ *
+ * Never throws. Callers reach this from an error path and must not lose the
+ * original error to a secondary failure — the return value says what
+ * happened instead.
+ */
+export const restoreInventory = (itemsToRestore) => {
+    if (!Array.isArray(itemsToRestore) || itemsToRestore.length === 0) {
+        return { restored: [], failed: [] };
+    }
+
+    try {
+        const data = fs.readFileSync(booksFilePath, 'utf8');
+        const books = JSON.parse(data);
+
+        const restored = [];
+        const failed = [];
+
+        for (const item of itemsToRestore) {
+            if (!Number.isInteger(item.quantity) || item.quantity < 1) {
+                failed.push({ bookId: item.bookId, reason: 'invalid quantity' });
+                continue;
+            }
+
+            const bookIndex = books.findIndex((b) => b.id === item.bookId);
+
+            if (bookIndex === -1) {
+                failed.push({ bookId: item.bookId, reason: 'book not found' });
+                continue;
+            }
+
+            books[bookIndex].inventory += item.quantity;
+            books[bookIndex].__v += 1;
+            restored.push({ bookId: item.bookId, quantity: item.quantity });
+        }
+
+        if (restored.length > 0) {
+            fs.writeFileSync(booksFilePath, JSON.stringify(books, null, 2), 'utf8');
+            cacheManager.del('books');
+        }
+
+        return { restored, failed };
+    } catch (error) {
+        // Losing stock is bad; losing the error that explains why the
+        // checkout failed in the first place is worse.
+        console.error('Failed to restore reserved inventory:', error);
+        return {
+            restored: [],
+            failed: itemsToRestore.map((item) => ({
+                bookId: item.bookId,
+                reason: error.message,
+            })),
+        };
     }
 };

--- a/bookshelf-backend/tests/checkout.test.js
+++ b/bookshelf-backend/tests/checkout.test.js
@@ -1,0 +1,322 @@
+import test, { describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  MAX_LINE_ITEMS,
+  MAX_QUANTITY_PER_LINE,
+  CheckoutValidationError,
+  validateItems,
+  priceOrder,
+  toReservation,
+  prepareCheckout,
+} from '../utils/checkout.js';
+
+/**
+ * A three-book catalogue. The real one is read from disk; the lookup is
+ * injected precisely so these tests do not have to be.
+ */
+const CATALOGUE = {
+  b1: { id: 'b1', title: 'The Quiet Ones', price: 349, inventory: 8, __v: 2 },
+  b2: { id: 'b2', title: 'Field Notes', price: 299, inventory: 10, __v: 1 },
+  b3: { id: 'b3', title: 'Half Moon Bay', price: 399, inventory: 0, __v: 5 },
+};
+
+const lookupBook = (id) => CATALOGUE[id];
+
+/** Asserts the call fails validation and returns the collected errors. */
+function expectRejected(items) {
+  try {
+    validateItems(items, lookupBook);
+  } catch (error) {
+    assert.ok(
+      error instanceof CheckoutValidationError,
+      `expected a CheckoutValidationError, got ${error.name}: ${error.message}`
+    );
+    assert.equal(error.status, 400);
+    return error.errors;
+  }
+
+  assert.fail('expected validation to reject, but it passed');
+}
+
+describe('validateItems — the shape of the request', () => {
+  test('rejects a missing items array instead of throwing a TypeError', () => {
+    // `for (const item of undefined)` used to reach the generic error
+    // handler and come back as a 500.
+    const errors = expectRejected(undefined);
+    assert.equal(errors[0].field, 'items');
+    assert.match(errors[0].message, /required/);
+  });
+
+  test('rejects a non-array items', () => {
+    for (const value of ['b1', 42, {}, true]) {
+      const errors = expectRejected(value);
+      assert.match(errors[0].message, /must be an array/);
+    }
+  });
+
+  test('rejects an empty cart', () => {
+    const errors = expectRejected([]);
+    assert.match(errors[0].message, /at least one entry/);
+  });
+
+  test('rejects a cart with too many lines', () => {
+    const items = Array.from({ length: MAX_LINE_ITEMS + 1 }, () => ({
+      id: 'b1',
+      quantity: 1,
+    }));
+
+    const errors = expectRejected(items);
+    assert.match(errors[0].message, /at most 50 entries/);
+  });
+
+  test('rejects entries that are not objects', () => {
+    const errors = expectRejected(['b1', null, 7]);
+    assert.equal(errors.length, 3);
+    assert.equal(errors[0].field, 'items[0]');
+    assert.equal(errors[2].field, 'items[2]');
+  });
+});
+
+describe('validateItems — the book id', () => {
+  test('accepts either bookId or id', () => {
+    const byBookId = validateItems([{ bookId: 'b1', quantity: 1 }], lookupBook);
+    const byId = validateItems([{ id: 'b1', quantity: 1 }], lookupBook);
+
+    assert.equal(byBookId[0].bookId, 'b1');
+    assert.equal(byId[0].bookId, 'b1');
+  });
+
+  test('trims surrounding whitespace', () => {
+    const items = validateItems([{ id: '  b1  ', quantity: 1 }], lookupBook);
+    assert.equal(items[0].bookId, 'b1');
+  });
+
+  test('rejects a missing, empty or non-string id', () => {
+    for (const id of [undefined, null, '', '   ', 42, {}]) {
+      const errors = expectRejected([{ id, quantity: 1 }]);
+      assert.equal(errors[0].field, 'items[0].bookId');
+    }
+  });
+
+  test('rejects an id that is not in the catalogue', () => {
+    const errors = expectRejected([{ id: 'does-not-exist', quantity: 1 }]);
+    assert.match(errors[0].message, /Book not found: does-not-exist/);
+  });
+});
+
+describe('validateItems — the quantity', () => {
+  test('accepts a positive integer', () => {
+    const items = validateItems([{ id: 'b1', quantity: 3 }], lookupBook);
+    assert.equal(items[0].quantity, 3);
+  });
+
+  /**
+   * The reported bug. A negative quantity passed the old stock check
+   * (`8 < -5` is false) and the mutation phase then ran `inventory -= -5`,
+   * adding five units to the catalogue on disk.
+   */
+  test('rejects a negative quantity', () => {
+    const errors = expectRejected([{ id: 'b1', quantity: -5 }]);
+    assert.equal(errors[0].field, 'items[0].quantity');
+    assert.match(errors[0].message, /at least 1, received -5/);
+  });
+
+  test('rejects a zero quantity', () => {
+    const errors = expectRejected([{ id: 'b1', quantity: 0 }]);
+    assert.match(errors[0].message, /at least 1/);
+  });
+
+  test('rejects a fractional quantity', () => {
+    const errors = expectRejected([{ id: 'b1', quantity: 1.5 }]);
+    assert.match(errors[0].message, /whole number/);
+  });
+
+  test('rejects a missing, non-numeric or NaN quantity', () => {
+    for (const quantity of [undefined, null, '3', NaN, Infinity, {}]) {
+      const errors = expectRejected([{ id: 'b1', quantity }]);
+      assert.equal(errors[0].field, 'items[0].quantity');
+    }
+  });
+
+  test('rejects a quantity beyond the per-line cap', () => {
+    const errors = expectRejected([
+      { id: 'b1', quantity: MAX_QUANTITY_PER_LINE + 1 },
+    ]);
+    assert.match(errors[0].message, /at most 20/);
+  });
+
+  test('collects every problem rather than stopping at the first', () => {
+    const errors = expectRejected([
+      { id: 'b1', quantity: -1 },
+      { id: 'nope', quantity: 1 },
+      { id: 'b2', quantity: 2.5 },
+    ]);
+
+    assert.equal(errors.length, 3);
+    assert.deepEqual(
+      errors.map((error) => error.field),
+      ['items[0].quantity', 'items[1].bookId', 'items[2].quantity']
+    );
+  });
+});
+
+describe('validateItems — duplicate lines', () => {
+  test('collapses the same book appearing twice', () => {
+    const items = validateItems(
+      [
+        { id: 'b1', quantity: 2 },
+        { id: 'b2', quantity: 1 },
+        { id: 'b1', quantity: 3 },
+      ],
+      lookupBook
+    );
+
+    assert.equal(items.length, 2);
+    assert.deepEqual(
+      items.map(({ bookId, quantity }) => ({ bookId, quantity })),
+      [
+        { bookId: 'b1', quantity: 5 },
+        { bookId: 'b2', quantity: 1 },
+      ]
+    );
+  });
+
+  test('applies the per-line cap to the merged quantity', () => {
+    // Two lines of 15 would otherwise slip 30 units past a cap of 20, and
+    // reserve against the same book twice.
+    const errors = expectRejected([
+      { id: 'b1', quantity: 15 },
+      { id: 'b1', quantity: 15 },
+    ]);
+
+    assert.match(errors[0].message, /Total quantity for b1/);
+  });
+});
+
+describe('priceOrder', () => {
+  test('prices a single line exactly', () => {
+    const items = validateItems([{ id: 'b1', quantity: 3 }], lookupBook);
+    const pricing = priceOrder(items);
+
+    assert.equal(pricing.subtotal, 1047);
+    assert.equal(pricing.tax, 52.35); // not 52.35000000000001
+    assert.equal(pricing.shipping, 5.99);
+    assert.equal(pricing.total, 1105.34);
+  });
+
+  test('reports the integer minor units alongside the major ones', () => {
+    const items = validateItems([{ id: 'b1', quantity: 3 }], lookupBook);
+    const { minorUnits } = priceOrder(items);
+
+    assert.deepEqual(minorUnits, {
+      subtotal: 104700,
+      tax: 5235,
+      shipping: 599,
+      total: 110534,
+    });
+  });
+
+  test('the parts always add up to the total', () => {
+    const carts = [
+      [{ id: 'b1', quantity: 1 }],
+      [{ id: 'b2', quantity: 7 }],
+      [
+        { id: 'b1', quantity: 3 },
+        { id: 'b2', quantity: 2 },
+        { id: 'b3', quantity: 1 },
+      ],
+    ];
+
+    for (const cart of carts) {
+      const { minorUnits } = priceOrder(validateItems(cart, lookupBook));
+
+      assert.equal(
+        minorUnits.subtotal + minorUnits.tax + minorUnits.shipping,
+        minorUnits.total,
+        `parts did not sum for ${JSON.stringify(cart)}`
+      );
+    }
+  });
+
+  test('builds the order line from the catalogue, not from the request', () => {
+    // The client sends a price too. It is ignored — that is the whole point
+    // of pricing server-side.
+    const items = validateItems(
+      [{ id: 'b1', quantity: 1, price: 0.01, title: 'Free Book' }],
+      lookupBook
+    );
+    const { orderItems } = priceOrder(items);
+
+    assert.deepEqual(orderItems, [
+      { bookId: 'b1', title: 'The Quiet Ones', price: 349, quantity: 1 },
+    ]);
+  });
+
+  test('a total can never come out negative', () => {
+    // Every route to a negative subtotal is closed at validation, so the
+    // only way to reach one here is a catalogue with a negative price —
+    // which validateItems also rejects.
+    const errors = expectRejected([{ id: 'bad', quantity: 1 }]);
+    assert.ok(errors.length > 0);
+  });
+});
+
+describe('toReservation', () => {
+  test('carries the version each book was read at', () => {
+    const items = validateItems(
+      [
+        { id: 'b1', quantity: 2 },
+        { id: 'b2', quantity: 1 },
+      ],
+      lookupBook
+    );
+
+    assert.deepEqual(toReservation(items), [
+      { bookId: 'b1', quantity: 2, expectedVersion: 2 },
+      { bookId: 'b2', quantity: 1, expectedVersion: 1 },
+    ]);
+  });
+
+  test('reserves one line per book after duplicates are merged', () => {
+    const items = validateItems(
+      [
+        { id: 'b1', quantity: 2 },
+        { id: 'b1', quantity: 1 },
+      ],
+      lookupBook
+    );
+
+    const reservation = toReservation(items);
+
+    assert.equal(reservation.length, 1);
+    assert.equal(reservation[0].quantity, 3);
+  });
+});
+
+describe('prepareCheckout', () => {
+  test('returns everything the controller needs in one call', () => {
+    const result = prepareCheckout([{ id: 'b1', quantity: 2 }], lookupBook);
+
+    assert.equal(result.total, 738.89);
+    assert.equal(result.orderItems.length, 1);
+    assert.deepEqual(result.reservation, [
+      { bookId: 'b1', quantity: 2, expectedVersion: 2 },
+    ]);
+  });
+
+  test('surfaces validation failures as a 400-shaped error', () => {
+    assert.throws(
+      () => prepareCheckout([{ id: 'b1', quantity: -5 }], lookupBook),
+      (error) => error instanceof CheckoutValidationError && error.status === 400
+    );
+  });
+
+  test('prices a book that is out of stock — reserving is a later step', () => {
+    // b3 has an inventory of 0. Validation is about the request being
+    // well-formed; whether the stock is there is the repository's call, and
+    // it answers 409.
+    const result = prepareCheckout([{ id: 'b3', quantity: 1 }], lookupBook);
+    assert.equal(result.subtotal, 399);
+  });
+});

--- a/bookshelf-backend/tests/money.test.js
+++ b/bookshelf-backend/tests/money.test.js
@@ -1,0 +1,198 @@
+import test, { describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  MAX_MINOR_UNITS,
+  MoneyError,
+  applyRate,
+  format,
+  multiply,
+  sum,
+  toMajorUnits,
+  toMinorUnits,
+} from '../utils/money.js';
+
+describe('toMinorUnits', () => {
+  test('converts whole major units exactly', () => {
+    assert.equal(toMinorUnits(349), 34900);
+    assert.equal(toMinorUnits(0), 0);
+  });
+
+  test('rounds to the nearest minor unit', () => {
+    assert.equal(toMinorUnits(5.99), 599);
+    assert.equal(toMinorUnits(19.995), 2000);
+    assert.equal(toMinorUnits(0.005), 1);
+  });
+
+  test('handles values that float multiplication gets wrong', () => {
+    // 1.005 * 100 is 100.49999999999999 in binary floating point. Rounding
+    // here is what stops that leaking into a total.
+    assert.equal(toMinorUnits(1.1), 110);
+    assert.equal(toMinorUnits(2.675), 268);
+  });
+
+  test('rejects anything that is not a finite non-negative number', () => {
+    assert.throws(() => toMinorUnits(-1), MoneyError);
+    assert.throws(() => toMinorUnits(NaN), MoneyError);
+    assert.throws(() => toMinorUnits(Infinity), MoneyError);
+    assert.throws(() => toMinorUnits('349'), MoneyError);
+    assert.throws(() => toMinorUnits(undefined), MoneyError);
+  });
+});
+
+describe('toMajorUnits', () => {
+  test('round-trips with toMinorUnits', () => {
+    for (const amount of [0, 5.99, 349, 1047.35, 0.01]) {
+      assert.equal(toMajorUnits(toMinorUnits(amount)), amount);
+    }
+  });
+
+  test('rejects a non-integer minor amount', () => {
+    assert.throws(() => toMajorUnits(52.35), MoneyError);
+  });
+});
+
+describe('multiply', () => {
+  test('is exact for the catalogue prices', () => {
+    assert.equal(multiply(34900, 3), 104700);
+  });
+
+  test('allows a zero quantity', () => {
+    assert.equal(multiply(34900, 0), 0);
+  });
+
+  test('rejects a negative or fractional quantity', () => {
+    assert.throws(() => multiply(34900, -5), MoneyError);
+    assert.throws(() => multiply(34900, 1.5), MoneyError);
+  });
+
+  test('refuses to build an amount beyond the ceiling', () => {
+    assert.throws(() => multiply(34900, 1e9), MoneyError);
+  });
+});
+
+describe('sum', () => {
+  test('adds minor amounts exactly', () => {
+    assert.equal(sum([104700, 5235, 599]), 110534);
+  });
+
+  test('is zero for an empty list', () => {
+    assert.equal(sum([]), 0);
+  });
+
+  test('rejects a non-integer member', () => {
+    assert.throws(() => sum([100, 52.35]), MoneyError);
+  });
+
+  test('refuses to exceed the ceiling', () => {
+    assert.throws(() => sum([MAX_MINOR_UNITS, 1]), MoneyError);
+  });
+});
+
+describe('applyRate', () => {
+  test('computes 5% tax as an integer', () => {
+    // The float version of this produced 52.35000000000001.
+    assert.equal(applyRate(104700, 0.05), 5235);
+  });
+
+  test('rounds half up', () => {
+    assert.equal(applyRate(101, 0.05), 5); // 5.05 -> 5
+    assert.equal(applyRate(110, 0.05), 6); // 5.5  -> 6
+  });
+
+  test('is zero for a zero rate or a zero amount', () => {
+    assert.equal(applyRate(104700, 0), 0);
+    assert.equal(applyRate(0, 0.05), 0);
+  });
+
+  test('rejects a negative or non-numeric rate', () => {
+    assert.throws(() => applyRate(100, -0.05), MoneyError);
+    assert.throws(() => applyRate(100, '5%'), MoneyError);
+  });
+});
+
+describe('format', () => {
+  test('renders two decimal places', () => {
+    assert.equal(format(110534), '1105.34');
+    assert.equal(format(0), '0.00');
+    assert.equal(format(5), '0.05');
+  });
+});
+
+/**
+ * The arithmetic the old controller got wrong.
+ *
+ * With the whole-number prices currently in books.json the float version
+ * happens to land on the right answer, which is exactly why this went
+ * unnoticed. It stops being true the moment a price has decimals — and the
+ * checkout page in the frontend already posts 19.99.
+ */
+describe('the arithmetic the old controller got wrong', () => {
+  /** What paymentController.js used to do. */
+  function priceWithFloats(price, quantity) {
+    const subtotal = price * quantity;
+    const tax = subtotal * 0.05;
+    const total = subtotal + tax + 5.99;
+    return { subtotal, tax, total };
+  }
+
+  /** What it does now. */
+  function priceWithIntegers(price, quantity) {
+    const subtotal = multiply(toMinorUnits(price), quantity);
+    const tax = applyRate(subtotal, 0.05);
+    const total = sum([subtotal, tax, toMinorUnits(5.99)]);
+    return { subtotal, tax, total };
+  }
+
+  test('binary drift undercharges by a cent at 12.95 x 6', () => {
+    const floats = priceWithFloats(12.95, 6);
+    const integers = priceWithIntegers(12.95, 6);
+
+    // The subtotal is not even 77.70.
+    assert.equal(floats.subtotal, 77.69999999999999);
+
+    // stripeService charges Math.round(amount * 100).
+    assert.equal(Math.round(floats.total * 100), 8757);
+    assert.equal(integers.total, 8758);
+  });
+
+  test('and at 7.35 x 2 and 13.45 x 6', () => {
+    assert.equal(Math.round(priceWithFloats(7.35, 2).total * 100), 2142);
+    assert.equal(priceWithIntegers(7.35, 2).total, 2143);
+
+    assert.equal(Math.round(priceWithFloats(13.45, 6).total * 100), 9072);
+    assert.equal(priceWithIntegers(13.45, 6).total, 9073);
+  });
+
+  test('a float total can hold a fraction of a cent, which nothing can charge', () => {
+    const floats = priceWithFloats(19.99, 3);
+
+    // This is what was written to the order document.
+    assert.equal(floats.tax, 2.9985);
+    assert.equal(floats.total, 68.9585);
+
+    // Stripe rounds, so the order says one thing and the customer is
+    // charged another.
+    assert.equal(Math.round(floats.total * 100) / 100, 68.96);
+
+    const integers = priceWithIntegers(19.99, 3);
+    assert.equal(integers.total, 6896);
+    assert.equal(toMajorUnits(integers.total), 68.96);
+  });
+
+  test('the value handed to Stripe survives its own *100 round trip', () => {
+    // stripeService does Math.round(amount * 100). Because the number given
+    // to it came from an integer, this is exact rather than approximate —
+    // for every cart shape, not just the convenient ones.
+    for (const [price, quantity] of [
+      [349, 3],
+      [12.95, 6],
+      [19.99, 3],
+      [7.35, 2],
+      [0.01, 1],
+    ]) {
+      const { total } = priceWithIntegers(price, quantity);
+      assert.equal(Math.round(toMajorUnits(total) * 100), total);
+    }
+  });
+});

--- a/bookshelf-backend/utils/checkout.js
+++ b/bookshelf-backend/utils/checkout.js
@@ -1,0 +1,307 @@
+/**
+ * Checkout validation and pricing.
+ *
+ * Pure functions over a plain cart and a lookup of the catalogue, so the
+ * rules that decide what a customer is charged can be tested without Stripe,
+ * without MongoDB and without an HTTP server.
+ *
+ * The bug this replaces: `createIntent` read `items` straight off the request
+ * body and used `item.quantity` unchecked. A quantity of -5 passed the stock
+ * check (`8 < -5` is false), *increased* the inventory in books.json by five,
+ * and produced an order with a negative total. See #297.
+ */
+
+import {
+  MoneyError,
+  applyRate,
+  multiply,
+  sum,
+  toMajorUnits,
+  toMinorUnits,
+} from './money.js';
+
+/** 5% mock tax, as before. Kept here so the number has one home. */
+export const TAX_RATE = 0.05;
+
+/** Flat shipping, in major units, as before. */
+export const SHIPPING_MAJOR_UNITS = 5.99;
+
+/**
+ * Bounds. None of these are business rules — they are the limits past which a
+ * request stops being a plausible cart and starts being someone probing the
+ * endpoint. A public, unauthenticated route needs all of them.
+ */
+export const MAX_LINE_ITEMS = 50;
+export const MAX_QUANTITY_PER_LINE = 20;
+
+export class CheckoutValidationError extends Error {
+  constructor(errors) {
+    const summary = errors.map((error) => error.message).join('; ');
+    super(`Invalid checkout request: ${summary}`);
+
+    this.name = 'CheckoutValidationError';
+    this.status = 400;
+    this.errors = errors;
+  }
+}
+
+function fieldError(field, message) {
+  return { field, message };
+}
+
+/**
+ * Validate the raw `items` array and normalise it.
+ *
+ * Collects every problem rather than stopping at the first, so a broken
+ * client gets one useful response instead of a sequence of them.
+ *
+ * `lookupBook` is passed in rather than imported so this module has no
+ * dependency on the repository, and so a test can describe a catalogue in
+ * three lines.
+ */
+export function validateItems(rawItems, lookupBook) {
+  const errors = [];
+
+  if (rawItems === undefined || rawItems === null) {
+    throw new CheckoutValidationError([
+      fieldError('items', 'items is required'),
+    ]);
+  }
+
+  if (!Array.isArray(rawItems)) {
+    throw new CheckoutValidationError([
+      fieldError('items', 'items must be an array'),
+    ]);
+  }
+
+  if (rawItems.length === 0) {
+    throw new CheckoutValidationError([
+      fieldError('items', 'items must contain at least one entry'),
+    ]);
+  }
+
+  if (rawItems.length > MAX_LINE_ITEMS) {
+    throw new CheckoutValidationError([
+      fieldError(
+        'items',
+        `items must contain at most ${MAX_LINE_ITEMS} entries, received ${rawItems.length}`
+      ),
+    ]);
+  }
+
+  const normalised = [];
+  // A cart with the same book on two lines is not malicious, but it has to be
+  // collapsed before the stock check — otherwise two lines of 5 each pass
+  // against an inventory of 8 and oversell by two.
+  const seen = new Map();
+
+  rawItems.forEach((item, index) => {
+    const field = `items[${index}]`;
+
+    if (item === null || typeof item !== 'object' || Array.isArray(item)) {
+      errors.push(fieldError(field, `${field} must be an object`));
+      return;
+    }
+
+    // The frontend has sent both shapes over time. Accept either, but require
+    // exactly one usable id.
+    const rawBookId = item.bookId ?? item.id;
+
+    if (typeof rawBookId !== 'string' || rawBookId.trim() === '') {
+      errors.push(
+        fieldError(`${field}.bookId`, `${field}.bookId must be a non-empty string`)
+      );
+      return;
+    }
+
+    const bookId = rawBookId.trim();
+    const quantity = item.quantity;
+
+    if (typeof quantity !== 'number' || !Number.isFinite(quantity)) {
+      errors.push(
+        fieldError(
+          `${field}.quantity`,
+          `${field}.quantity must be a number, received ${describe(quantity)}`
+        )
+      );
+      return;
+    }
+
+    if (!Number.isInteger(quantity)) {
+      errors.push(
+        fieldError(
+          `${field}.quantity`,
+          `${field}.quantity must be a whole number, received ${quantity}`
+        )
+      );
+      return;
+    }
+
+    // The one that mattered. A negative quantity used to add stock.
+    if (quantity < 1) {
+      errors.push(
+        fieldError(
+          `${field}.quantity`,
+          `${field}.quantity must be at least 1, received ${quantity}`
+        )
+      );
+      return;
+    }
+
+    if (quantity > MAX_QUANTITY_PER_LINE) {
+      errors.push(
+        fieldError(
+          `${field}.quantity`,
+          `${field}.quantity must be at most ${MAX_QUANTITY_PER_LINE}, received ${quantity}`
+        )
+      );
+      return;
+    }
+
+    const book = lookupBook(bookId);
+
+    if (!book) {
+      errors.push(
+        fieldError(`${field}.bookId`, `Book not found: ${bookId}`)
+      );
+      return;
+    }
+
+    if (typeof book.price !== 'number' || !Number.isFinite(book.price) || book.price < 0) {
+      // A catalogue problem, not a client one, but it must not become a
+      // NaN total silently charged to somebody.
+      errors.push(
+        fieldError(`${field}.bookId`, `Book ${bookId} has no usable price`)
+      );
+      return;
+    }
+
+    const existing = seen.get(bookId);
+
+    if (existing) {
+      const merged = existing.quantity + quantity;
+
+      if (merged > MAX_QUANTITY_PER_LINE) {
+        errors.push(
+          fieldError(
+            `${field}.quantity`,
+            `Total quantity for ${bookId} must be at most ${MAX_QUANTITY_PER_LINE}, received ${merged}`
+          )
+        );
+        return;
+      }
+
+      existing.quantity = merged;
+      return;
+    }
+
+    const entry = { bookId, quantity, book };
+    seen.set(bookId, entry);
+    normalised.push(entry);
+  });
+
+  if (errors.length > 0) {
+    throw new CheckoutValidationError(errors);
+  }
+
+  return normalised;
+}
+
+function describe(value) {
+  if (value === undefined) return 'undefined';
+  if (value === null) return 'null';
+  if (Number.isNaN(value)) return 'NaN';
+  return `${typeof value} ${JSON.stringify(value)}`;
+}
+
+/**
+ * Price a validated cart.
+ *
+ * Returns both the minor-unit integers (what the arithmetic ran on) and the
+ * major-unit numbers (what goes on the order document and to Stripe), so a
+ * caller never has to divide by 100 itself and get it subtly wrong.
+ */
+export function priceOrder(items, { taxRate = TAX_RATE, shipping = SHIPPING_MAJOR_UNITS } = {}) {
+  const orderItems = [];
+  const lineTotals = [];
+
+  for (const { bookId, quantity, book } of items) {
+    const unitMinor = toMinorUnits(book.price);
+    const lineMinor = multiply(unitMinor, quantity);
+
+    lineTotals.push(lineMinor);
+
+    orderItems.push({
+      bookId: book.id ?? bookId,
+      title: book.title,
+      price: toMajorUnits(unitMinor),
+      quantity,
+    });
+  }
+
+  const subtotalMinor = sum(lineTotals);
+  const taxMinor = applyRate(subtotalMinor, taxRate);
+  const shippingMinor = toMinorUnits(shipping);
+  const totalMinor = sum([subtotalMinor, taxMinor, shippingMinor]);
+
+  return {
+    orderItems,
+    minorUnits: {
+      subtotal: subtotalMinor,
+      tax: taxMinor,
+      shipping: shippingMinor,
+      total: totalMinor,
+    },
+    subtotal: toMajorUnits(subtotalMinor),
+    tax: toMajorUnits(taxMinor),
+    shipping: toMajorUnits(shippingMinor),
+    total: toMajorUnits(totalMinor),
+  };
+}
+
+/**
+ * The reservation instruction for the repository: which books, how many, and
+ * the version each was read at, so an interleaved checkout is caught.
+ */
+export function toReservation(items) {
+  return items.map(({ bookId, quantity, book }) => ({
+    bookId,
+    quantity,
+    expectedVersion: book.__v,
+  }));
+}
+
+/**
+ * Validate and price in one call — the whole decision a checkout has to make
+ * before it touches inventory, Stripe or the database.
+ */
+export function prepareCheckout(rawItems, lookupBook, options) {
+  const items = validateItems(rawItems, lookupBook);
+
+  let pricing;
+  try {
+    pricing = priceOrder(items, options);
+  } catch (error) {
+    // The bounds in money.js are the last line of defence. Reaching one means
+    // a request got past validateItems that should not have, so report it as
+    // the client error it is rather than as a 500.
+    if (error instanceof MoneyError) {
+      throw new CheckoutValidationError([fieldError('items', error.message)]);
+    }
+    throw error;
+  }
+
+  return { items, reservation: toReservation(items), ...pricing };
+}
+
+export default {
+  TAX_RATE,
+  SHIPPING_MAJOR_UNITS,
+  MAX_LINE_ITEMS,
+  MAX_QUANTITY_PER_LINE,
+  CheckoutValidationError,
+  validateItems,
+  priceOrder,
+  toReservation,
+  prepareCheckout,
+};

--- a/bookshelf-backend/utils/money.js
+++ b/bookshelf-backend/utils/money.js
@@ -1,0 +1,149 @@
+/**
+ * Money arithmetic, in integer minor units.
+ *
+ * The checkout totals were computed with floating point:
+ *
+ *     subtotal += bookRecord.price * item.quantity;
+ *     const tax = subtotal * 0.05;
+ *     const total = subtotal + tax + shipping;
+ *
+ * Three books at 349 gives a subtotal of 1047 and a tax of
+ * 52.35000000000001. That value was stored on the order document and handed
+ * to Stripe, which multiplies by 100 and rounds — so the amount charged and
+ * the amount recorded could differ by a cent, and no amount of staring at
+ * either number would explain why.
+ *
+ * Everything here is an integer number of the currency's smallest unit.
+ * Rounding happens once, deliberately, at the points marked below.
+ */
+
+/** Minor units per major unit. Two decimal places, as for USD and INR. */
+export const MINOR_UNITS_PER_MAJOR = 100;
+
+/**
+ * The largest total we are willing to construct. Not a business rule — a
+ * guard so a malformed request cannot drive the arithmetic into a region
+ * where an integer stops being exact. Well below Number.MAX_SAFE_INTEGER.
+ */
+export const MAX_MINOR_UNITS = 1_000_000_000; // ten million major units
+
+export class MoneyError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'MoneyError';
+  }
+}
+
+/**
+ * Convert a major-unit amount (what books.json stores) to minor units.
+ *
+ * This is the only place a price crosses from decimal to integer, and the
+ * only rounding on the way in.
+ */
+export function toMinorUnits(amount) {
+  if (typeof amount !== 'number' || !Number.isFinite(amount)) {
+    throw new MoneyError(`Amount must be a finite number, received ${amount}`);
+  }
+
+  if (amount < 0) {
+    throw new MoneyError(`Amount must not be negative, received ${amount}`);
+  }
+
+  return Math.round(amount * MINOR_UNITS_PER_MAJOR);
+}
+
+/**
+ * Convert back to major units for display, for storage on the order, and for
+ * the Stripe service — which takes a major-unit amount and does its own
+ * `Math.round(amount * 100)`. Because the value handed over came from an
+ * integer, that round-trip is exact rather than approximate.
+ */
+export function toMajorUnits(minorUnits) {
+  assertMinorUnits(minorUnits);
+  return minorUnits / MINOR_UNITS_PER_MAJOR;
+}
+
+function assertMinorUnits(value) {
+  if (!Number.isSafeInteger(value)) {
+    throw new MoneyError(
+      `Minor-unit amounts must be safe integers, received ${value}`
+    );
+  }
+}
+
+/**
+ * Multiply a unit price by a quantity.
+ *
+ * Both are integers, so this is exact — but the product can still overflow
+ * the ceiling above if a request asks for an absurd quantity, which is
+ * exactly what an attacker probing the endpoint would try.
+ */
+export function multiply(unitMinorUnits, quantity) {
+  assertMinorUnits(unitMinorUnits);
+
+  if (!Number.isSafeInteger(quantity) || quantity < 0) {
+    throw new MoneyError(
+      `Quantity must be a non-negative integer, received ${quantity}`
+    );
+  }
+
+  const product = unitMinorUnits * quantity;
+  assertWithinCeiling(product);
+
+  return product;
+}
+
+export function sum(amounts) {
+  let total = 0;
+
+  for (const amount of amounts) {
+    assertMinorUnits(amount);
+    total += amount;
+    assertWithinCeiling(total);
+  }
+
+  return total;
+}
+
+function assertWithinCeiling(value) {
+  if (value > MAX_MINOR_UNITS) {
+    throw new MoneyError(
+      `Amount ${value} exceeds the maximum of ${MAX_MINOR_UNITS} minor units`
+    );
+  }
+}
+
+/**
+ * Apply a rate (0.05 for 5% tax) and round half up to the nearest minor unit.
+ *
+ * Half-up is what a customer expects and what most tax authorities specify.
+ * `Math.round` in JavaScript rounds half *away from zero* for positives,
+ * which is the same thing here because the input is never negative — the
+ * guards above see to that.
+ */
+export function applyRate(minorUnits, rate) {
+  assertMinorUnits(minorUnits);
+
+  if (typeof rate !== 'number' || !Number.isFinite(rate) || rate < 0) {
+    throw new MoneyError(`Rate must be a non-negative number, received ${rate}`);
+  }
+
+  return Math.round(minorUnits * rate);
+}
+
+/** Formats for a log line or an error message. Not for the UI. */
+export function format(minorUnits) {
+  return (minorUnits / MINOR_UNITS_PER_MAJOR).toFixed(2);
+}
+
+export default {
+  MINOR_UNITS_PER_MAJOR,
+  MAX_MINOR_UNITS,
+  MoneyError,
+  toMinorUnits,
+  toMajorUnits,
+  multiply,
+  sum,
+  applyRate,
+  format,
+};


### PR DESCRIPTION
Closes #297.

## The bug

`POST /api/payments/create-intent` is deliberately unauthenticated (`// Allow guests to checkout for now`) and read `items` straight off the request body. `item.quantity` was never checked.

**A negative quantity mints inventory.** The stock guard is `book.inventory < item.quantity`, which `8 < -5` fails to trip. The mutation phase then runs:

```js
books[index].inventory -= quantity;   // 8 - (-5) = 13
```

and writes `data/books.json` back to disk. The same request builds `subtotal += 349 * -5` and persists an order with a total of `-1826.7`.

Reproduced against `main` in a scratch copy of the repository:

```
MAIN b1 before: 8
MAIN b1 after quantity=-5: 13 (stock minted: true)
```

**A missing `items` is a 500.** `for (const item of undefined)` throws a `TypeError` that reaches the generic error handler.

**Stock is reserved before payment and never returned.** The order is: reserve → create Stripe intent → save. If `createPaymentIntent` throws — bad key, Stripe down, network — the handler falls into `catch` and calls `next(error)`. The decrement is already on disk and nothing reverses it. Every failed checkout permanently destroys stock.

## The fix

### `utils/checkout.js` (new)

Validation and pricing as pure functions over a cart and an injected `lookupBook`. No Stripe, no MongoDB, no HTTP server — which is exactly why none of this was under test before.

- Collects **every** field error rather than stopping at the first, so a broken client gets one useful 400 instead of a sequence of them.
- Bounds line count (50) and per-line quantity (20). Neither is a business rule; they are the limits past which a request stops being a plausible cart. A public endpoint needs them.
- **Merges duplicate lines before the stock check.** Two lines of 5 for the same book would otherwise both pass against an inventory of 8 and oversell by two. This was latent in the original too.
- Order lines are built from the catalogue, never from the request — the client sends a `price` and it is ignored.

### `utils/money.js` (new)

Integer minor units, with rounding at two marked points.

Worth being precise about the motivation, because the obvious example does not actually fail: with the whole-number prices currently in `books.json`, `349 × 3` gives a subtotal of `1047` and a tax of exactly `52.35`. The float arithmetic is right, which is why this went unnoticed. It stops being right as soon as a price has decimals:

| cart | float total | charged | correct |
|---|---|---|---|
| 12.95 × 6 | `87.57499999999999` | 8757 | **8758** |
| 7.35 × 2 | `21.424999999999997` | 2142 | **2143** |
| 13.45 × 6 | `90.72499999999998` | 9072 | **9073** |

And `19.99 × 3` — the exact cart `pages/Checkout.jsx` posts today — produces a tax of `2.9985` and a total of `68.9585`. That fraction-of-a-cent value is written to the order document, while Stripe rounds and charges `68.96`. The order and the charge disagree, and no amount of staring at either number explains why.

`stripeService.createPaymentIntent` still takes a major-unit amount and does its own `Math.round(amount * 100)`; because the number handed to it now comes from an integer, that round trip is exact. No change to the service.

### `repositories/bookRepository.js`

- `updateInventoryWithOCC` refuses a non-positive quantity itself. The controller validates its input now, but a repository that can be talked into minting stock should not be one refactor away from being reachable again.
- `restoreInventory` (new) is the release counterpart. It is deliberately **not** version-checked: it compensates for a reservation that already happened, and refusing to run because someone else bought a copy in between would leave the units lost, which is the outcome it exists to prevent. It never throws — callers reach it from an error path and must not lose the original error to a secondary failure — and returns `{ restored, failed }` instead.
- Insufficient stock is now **409** rather than 400. It is a conflict with current state, not a malformed request.

### `controllers/paymentController.js`

Rewritten around an explicit order of operations, each step commented with why it is where it is. Validate and price first (a request that fails here has touched nothing), then reserve, then create the order and the intent — with every failure from the reservation onward releasing it. If the payment intent fails the order is also marked `payment_failed` rather than being left at `pending` forever with no intent attached.

Reservation ownership hands over to the webhook once the intent exists; `payment_intent.payment_failed` and `payment_intent.canceled` are where it is released from there. **That handover is not implemented in this PR** — see below.

## Tests

`tests/checkout.test.js` (36 cases) and `tests/money.test.js` (26 cases), no database and no network.

Directly on the report:

- `rejects a negative quantity` / `rejects a zero quantity` / `rejects a fractional quantity`
- `rejects a missing items array instead of throwing a TypeError`
- `applies the per-line cap to the merged quantity` — the oversell via duplicate lines
- `binary drift undercharges by a cent at 12.95 x 6`
- `a float total can hold a fraction of a cent, which nothing can charge`
- `the parts always add up to the total`, across several cart shapes

```
# tests 149
# pass 149
# fail 0
```

(121 before this branch, 98 on main.)

## Verified by hand

Against the real `data/books.json`, restored afterwards:

```
b1 before: 8 v2
negative qty rejected -> 400 [{"field":"items[0].quantity","message":"...must be at least 1, received -5"}]
repository refused    -> 400 Quantity for book b1 must be a positive integer, received -5.
missing items         -> 400 items is required
priced: 698 34.9 5.99 738.89
after reserve: 6 v3
after release: 8 v4   {"restored":[{"bookId":"b1","quantity":2}],"failed":[]}
inventory restored: true
```

## Notes for review

- **Not fixed here, and it should be a follow-up issue:** the webhook does not release the reservation on `payment_intent.payment_failed` or `payment_intent.canceled`. A customer who abandons a card entry still holds the stock indefinitely. Doing it properly needs the order to record whether its reservation is still held, so it is a bigger change than belongs in this PR — happy to open it separately.
- `couponCode` was destructured from the body and never used. Dropped; nothing read it.
- The response now includes an `amount` breakdown so the client can display the same numbers the server charged instead of recomputing them.
- The `MAX_LINE_ITEMS` and `MAX_QUANTITY_PER_LINE` values are a judgement call. Say the word if the shop wants different limits.