### PR TITLE
fix(backend): stop one attacker locking every user out of login (closes #298)

### DIFF
--- a/bookshelf-backend/.env.example
+++ b/bookshelf-backend/.env.example
@@ -23,6 +23,21 @@ NODE_ENV=development
 # and credentials are sent, so it cannot be "*".
 FRONTEND_URL=http://localhost:5173
 
+# How many reverse proxies sit in front of this app.
+#
+# Leave unset locally. Set it in any deployment behind nginx, a load balancer,
+# or a platform like Render / Railway / Fly / Heroku — otherwise req.ip is the
+# proxy's own address on every request and the login rate limit applies to all
+# users at once instead of per user.
+#
+# Use the number of proxies (usually 1). Do NOT use "true": that trusts the
+# whole X-Forwarded-For header, which the client controls, so an attacker can
+# forge a fresh IP per request and walk straight past the limiter.
+#
+# Also accepts "loopback", "linklocal", "uniquelocal", or a comma-separated
+# list of addresses and subnets.
+# TRUST_PROXY=1
+
 # Stripe. The webhook secret comes from the Stripe dashboard, or from
 # `stripe listen` when testing locally.
 STRIPE_SECRET_KEY=sk_test_your_key_here

--- a/bookshelf-backend/app.js
+++ b/bookshelf-backend/app.js
@@ -8,8 +8,17 @@ import orderRoutes from './routes/orderRoutes.js';
 import wishlistRoutes from './routes/wishlistRoutes.js';
 import bookRoutes from './routes/books.js';
 import stripeWebhookHandler from './webhook/stripeWebhook.js';
+import { configureTrustProxy } from './config/trustProxy.js';
 
 const app = express();
+
+/*
+ * Must run before anything reads req.ip — which the rate limiters on
+ * /api/auth do. Without it, req.ip behind a proxy is the proxy's own address
+ * on every request, so a per-IP limit applied to every user at once.
+ * Defaults to trusting nothing, which is correct for a local run. See #298.
+ */
+configureTrustProxy(app);
 
 app.use(cors({
   origin: process.env.FRONTEND_URL || 'http://localhost:5173',

--- a/bookshelf-backend/config/trustProxy.js
+++ b/bookshelf-backend/config/trustProxy.js
@@ -1,0 +1,130 @@
+/**
+ * How much of X-Forwarded-For to believe.
+ *
+ * Express derives `req.ip` from the socket unless `trust proxy` is set, in
+ * which case it walks X-Forwarded-For instead. That setting was never
+ * configured, so behind a reverse proxy — which is every real deployment —
+ * `req.ip` was the proxy's own address, identical for every visitor. The
+ * login rate limiter keys on `req.ip`, so every user in the world shared one
+ * bucket: ten bad passwords from one script held the login endpoint at 429
+ * for everybody. See #298.
+ *
+ * The naive fix is `app.set('trust proxy', true)`, and it is worse than the
+ * bug. X-Forwarded-For is a client-supplied header. Trusting all of it means
+ * an attacker sends a different value on every request, gets a fresh
+ * identity each time and bypasses the limiter entirely — while a
+ * well-behaved user still shares a bucket with their whole office.
+ *
+ * The safe form is a hop count. `trust proxy = 1` tells Express to take the
+ * entry one from the *end* of the chain, which the outermost proxy appended
+ * and the client cannot control. Set it to the number of proxies actually in
+ * front of this app.
+ *
+ * Accepted values for TRUST_PROXY:
+ *
+ *   unset / "false" / "0" / "off"  trust nothing (default — correct locally)
+ *   "1", "2", ...                  number of trusted hops (what you want)
+ *   "loopback" | "linklocal" |     Express's named ranges
+ *     "uniquelocal"
+ *   "10.0.0.0/8, 192.168.0.1"      explicit addresses or subnets
+ *   "true" / "on"                  trust the whole header (unsafe — warns)
+ */
+
+const FALSEY = new Set(['', 'false', '0', 'off', 'no']);
+const TRUTHY = new Set(['true', 'on', 'yes']);
+const NAMED_RANGES = new Set(['loopback', 'linklocal', 'uniquelocal']);
+
+/**
+ * Turn the raw env value into something `app.set('trust proxy', ...)` accepts.
+ *
+ * Returns `{ value, warning }`. The warning is a string a caller should log,
+ * or null. Parsing never throws: refusing to boot over a proxy setting would
+ * be a worse outcome than booting with the safe default and saying so.
+ */
+export function parseTrustProxy(raw) {
+  if (raw === undefined || raw === null) {
+    return { value: false, warning: null };
+  }
+
+  const normalised = String(raw).trim().toLowerCase();
+
+  if (FALSEY.has(normalised)) {
+    return { value: false, warning: null };
+  }
+
+  if (TRUTHY.has(normalised)) {
+    return {
+      value: true,
+      warning:
+        'TRUST_PROXY=true trusts the whole X-Forwarded-For header, which the ' +
+        'client controls. Anyone can then forge a fresh IP per request and ' +
+        'walk past the rate limiter. Set it to the number of proxies in ' +
+        'front of this app instead (usually TRUST_PROXY=1).',
+    };
+  }
+
+  // A hop count. The safe answer, so it is checked before the list form —
+  // otherwise "1" would be read as an IP address.
+  if (/^\d+$/.test(normalised)) {
+    const hops = Number.parseInt(normalised, 10);
+
+    if (hops === 0) {
+      return { value: false, warning: null };
+    }
+
+    return { value: hops, warning: null };
+  }
+
+  if (NAMED_RANGES.has(normalised)) {
+    return { value: normalised, warning: null };
+  }
+
+  // A comma-separated list of addresses, subnets or named ranges. Express
+  // parses these itself; passing the original casing through because IPv6
+  // literals are conventionally lowercase but hostnames are not ours to
+  // normalise.
+  const entries = String(raw)
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  if (entries.length > 0) {
+    return { value: entries.join(', '), warning: null };
+  }
+
+  return {
+    value: false,
+    warning: `TRUST_PROXY value "${raw}" was not understood. Trusting no proxy.`,
+  };
+}
+
+/**
+ * Apply the setting to an Express app and report what happened.
+ *
+ * The production warning is the one that matters: a deployment on Render,
+ * Railway, Fly, Heroku or behind nginx with TRUST_PROXY unset is almost
+ * certainly suffering the shared-bucket bug, and nothing else in the system
+ * will tell anyone.
+ */
+export function configureTrustProxy(app, env = process.env) {
+  const { value, warning } = parseTrustProxy(env.TRUST_PROXY);
+
+  app.set('trust proxy', value);
+
+  if (warning) {
+    console.warn(`[config] ${warning}`);
+  }
+
+  if (value === false && env.NODE_ENV === 'production') {
+    console.warn(
+      '[config] NODE_ENV=production with TRUST_PROXY unset. If this app sits ' +
+        'behind a proxy or load balancer, req.ip is the proxy for every ' +
+        'request and per-IP rate limits apply to all users at once. Set ' +
+        'TRUST_PROXY to the number of proxies in front of it.'
+    );
+  }
+
+  return value;
+}
+
+export default { parseTrustProxy, configureTrustProxy };

--- a/bookshelf-backend/middleware/rateLimiter.js
+++ b/bookshelf-backend/middleware/rateLimiter.js
@@ -18,9 +18,45 @@ const DEFAULT_MAX = 10;
  * 'trust proxy' setting is on. Falling back to a constant would put every
  * unidentifiable caller in one shared bucket, which is the safe direction to
  * fail for a limiter.
+ *
+ * This is only as good as the 'trust proxy' setting — see
+ * config/trustProxy.js. With it unset behind a proxy, every request reports
+ * the proxy's address and this returns the same string for everybody.
  */
-function defaultKeyGenerator(req) {
+export function ipKeyGenerator(req) {
   return req.ip || req.socket?.remoteAddress || 'unknown';
+}
+
+const defaultKeyGenerator = ipKeyGenerator;
+
+/**
+ * Key on the IP *and* the account being attempted.
+ *
+ * Keying on the IP alone means one attacker hammering one account exhausts
+ * the budget for every user sharing that address — which, behind a proxy or
+ * a corporate NAT, is all of them. The endpoint being protected is a login,
+ * so the account is the more meaningful half of the identity: it bounds
+ * guesses per account, which is what actually stops a password being
+ * brute-forced, without letting one victim's attacker lock out bystanders.
+ *
+ * The email is normalised the way validators.normaliseEmail does it, because
+ * this middleware runs *before* validateBody — a limiter should not have to
+ * wait on body validation to decide whether to answer 429. Without
+ * normalising, "Alice@Example.com" and "alice@example.com" would each get a
+ * fresh budget and the per-account limit would be trivial to sidestep.
+ *
+ * A request with no usable email falls back to the IP alone. That is the
+ * malformed-request case, and validateBody rejects it a moment later.
+ */
+export function ipAndEmailKeyGenerator(req) {
+  const ip = ipKeyGenerator(req);
+  const rawEmail = req.body?.email;
+
+  if (typeof rawEmail !== 'string' || rawEmail.trim() === '') {
+    return `${ip}|-`;
+  }
+
+  return `${ip}|${rawEmail.trim().toLowerCase()}`;
 }
 
 export function createRateLimiter({
@@ -101,13 +137,43 @@ export function createRateLimiter({
  * Login is the endpoint worth protecting: it returns a fast, distinguishable
  * 401 for a wrong password, so it can be brute-forced as fast as the network
  * allows. Successful logins clear the counter.
+ *
+ * Keyed on address *and* account. Keyed on the address alone — which is what
+ * this did — a single attacker running a loop of bad passwords could hold
+ * the whole endpoint at 429 indefinitely: once the shared counter is over
+ * the limit, `authUser` is never reached, so nobody can produce the success
+ * that would reset it. That is a denial of service on authentication,
+ * delivered through the control added to prevent one. See #298.
  */
 export const loginLimiter = createRateLimiter({
   windowMs: 15 * 60 * 1000,
   max: 10,
   resetOnSuccess: true,
+  keyGenerator: ipAndEmailKeyGenerator,
   message:
-    'Too many login attempts from this address. Please try again in a few minutes.',
+    'Too many login attempts for this account. Please try again in a few minutes.',
+});
+
+/**
+ * A looser ceiling per address, alongside the per-account limit above.
+ *
+ * The per-account limit stops one password being guessed. It does nothing
+ * about credential stuffing — one attempt each against a thousand different
+ * emails never trips it, because every attempt lands in a fresh bucket. This
+ * bounds the total from one address.
+ *
+ * The number has to clear a shared NAT: an office or a school arrives as one
+ * address, and a hundred attempts an hour is generous for real people and
+ * still four orders of magnitude slower than a script wants. It does not
+ * reset on success — the point is the aggregate rate, and a stuffing run
+ * produces successes too.
+ */
+export const loginIpLimiter = createRateLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 100,
+  keyGenerator: ipKeyGenerator,
+  message:
+    'Too many login attempts from this address. Please try again later.',
 });
 
 /**

--- a/bookshelf-backend/routes/authRoutes.js
+++ b/bookshelf-backend/routes/authRoutes.js
@@ -7,7 +7,11 @@ import {
 } from '../controllers/authController.js';
 import { protect } from '../middleware/authMiddleware.js';
 import { validateBody } from '../middleware/validateBody.js';
-import { loginLimiter, registerLimiter } from '../middleware/rateLimiter.js';
+import {
+  loginLimiter,
+  loginIpLimiter,
+  registerLimiter,
+} from '../middleware/rateLimiter.js';
 import { registerSchema, loginSchema } from '../validators/authValidators.js';
 
 const router = express.Router();
@@ -20,7 +24,30 @@ router.post(
   validateBody(registerSchema),
   registerUser
 );
-router.post('/login', loginLimiter, validateBody(loginSchema), authUser);
+
+/*
+ * Login carries two limits, and the order is deliberate.
+ *
+ * loginIpLimiter is the loose per-address ceiling that catches credential
+ * stuffing — one attempt each against a thousand accounts never trips a
+ * per-account limit. loginLimiter is the tight per-account limit that stops
+ * a single password being guessed.
+ *
+ * The per-account one runs second so its X-RateLimit-* headers are the ones
+ * the client sees; it is the limit an ordinary user with a forgotten
+ * password will actually meet.
+ *
+ * Both read req.body.email, which express.json() has already parsed at the
+ * app level. Neither waits on validateBody — a request over the limit should
+ * be answered before anything else is spent on it.
+ */
+router.post(
+  '/login',
+  loginIpLimiter,
+  loginLimiter,
+  validateBody(loginSchema),
+  authUser
+);
 router.post('/logout', logoutUser);
 router.get('/me', protect, getUserProfile);
 

--- a/bookshelf-backend/tests/rateLimiter.test.js
+++ b/bookshelf-backend/tests/rateLimiter.test.js
@@ -1,7 +1,11 @@
 import test, { describe } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { createRateLimiter } from '../middleware/rateLimiter.js';
+import {
+  createRateLimiter,
+  ipKeyGenerator,
+  ipAndEmailKeyGenerator,
+} from '../middleware/rateLimiter.js';
 
 /**
  * A clock the tests drive by hand, so the window can be crossed without
@@ -231,5 +235,191 @@ describe('createRateLimiter', () => {
     limiter.reset();
 
     assert.equal(call(limiter).allowed, true);
+  });
+});
+
+/**
+ * Key derivation.
+ *
+ * The reported bug is not in the counting — it is in what the counter is
+ * keyed on. See #298.
+ */
+describe('ipKeyGenerator', () => {
+  test('uses req.ip when Express has resolved one', () => {
+    assert.equal(ipKeyGenerator({ ip: '203.0.113.7' }), '203.0.113.7');
+  });
+
+  test('falls back to the socket address', () => {
+    assert.equal(
+      ipKeyGenerator({ socket: { remoteAddress: '203.0.113.9' } }),
+      '203.0.113.9'
+    );
+  });
+
+  test('falls back to a shared bucket rather than to no limit', () => {
+    // Unidentifiable callers sharing one bucket is the safe direction for a
+    // limiter to fail.
+    assert.equal(ipKeyGenerator({}), 'unknown');
+  });
+});
+
+describe('ipAndEmailKeyGenerator', () => {
+  const req = (ip, email) => ({ ip, body: email === undefined ? {} : { email } });
+
+  test('combines the address and the account', () => {
+    assert.equal(
+      ipAndEmailKeyGenerator(req('203.0.113.7', 'alice@example.com')),
+      '203.0.113.7|alice@example.com'
+    );
+  });
+
+  test('separates two accounts on the same address', () => {
+    const alice = ipAndEmailKeyGenerator(req('203.0.113.7', 'alice@example.com'));
+    const bob = ipAndEmailKeyGenerator(req('203.0.113.7', 'bob@example.com'));
+
+    assert.notEqual(alice, bob);
+  });
+
+  test('separates the same account on two addresses', () => {
+    const home = ipAndEmailKeyGenerator(req('203.0.113.7', 'alice@example.com'));
+    const cafe = ipAndEmailKeyGenerator(req('198.51.100.4', 'alice@example.com'));
+
+    assert.notEqual(home, cafe);
+  });
+
+  test('normalises the email the way the validators do', () => {
+    // This middleware runs before validateBody, so the email arrives raw.
+    // Without normalising, changing the casing would hand an attacker a
+    // fresh budget on every request.
+    const canonical = ipAndEmailKeyGenerator(req('203.0.113.7', 'alice@example.com'));
+
+    for (const variant of [
+      'ALICE@EXAMPLE.COM',
+      '  Alice@Example.com  ',
+      'aLiCe@ExAmPlE.cOm',
+    ]) {
+      assert.equal(ipAndEmailKeyGenerator(req('203.0.113.7', variant)), canonical, variant);
+    }
+  });
+
+  test('falls back to the address alone when there is no usable email', () => {
+    for (const email of [undefined, '', '   ', null, 42]) {
+      assert.equal(
+        ipAndEmailKeyGenerator(req('203.0.113.7', email)),
+        '203.0.113.7|-'
+      );
+    }
+  });
+
+  test('survives a request with no body at all', () => {
+    assert.equal(ipAndEmailKeyGenerator({ ip: '203.0.113.7' }), '203.0.113.7|-');
+  });
+});
+
+/**
+ * The behaviour the key change buys, expressed against a limiter rather than
+ * against the key function.
+ */
+describe('login limiting behaviour', () => {
+  function callWith(limiter, { ip = '10.0.0.1', email, statusCode = 200 } = {}) {
+    const req = { ip, body: email === undefined ? {} : { email } };
+    const res = makeRes();
+    let nextCalled = false;
+
+    limiter(req, res, () => {
+      nextCalled = true;
+    });
+
+    res.statusCode = nextCalled ? statusCode : res.statusCode;
+    res.finish();
+
+    return { res, allowed: nextCalled };
+  }
+
+  test('exhausting one account does not lock out another on the same address', () => {
+    // Keyed on the address alone — which is what it did — the victim below
+    // gets a 429 having made no requests at all.
+    const limiter = createRateLimiter({
+      max: 3,
+      windowMs: 60_000,
+      keyGenerator: ipAndEmailKeyGenerator,
+    });
+
+    const attacker = { ip: '203.0.113.7', email: 'target@example.com', statusCode: 401 };
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      callWith(limiter, attacker);
+    }
+
+    assert.equal(callWith(limiter, attacker).allowed, false);
+
+    const bystander = callWith(limiter, {
+      ip: '203.0.113.7',
+      email: 'someone-else@example.com',
+    });
+
+    assert.equal(bystander.allowed, true);
+  });
+
+  test('still bounds guesses against a single account', () => {
+    const limiter = createRateLimiter({
+      max: 3,
+      windowMs: 60_000,
+      keyGenerator: ipAndEmailKeyGenerator,
+    });
+
+    const target = { ip: '203.0.113.7', email: 'target@example.com', statusCode: 401 };
+
+    assert.equal(callWith(limiter, target).allowed, true);
+    assert.equal(callWith(limiter, target).allowed, true);
+    assert.equal(callWith(limiter, target).allowed, true);
+    assert.equal(callWith(limiter, target).allowed, false);
+  });
+
+  test('a per-address ceiling still catches a spray across many accounts', () => {
+    // Per-account limits never trip when every attempt is a different
+    // account, so the looser per-IP limiter is what bounds credential
+    // stuffing.
+    const limiter = createRateLimiter({
+      max: 5,
+      windowMs: 60_000,
+      keyGenerator: ipKeyGenerator,
+    });
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const result = callWith(limiter, {
+        ip: '203.0.113.7',
+        email: `victim-${attempt}@example.com`,
+        statusCode: 401,
+      });
+      assert.equal(result.allowed, true, `attempt ${attempt}`);
+    }
+
+    const blocked = callWith(limiter, {
+      ip: '203.0.113.7',
+      email: 'victim-6@example.com',
+    });
+
+    assert.equal(blocked.allowed, false);
+  });
+
+  test('a successful login clears only that account, not the whole address', () => {
+    const limiter = createRateLimiter({
+      max: 2,
+      windowMs: 60_000,
+      resetOnSuccess: true,
+      keyGenerator: ipAndEmailKeyGenerator,
+    });
+
+    const alice = { ip: '203.0.113.7', email: 'alice@example.com' };
+    const bob = { ip: '203.0.113.7', email: 'bob@example.com', statusCode: 401 };
+
+    callWith(limiter, bob);
+    callWith(limiter, bob);
+
+    callWith(limiter, { ...alice, statusCode: 200 }); // succeeds, clears alice
+
+    assert.equal(callWith(limiter, bob).allowed, false);
+    assert.equal(callWith(limiter, alice).allowed, true);
   });
 });

--- a/bookshelf-backend/tests/trustProxy.test.js
+++ b/bookshelf-backend/tests/trustProxy.test.js
@@ -1,0 +1,194 @@
+import test, { describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseTrustProxy, configureTrustProxy } from '../config/trustProxy.js';
+
+/** Minimal Express app double — the setting is all we care about. */
+function makeApp() {
+  const settings = new Map();
+
+  return {
+    set(key, value) {
+      settings.set(key, value);
+    },
+    get(key) {
+      return settings.get(key);
+    },
+  };
+}
+
+/** Captures console.warn for the duration of a call. */
+function captureWarnings(fn) {
+  const original = console.warn;
+  const warnings = [];
+
+  console.warn = (...args) => warnings.push(args.join(' '));
+
+  try {
+    fn();
+  } finally {
+    console.warn = original;
+  }
+
+  return warnings;
+}
+
+describe('parseTrustProxy — the safe default', () => {
+  test('trusts nothing when unset', () => {
+    assert.deepEqual(parseTrustProxy(undefined), { value: false, warning: null });
+    assert.deepEqual(parseTrustProxy(null), { value: false, warning: null });
+  });
+
+  test('trusts nothing for the falsey spellings', () => {
+    for (const raw of ['', 'false', 'FALSE', '0', 'off', 'no', '  false  ']) {
+      assert.equal(parseTrustProxy(raw).value, false, raw);
+    }
+  });
+
+  test('treats 0 hops as trusting nothing', () => {
+    assert.equal(parseTrustProxy('0').value, false);
+  });
+});
+
+describe('parseTrustProxy — hop counts', () => {
+  test('reads a number of hops', () => {
+    assert.equal(parseTrustProxy('1').value, 1);
+    assert.equal(parseTrustProxy('2').value, 2);
+    assert.equal(parseTrustProxy(' 3 ').value, 3);
+  });
+
+  test('accepts a number as well as a string', () => {
+    assert.equal(parseTrustProxy(1).value, 1);
+  });
+
+  test('a hop count is not a warning — it is the recommended setting', () => {
+    assert.equal(parseTrustProxy('1').warning, null);
+  });
+
+  test('reads "1" as a hop count and not as an IP address', () => {
+    // The list branch would happily accept "1" as an address, which Express
+    // would then never match. Order matters.
+    assert.equal(typeof parseTrustProxy('1').value, 'number');
+  });
+});
+
+describe('parseTrustProxy — trusting everything', () => {
+  test('accepts true but warns about it', () => {
+    for (const raw of ['true', 'TRUE', 'on', 'yes']) {
+      const result = parseTrustProxy(raw);
+      assert.equal(result.value, true, raw);
+      assert.match(result.warning, /client controls/);
+    }
+  });
+
+  test('the warning names the safe alternative', () => {
+    assert.match(parseTrustProxy('true').warning, /TRUST_PROXY=1/);
+  });
+});
+
+describe('parseTrustProxy — named ranges and lists', () => {
+  test('passes through the names Express understands', () => {
+    for (const name of ['loopback', 'linklocal', 'uniquelocal']) {
+      assert.equal(parseTrustProxy(name).value, name);
+    }
+  });
+
+  test('normalises a comma-separated list', () => {
+    assert.equal(
+      parseTrustProxy('10.0.0.0/8,  192.168.0.1 , loopback').value,
+      '10.0.0.0/8, 192.168.0.1, loopback'
+    );
+  });
+
+  test('preserves the casing of addresses in a list', () => {
+    // IPv6 literals and hostnames are not ours to lowercase.
+    assert.equal(
+      parseTrustProxy('2001:DB8::1, 10.0.0.1').value,
+      '2001:DB8::1, 10.0.0.1'
+    );
+  });
+
+  test('a single address is still a list', () => {
+    assert.equal(parseTrustProxy('192.168.1.1').value, '192.168.1.1');
+  });
+
+  test('falls back to trusting nothing for an empty list', () => {
+    const result = parseTrustProxy(' , , ');
+    assert.equal(result.value, false);
+    assert.match(result.warning, /not understood/);
+  });
+});
+
+describe('configureTrustProxy', () => {
+  test('applies the setting to the app', () => {
+    const app = makeApp();
+    configureTrustProxy(app, { TRUST_PROXY: '1' });
+
+    assert.equal(app.get('trust proxy'), 1);
+  });
+
+  test('defaults to false with no env', () => {
+    const app = makeApp();
+    configureTrustProxy(app, {});
+
+    assert.equal(app.get('trust proxy'), false);
+  });
+
+  test('returns the value it applied', () => {
+    const app = makeApp();
+    assert.equal(configureTrustProxy(app, { TRUST_PROXY: '2' }), 2);
+  });
+
+  test('warns loudly about production with no setting', () => {
+    // The exact combination that produces the reported bug, and the only
+    // thing in the system that will ever mention it.
+    const warnings = captureWarnings(() =>
+      configureTrustProxy(makeApp(), { NODE_ENV: 'production' })
+    );
+
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /TRUST_PROXY unset/);
+    assert.match(warnings[0], /all users at once/);
+  });
+
+  test('says nothing in production once it is configured', () => {
+    const warnings = captureWarnings(() =>
+      configureTrustProxy(makeApp(), {
+        NODE_ENV: 'production',
+        TRUST_PROXY: '1',
+      })
+    );
+
+    assert.deepEqual(warnings, []);
+  });
+
+  test('says nothing in development with no setting', () => {
+    const warnings = captureWarnings(() =>
+      configureTrustProxy(makeApp(), { NODE_ENV: 'development' })
+    );
+
+    assert.deepEqual(warnings, []);
+  });
+
+  test('warns about TRUST_PROXY=true in any environment', () => {
+    const warnings = captureWarnings(() =>
+      configureTrustProxy(makeApp(), { TRUST_PROXY: 'true' })
+    );
+
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /client controls/);
+  });
+
+  test('never throws on a value it cannot parse', () => {
+    const app = makeApp();
+
+    captureWarnings(() => {
+      assert.doesNotThrow(() =>
+        configureTrustProxy(app, { TRUST_PROXY: '{"nope":true}' })
+      );
+    });
+
+    // Whatever it made of it, the app still booted.
+    assert.ok(app.get('trust proxy') !== undefined);
+  });
+});


### PR DESCRIPTION
Closes #298.

## The bug

`rateLimiter.js` keys on `req.ip`. The comment above the key generator states the assumption:

> Express sets req.ip from the socket, or from X-Forwarded-For when the 'trust proxy' setting is on.

`trust proxy` is never set anywhere in the repo. Behind a reverse proxy — nginx, a load balancer, Render, Railway, Fly, Heroku — `req.ip` is the **proxy's** address, identical for every visitor. So every user in the world shared one bucket.

It is worse than a shared quota, because the limiter is a fixed window with `resetOnSuccess`. Once `entry.count > max`, `authUser` is never reached, so nobody can produce the successful login that would clear the counter. An attacker with a `while true` loop of bad passwords holds `/api/auth/login` at 429 **indefinitely**, from one machine, with no credentials. That is a denial of service on authentication, delivered through the control that was added to prevent one.

## Why the obvious fix is worse than the bug

`app.set('trust proxy', true)` tells Express to believe the whole `X-Forwarded-For` header. That header is written by the client. An attacker sends a different value on every request, gets a fresh identity each time, and bypasses the limiter completely — while a well-behaved office still shares one bucket.

Measured, not asserted. Four failed logins from one client behind a proxy, then one request from an unrelated user, then one request with a forged `X-Forwarded-For`:

```
--- what main does: trust proxy unset, key on IP alone ---
unset + ip key (main)          attacker=429  bystander=429  forged-xff=429
--- naive fix: trust the whole header ---
TRUST_PROXY=true + ip key      attacker=429  bystander=401  forged-xff=401
--- this PR: one hop + ip|email key ---
TRUST_PROXY=1 + ip|email key   attacker=429  bystander=401  forged-xff=429
```

Row 1: the bystander is locked out having made no requests at all.
Row 2: the bystander is fine, but the forged header walks straight past the limiter.
Row 3: both closed.

(Script used is in the PR discussion below if anyone wants to rerun it — it boots a real Express app on an ephemeral port.)

## The fix

### `config/trustProxy.js` (new)

`TRUST_PROXY` is parsed into whatever `app.set('trust proxy', ...)` accepts:

| value | meaning |
|---|---|
| unset / `false` / `0` / `off` | trust nothing — **the default**, and correct locally |
| `1`, `2`, … | number of trusted hops — **what you want** |
| `loopback` / `linklocal` / `uniquelocal` | Express's named ranges |
| `10.0.0.0/8, 192.168.0.1` | explicit addresses or subnets |
| `true` / `on` | trust the whole header — unsafe, warns |

The hop-count form is the safe one: Express counts from the **end** of `X-Forwarded-For`, which the outermost proxy appended and the client cannot control. That is why row 3 above still returns 429 for the forged header.

Parsing never throws — refusing to boot over a proxy setting is a worse outcome than booting safely and saying so. The hop-count branch is checked before the list branch, or `"1"` would be read as an IP address.

Two warnings, because nothing else in the system will ever mention this:

- `NODE_ENV=production` with `TRUST_PROXY` unset — almost certainly the bug above.
- `TRUST_PROXY=true` — names `TRUST_PROXY=1` as the alternative.

### `middleware/rateLimiter.js`

`loginLimiter` now keys on **address and account**. Keying on the address alone means one attacker hammering one account exhausts the budget for everyone sharing that address; behind a proxy or an office NAT, that is everyone. Since the endpoint is a login, the account is the meaningful half: it bounds guesses per account, which is what actually stops a password being brute-forced, without letting one victim's attacker take out bystanders.

The email is normalised (trim + lowercase, matching `validators.normaliseEmail`) **inside the key generator**, because the limiter runs before `validateBody` — a limiter should not wait on body validation to decide whether to answer 429. Without normalising, an attacker varies the casing and gets a fresh budget every request.

`loginIpLimiter` (new) is a looser ceiling per address — 100/hour, no reset on success. The per-account limit never trips on credential stuffing, because one attempt each against a thousand emails lands in a thousand buckets. The number has to clear a shared NAT: generous for real people, four orders of magnitude slower than a script wants.

### `routes/authRoutes.js`

Both limiters on `/login`, IP ceiling first, per-account second so its `X-RateLimit-*` headers are the ones the client sees — that is the limit an ordinary user with a forgotten password will actually meet.

### `.env.example`

`TRUST_PROXY` documented, commented out, with the "do not use `true`" warning.

## Tests

`tests/trustProxy.test.js` (24 cases) and 11 new cases in `tests/rateLimiter.test.js`.

The ones tied to the report:

- `exhausting one account does not lock out another on the same address` — the reported lockout
- `a per-address ceiling still catches a spray across many accounts`
- `a successful login clears only that account, not the whole address`
- `normalises the email the way the validators do`
- `warns loudly about production with no setting`
- `reads "1" as a hop count and not as an IP address`

```
# tests 133
# pass 133
# fail 0
```

(98 on main.)

## Notes for review

- **Nothing changes for a local run.** With `TRUST_PROXY` unset the app trusts no proxy, exactly as today.
- **This does need a deploy-time change.** Whoever owns the deployment has to set `TRUST_PROXY` to the number of proxies in front of the app, usually `1`. Until they do, the shared-bucket behaviour persists — but the startup warning now says so out loud.
- The counters are still in process memory. Behind more than one instance each enforces its own limit, as the module's own header comment already notes. Moving the store to Redis is a separate change and only `hits` needs to move.
- 100/hour per address is a judgement call. Say the word if the project wants it tighter or looser.