### PR TITLE
fix(frontend): stop the wishlist surviving logout and leaking to the next user (closes #299)

### DIFF
--- a/bookshelf-frontend/src/components/BookCard.jsx
+++ b/bookshelf-frontend/src/components/BookCard.jsx
@@ -1,7 +1,6 @@
-import { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import WishlistButton from './WishlistButton.jsx';
-import { WishlistContext } from '../context/WishlistContext.jsx';
+import { useWishlist } from '../hooks/useWishlist.js';
 import { useCart } from '../hooks/useCart.js';
 import './BookCard.css';
 
@@ -16,9 +15,9 @@ import './BookCard.css';
  *                          (e.g. RecentlyViewed). Falls back to addToCart.
  */
 export default function BookCard({ book, onAddToCart }) {
-  const { wishlist, toggleWishlist } = useContext(WishlistContext);
+  const { isWishlisted, toggleWishlist } = useWishlist();
   const { addToCart } = useCart();
-  const isWishlisted = wishlist?.includes(book.id);
+  const wishlisted = isWishlisted(book.id);
 
   const handleAddToCart = () => {
     if (onAddToCart) {
@@ -35,7 +34,7 @@ export default function BookCard({ book, onAddToCart }) {
         <span className="book-card__cover-title">{book.title}</span>
         <div className="book-card__wishlist-overlay">
           <WishlistButton
-            active={isWishlisted}
+            active={wishlisted}
             onToggle={() => toggleWishlist(book.id)}
           />
         </div>

--- a/bookshelf-frontend/src/context/AuthContext.jsx
+++ b/bookshelf-frontend/src/context/AuthContext.jsx
@@ -47,7 +47,6 @@ export const AuthProvider = ({ children }) => {
     if (data && data.user) {
       setUser(data.user);
       setIsAuthenticated(true);
-      await mergeWishlist();
     }
     return data;
   };
@@ -57,32 +56,29 @@ export const AuthProvider = ({ children }) => {
     if (data && data.user) {
       setUser(data.user);
       setIsAuthenticated(true);
-      await mergeWishlist();
     }
     return data;
   };
 
-  const mergeWishlist = async () => {
-    try {
-      const local = localStorage.getItem('wishlist');
-      if (local) {
-        const localArray = JSON.parse(local);
-        if (localArray.length > 0) {
-          // Dynamic import to avoid circular dependencies if any, or just import at the top
-          const wishlistService = (await import('../services/wishlistService.js')).default;
-          await wishlistService.mergeWishlist(localArray);
-        }
-      }
-      localStorage.removeItem('wishlist');
-    } catch (error) {
-      console.error('Error merging wishlist during auth:', error);
-    }
-  };
-
+  /*
+   * Logging out clears the session here and nothing else. Every provider that
+   * holds per-user state is responsible for reacting to the change — see
+   * WishlistProvider, which keys its state on the user id and empties it the
+   * moment that id changes.
+   *
+   * The local session is dropped even if the request to clear the server
+   * cookie fails. A logout that leaves the previous user's data on screen
+   * because the network was down is the failure mode of #299 all over again.
+   */
   const logout = async () => {
-    await authService.logout();
-    setUser(null);
-    setIsAuthenticated(false);
+    try {
+      await authService.logout();
+    } catch (error) {
+      console.error('[auth] logout request failed:', error);
+    } finally {
+      setUser(null);
+      setIsAuthenticated(false);
+    }
   };
 
   return (

--- a/bookshelf-frontend/src/context/WishlistContext.jsx
+++ b/bookshelf-frontend/src/context/WishlistContext.jsx
@@ -1,98 +1,255 @@
-import React, { createContext, useState, useEffect, useContext } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
 import wishlistService from '../services/wishlistService.js';
 import { AuthContext } from './AuthContext.jsx';
 
-export const WishlistContext = createContext();
+/**
+ * The wishlist, for whoever is signed in right now.
+ *
+ * The bug this rewrite exists to close: the provider never cleared its state
+ * when the session ended. `loadLocalWishlist` returned early when
+ * localStorage was empty — which it always is after a login, because the
+ * merge removes the key — so `setWishlist` was simply never called on the way
+ * out. The signed-out user's books stayed on screen, their hearts stayed
+ * filled, and the next person to sign in on that browser saw them until a
+ * network round trip happened to overwrite them. Click a heart inside that
+ * window and one user's book id was written to another user's account. See
+ * #299.
+ *
+ * Two rules keep it closed:
+ *
+ *   1. State is keyed to an identity. The moment the identity changes the
+ *      list is emptied, synchronously, before any request is issued. No state
+ *      ever spans two users.
+ *   2. Every async load carries the identity it was started for. A response
+ *      that arrives after the identity has moved on is dropped rather than
+ *      applied.
+ */
+
+export const WishlistContext = createContext(undefined);
+
+const STORAGE_KEY = 'wishlist';
+
+/** Signed out is an identity too, and a distinct one from "not resolved yet". */
+const ANONYMOUS = 'anonymous';
+
+/**
+ * localStorage throws in Safari private browsing and wherever storage is
+ * blocked. A wishlist is not worth crashing the app over.
+ */
+function readLocalWishlist() {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw);
+    // Anything can be in localStorage — another tab, an older version of the
+    // app, a user with devtools open.
+    return Array.isArray(parsed)
+      ? parsed.filter((id) => typeof id === 'string')
+      : [];
+  } catch (error) {
+    console.error('[wishlist] could not read the local wishlist:', error);
+    return [];
+  }
+}
+
+function writeLocalWishlist(bookIds) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(bookIds));
+  } catch (error) {
+    console.error('[wishlist] could not save the local wishlist:', error);
+  }
+}
+
+function clearLocalWishlist() {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    console.error('[wishlist] could not clear the local wishlist:', error);
+  }
+}
+
+/** The API returns an array of ids; be defensive about what actually arrives. */
+function asBookIds(value) {
+  return Array.isArray(value) ? value.filter((id) => typeof id === 'string') : [];
+}
 
 export const WishlistProvider = ({ children }) => {
+  const { user, isAuthenticated, loading: authLoading } = useContext(AuthContext);
+
   const [wishlist, setWishlist] = useState([]);
-  const { isAuthenticated, loading: authLoading } = useContext(AuthContext);
   const [loading, setLoading] = useState(true);
 
-  // Load wishlist based on auth status
+  /**
+   * Who the current list belongs to. A user id when signed in, ANONYMOUS when
+   * signed out, null while auth is still resolving.
+   */
+  const identity = authLoading
+    ? null
+    : isAuthenticated && user?._id
+      ? String(user._id)
+      : ANONYMOUS;
+
+  /**
+   * Bumped every time a load starts. An in-flight response compares against
+   * it and drops itself if it lost the race — otherwise a slow response for
+   * user A can land after user B has signed in and overwrite their list.
+   */
+  const loadIdRef = useRef(0);
+
+  /** The identity the current state belongs to, for toggleWishlist to check. */
+  const identityRef = useRef(identity);
+  identityRef.current = identity;
+
   useEffect(() => {
-    if (authLoading) return;
-
-    if (isAuthenticated) {
-      loadBackendWishlist();
-    } else {
-      loadLocalWishlist();
+    if (identity === null) {
+      // Auth has not resolved yet. Nothing is known, so nothing is shown.
+      return undefined;
     }
-  }, [isAuthenticated, authLoading]);
 
-  const loadLocalWishlist = () => {
-    try {
-      const local = localStorage.getItem('wishlist');
-      if (local) {
-        setWishlist(JSON.parse(local));
+    const loadId = loadIdRef.current + 1;
+    loadIdRef.current = loadId;
+
+    // Clear first, synchronously. This is the fix: whatever the previous
+    // identity had is gone before a single byte is requested for the new one,
+    // so there is no window in which one user sees another's list.
+    setWishlist([]);
+    setLoading(true);
+
+    let cancelled = false;
+    const isCurrent = () => !cancelled && loadIdRef.current === loadId;
+
+    async function load() {
+      if (identity === ANONYMOUS) {
+        if (isCurrent()) {
+          setWishlist(readLocalWishlist());
+          setLoading(false);
+        }
+        return;
       }
-    } catch (error) {
-      console.error('Error loading local wishlist:', error);
-    }
-    setLoading(false);
-  };
 
-  const loadBackendWishlist = async () => {
-    try {
-      setLoading(true);
-      const data = await wishlistService.getWishlist();
-      setWishlist(data);
-    } catch (error) {
-      console.error('Error loading backend wishlist:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
+      const local = readLocalWishlist();
 
-  const toggleWishlist = async (bookId) => {
-    if (isAuthenticated) {
       try {
-        const updatedWishlist = await wishlistService.toggleWishlist(bookId);
-        setWishlist(updatedWishlist);
-      } catch (error) {
-        console.error('Error toggling wishlist:', error);
-      }
-    } else {
-      setWishlist((prev) => {
-        let newWishlist;
-        if (prev.includes(bookId)) {
-          newWishlist = prev.filter((id) => id !== bookId);
-        } else {
-          newWishlist = [...prev, bookId];
-        }
-        localStorage.setItem('wishlist', JSON.stringify(newWishlist));
-        return newWishlist;
-      });
-    }
-  };
+        // Merge before loading, in that order, awaited. Previously
+        // AuthContext fired the merge while this effect fired the load, in
+        // the same tick, with no ordering between them — so the GET usually
+        // won and came back without the just-merged items, which then only
+        // appeared after a full reload.
+        const data =
+          local.length > 0
+            ? await wishlistService.mergeWishlist(local)
+            : await wishlistService.getWishlist();
 
-  // Called from AuthContext on login/register
-  const mergeLocalWishlist = async () => {
-    try {
-      const local = localStorage.getItem('wishlist');
-      if (local) {
-        const localArray = JSON.parse(local);
-        if (localArray.length > 0) {
-          const merged = await wishlistService.mergeWishlist(localArray);
-          setWishlist(merged);
+        if (!isCurrent()) {
+          return;
+        }
+
+        setWishlist(asBookIds(data));
+
+        // Only once the server has acknowledged the merge. Clearing it
+        // first — which is what AuthContext did, in a block that ran whether
+        // or not the request had succeeded — loses the items outright if the
+        // merge fails.
+        if (local.length > 0) {
+          clearLocalWishlist();
+        }
+      } catch (error) {
+        console.error('[wishlist] could not load the wishlist:', error);
+
+        if (isCurrent()) {
+          // Deliberately not falling back to `local`: showing a signed-in
+          // user a list that is not theirs is the failure being fixed. An
+          // empty list is wrong but honest, and the local copy is still in
+          // storage to be merged on the next successful load.
+          setWishlist([]);
+        }
+      } finally {
+        if (isCurrent()) {
+          setLoading(false);
         }
       }
-      localStorage.removeItem('wishlist');
-    } catch (error) {
-      console.error('Error merging wishlist:', error);
     }
-  };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [identity]);
+
+  const toggleWishlist = useCallback(async (bookId) => {
+    if (typeof bookId !== 'string' || bookId === '') {
+      return;
+    }
+
+    const identityAtCall = identityRef.current;
+
+    if (identityAtCall === null) {
+      // Auth has not resolved. Acting now would write to whichever identity
+      // turns out to be current, which is the bug in miniature.
+      return;
+    }
+
+    if (identityAtCall === ANONYMOUS) {
+      setWishlist((previous) => {
+        const next = previous.includes(bookId)
+          ? previous.filter((id) => id !== bookId)
+          : [...previous, bookId];
+
+        writeLocalWishlist(next);
+        return next;
+      });
+      return;
+    }
+
+    try {
+      const data = await wishlistService.toggleWishlist(bookId);
+
+      // The session can end mid-request. Applying the response then would put
+      // the previous user's list back on screen.
+      if (identityRef.current !== identityAtCall) {
+        return;
+      }
+
+      setWishlist(asBookIds(data));
+    } catch (error) {
+      console.error('[wishlist] could not update the wishlist:', error);
+    }
+  }, []);
+
+  const isWishlisted = useCallback(
+    (bookId) => wishlist.includes(bookId),
+    [wishlist]
+  );
+
+  const value = useMemo(
+    () => ({
+      wishlist,
+      loading,
+      toggleWishlist,
+      isWishlisted,
+      count: wishlist.length,
+    }),
+    [wishlist, loading, toggleWishlist, isWishlisted]
+  );
 
   return (
-    <WishlistContext.Provider
-      value={{
-        wishlist,
-        loading,
-        toggleWishlist,
-        mergeLocalWishlist,
-      }}
-    >
+    <WishlistContext.Provider value={value}>
       {children}
     </WishlistContext.Provider>
   );
 };
+
+export default WishlistProvider;

--- a/bookshelf-frontend/src/context/WishlistContext.test.jsx
+++ b/bookshelf-frontend/src/context/WishlistContext.test.jsx
@@ -1,0 +1,335 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { WishlistProvider } from './WishlistContext.jsx';
+import { AuthContext } from './AuthContext.jsx';
+import { useWishlist } from '../hooks/useWishlist.js';
+import wishlistService from '../services/wishlistService.js';
+
+vi.mock('../services/wishlistService.js', () => ({
+  default: {
+    getWishlist: vi.fn(),
+    toggleWishlist: vi.fn(),
+    mergeWishlist: vi.fn(),
+  },
+}));
+
+/**
+ * Stands in for AuthProvider so a test can change who is signed in without
+ * going through the API.
+ */
+function auth({ userId = null, loading = false } = {}) {
+  return {
+    user: userId ? { _id: userId, name: 'Test', email: 't@example.com' } : null,
+    isAuthenticated: Boolean(userId),
+    loading,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    checkAuth: vi.fn(),
+  };
+}
+
+function Probe() {
+  const { wishlist, loading, count, isWishlisted, toggleWishlist } =
+    useWishlist();
+
+  return (
+    <div>
+      <span data-testid="ids">{wishlist.join(',')}</span>
+      <span data-testid="count">{count}</span>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="has-b1">{String(isWishlisted('b1'))}</span>
+      <button onClick={() => toggleWishlist('b1')}>toggle b1</button>
+      <button onClick={() => toggleWishlist('b9')}>toggle b9</button>
+    </div>
+  );
+}
+
+function renderWith(authValue) {
+  return render(
+    <AuthContext.Provider value={authValue}>
+      <WishlistProvider>
+        <Probe />
+      </WishlistProvider>
+    </AuthContext.Provider>
+  );
+}
+
+const ids = () => screen.getByTestId('ids').textContent;
+
+/** A promise whose resolution the test controls. */
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('WishlistProvider', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.clearAllMocks();
+    wishlistService.getWishlist.mockResolvedValue([]);
+    wishlistService.mergeWishlist.mockResolvedValue([]);
+    wishlistService.toggleWishlist.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('while auth is still resolving', () => {
+    it('shows nothing and asks for nothing', () => {
+      renderWith(auth({ loading: true }));
+
+      expect(ids()).toBe('');
+      expect(screen.getByTestId('loading')).toHaveTextContent('true');
+      expect(wishlistService.getWishlist).not.toHaveBeenCalled();
+    });
+
+    it('ignores a toggle rather than guessing the identity', async () => {
+      const user = userEvent.setup();
+      renderWith(auth({ loading: true }));
+
+      await user.click(screen.getByText('toggle b1'));
+
+      expect(ids()).toBe('');
+      expect(wishlistService.toggleWishlist).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('signed out', () => {
+    it('reads the list from localStorage', async () => {
+      window.localStorage.setItem('wishlist', JSON.stringify(['b1', 'b2']));
+
+      renderWith(auth());
+
+      await waitFor(() => expect(ids()).toBe('b1,b2'));
+      expect(screen.getByTestId('count')).toHaveTextContent('2');
+      expect(wishlistService.getWishlist).not.toHaveBeenCalled();
+    });
+
+    it('toggles locally and persists', async () => {
+      const user = userEvent.setup();
+      renderWith(auth());
+
+      await waitFor(() =>
+        expect(screen.getByTestId('loading')).toHaveTextContent('false')
+      );
+
+      await user.click(screen.getByText('toggle b1'));
+
+      expect(ids()).toBe('b1');
+      expect(JSON.parse(window.localStorage.getItem('wishlist'))).toEqual(['b1']);
+
+      await user.click(screen.getByText('toggle b1'));
+
+      expect(ids()).toBe('');
+      expect(JSON.parse(window.localStorage.getItem('wishlist'))).toEqual([]);
+    });
+
+    it('survives junk in localStorage', async () => {
+      window.localStorage.setItem('wishlist', 'not json at all');
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      renderWith(auth());
+
+      await waitFor(() =>
+        expect(screen.getByTestId('loading')).toHaveTextContent('false')
+      );
+      expect(ids()).toBe('');
+    });
+
+    it('ignores non-string entries in a stored list', async () => {
+      window.localStorage.setItem('wishlist', JSON.stringify(['b1', 42, null]));
+
+      renderWith(auth());
+
+      await waitFor(() => expect(ids()).toBe('b1'));
+    });
+  });
+
+  describe('signed in', () => {
+    it('loads from the API', async () => {
+      wishlistService.getWishlist.mockResolvedValue(['b3']);
+
+      renderWith(auth({ userId: 'user-a' }));
+
+      await waitFor(() => expect(ids()).toBe('b3'));
+    });
+
+    it('merges a local list first, then applies the merged result', async () => {
+      window.localStorage.setItem('wishlist', JSON.stringify(['b1']));
+      wishlistService.mergeWishlist.mockResolvedValue(['b1', 'b3']);
+
+      renderWith(auth({ userId: 'user-a' }));
+
+      await waitFor(() => expect(ids()).toBe('b1,b3'));
+
+      expect(wishlistService.mergeWishlist).toHaveBeenCalledWith(['b1']);
+      // The merge replaces the load; there is no second request to race it.
+      expect(wishlistService.getWishlist).not.toHaveBeenCalled();
+      expect(window.localStorage.getItem('wishlist')).toBeNull();
+    });
+
+    it('keeps the local list when the merge fails', async () => {
+      // AuthContext used to remove the key whether or not the request had
+      // succeeded, so a failed merge lost the items outright.
+      window.localStorage.setItem('wishlist', JSON.stringify(['b1']));
+      wishlistService.mergeWishlist.mockRejectedValue(new Error('offline'));
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      renderWith(auth({ userId: 'user-a' }));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('loading')).toHaveTextContent('false')
+      );
+
+      expect(JSON.parse(window.localStorage.getItem('wishlist'))).toEqual(['b1']);
+    });
+
+    it('toggles through the API and takes the server list as the truth', async () => {
+      const user = userEvent.setup();
+      wishlistService.getWishlist.mockResolvedValue([]);
+      wishlistService.toggleWishlist.mockResolvedValue(['b1']);
+
+      renderWith(auth({ userId: 'user-a' }));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('loading')).toHaveTextContent('false')
+      );
+
+      await user.click(screen.getByText('toggle b1'));
+
+      await waitFor(() => expect(ids()).toBe('b1'));
+      expect(wishlistService.toggleWishlist).toHaveBeenCalledWith('b1');
+      // Nothing was written to localStorage for a signed-in user.
+      expect(window.localStorage.getItem('wishlist')).toBeNull();
+    });
+  });
+
+  /**
+   * The reported bug, and the reason for the rewrite.
+   */
+  describe('when the session changes', () => {
+    it('empties the list on logout', async () => {
+      wishlistService.getWishlist.mockResolvedValue(['b1', 'b2']);
+
+      const { rerender } = renderWith(auth({ userId: 'user-a' }));
+      await waitFor(() => expect(ids()).toBe('b1,b2'));
+
+      rerender(
+        <AuthContext.Provider value={auth()}>
+          <WishlistProvider>
+            <Probe />
+          </WishlistProvider>
+        </AuthContext.Provider>
+      );
+
+      // Previously loadLocalWishlist returned early on an empty
+      // localStorage, so setWishlist was never called and user A's books
+      // stayed on screen while signed out.
+      await waitFor(() => expect(ids()).toBe(''));
+      expect(screen.getByTestId('has-b1')).toHaveTextContent('false');
+    });
+
+    it('does not show one user the previous user list, even for a moment', async () => {
+      const pending = deferred();
+      wishlistService.getWishlist.mockResolvedValueOnce(['b1', 'b2']);
+
+      const { rerender } = renderWith(auth({ userId: 'user-a' }));
+      await waitFor(() => expect(ids()).toBe('b1,b2'));
+
+      wishlistService.getWishlist.mockReturnValueOnce(pending.promise);
+
+      rerender(
+        <AuthContext.Provider value={auth({ userId: 'user-b' })}>
+          <WishlistProvider>
+            <Probe />
+          </WishlistProvider>
+        </AuthContext.Provider>
+      );
+
+      // User B's request has not resolved yet. The list must already be
+      // empty — this is the window in which a click used to write user A's
+      // book id into user B's account.
+      expect(ids()).toBe('');
+      expect(screen.getByTestId('has-b1')).toHaveTextContent('false');
+
+      await act(async () => {
+        pending.resolve(['b7']);
+      });
+
+      await waitFor(() => expect(ids()).toBe('b7'));
+    });
+
+    it('does not leak the previous list when the new load fails', async () => {
+      wishlistService.getWishlist.mockResolvedValueOnce(['b1', 'b2']);
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { rerender } = renderWith(auth({ userId: 'user-a' }));
+      await waitFor(() => expect(ids()).toBe('b1,b2'));
+
+      wishlistService.getWishlist.mockRejectedValueOnce(new Error('500'));
+
+      rerender(
+        <AuthContext.Provider value={auth({ userId: 'user-b' })}>
+          <WishlistProvider>
+            <Probe />
+          </WishlistProvider>
+        </AuthContext.Provider>
+      );
+
+      await waitFor(() =>
+        expect(screen.getByTestId('loading')).toHaveTextContent('false')
+      );
+
+      // The old catch only logged, so user A's list was what user B saw for
+      // the rest of the session.
+      expect(ids()).toBe('');
+    });
+
+    it('drops a response that arrives after the identity moved on', async () => {
+      const slow = deferred();
+      wishlistService.getWishlist.mockReturnValueOnce(slow.promise);
+
+      const { rerender } = renderWith(auth({ userId: 'user-a' }));
+
+      wishlistService.getWishlist.mockResolvedValueOnce(['b7']);
+
+      rerender(
+        <AuthContext.Provider value={auth({ userId: 'user-b' })}>
+          <WishlistProvider>
+            <Probe />
+          </WishlistProvider>
+        </AuthContext.Provider>
+      );
+
+      await waitFor(() => expect(ids()).toBe('b7'));
+
+      // User A's request finally lands. It must not overwrite user B.
+      await act(async () => {
+        slow.resolve(['b1', 'b2']);
+      });
+
+      expect(ids()).toBe('b7');
+    });
+  });
+});
+
+describe('useWishlist', () => {
+  it('throws outside the provider instead of returning undefined', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() => render(<Probe />)).toThrow(/WishlistProvider/);
+
+    consoleError.mockRestore();
+  });
+});

--- a/bookshelf-frontend/src/hooks/useWishlist.js
+++ b/bookshelf-frontend/src/hooks/useWishlist.js
@@ -1,0 +1,35 @@
+import { useContext } from 'react';
+import { WishlistContext } from '../context/WishlistContext.jsx';
+
+/**
+ * Access the wishlist.
+ *
+ * Prefer this over `useContext(WishlistContext)` directly. Reading the context
+ * straight gives you `undefined` when the provider is missing, and every
+ * caller then blows up on the destructuring line with a message that points
+ * at the consumer rather than at the missing provider. This throws with the
+ * actual cause instead — the same pattern `useCart` already uses.
+ *
+ * Returns:
+ *   wishlist              array of book ids for the current session
+ *   loading               true while the list is being fetched
+ *   count                 wishlist.length
+ *   isWishlisted(bookId)  membership test, so callers stop writing
+ *                         `wishlist.includes(...)` by hand
+ *   toggleWishlist(id)    add or remove; writes to the API when signed in and
+ *                         to localStorage when not
+ */
+export function useWishlist() {
+  const context = useContext(WishlistContext);
+
+  if (context === undefined) {
+    throw new Error(
+      'useWishlist() must be used inside a <WishlistProvider>. ' +
+        'Check that WishlistProvider wraps the component tree in main.jsx.'
+    );
+  }
+
+  return context;
+}
+
+export default useWishlist;

--- a/bookshelf-frontend/src/pages/BookDetail.jsx
+++ b/bookshelf-frontend/src/pages/BookDetail.jsx
@@ -1,11 +1,11 @@
-import { useState, useEffect, useContext } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { books } from '../data/books.js';
 import Rating from '../components/Rating.jsx';
 import WishlistButton from '../components/WishlistButton.jsx';
 import SkeletonLoader from '../components/SkeletonLoader.jsx';
 import { useCart } from '../hooks/useCart.js';
-import { WishlistContext } from '../context/WishlistContext.jsx';
+import { useWishlist } from '../hooks/useWishlist.js';
 import { useTranslation } from 'react-i18next';
 import BookCard from '../components/BookCard.jsx';
 import './BookDetail.css';
@@ -19,7 +19,7 @@ export default function BookDetail() {
   const [successMsg, setSuccessMsg] = useState('');
   const [loading, setLoading] = useState(true);
   const { addToCart } = useCart();
-  const { wishlist, toggleWishlist } = useContext(WishlistContext);
+  const { isWishlisted, toggleWishlist } = useWishlist();
 
   const book = books.find((item) => String(item.id) === String(id));
 
@@ -105,7 +105,7 @@ export default function BookDetail() {
             <button className="book-detail-add-btn" onClick={() => addToCart(book)}>
               {t('bookDetail.addToCart') || 'Add to Cart'}
             </button>
-            <WishlistButton active={wishlist?.includes(book.id)} onToggle={() => toggleWishlist(book.id)} />
+            <WishlistButton active={isWishlisted(book.id)} onToggle={() => toggleWishlist(book.id)} />
           </div>
         </div>
       </div>

--- a/bookshelf-frontend/src/pages/Wishlist.jsx
+++ b/bookshelf-frontend/src/pages/Wishlist.jsx
@@ -1,13 +1,13 @@
-import { useContext, useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import BookCard from '../components/BookCard.jsx';
 import SkeletonLoader from '../components/SkeletonLoader.jsx';
 import { books } from '../data/books.js';
-import { WishlistContext } from '../context/WishlistContext.jsx';
+import { useWishlist } from '../hooks/useWishlist.js';
 import './Wishlist.css';
 
 export default function Wishlist() {
-  const { wishlist } = useContext(WishlistContext);
+  const { wishlist } = useWishlist();
   const wishlistedBooks = books.filter((book) => wishlist.includes(book.id));
   const [loading, setLoading] = useState(true);
 

--- a/bookshelf-frontend/src/pages/WishlistPage.jsx
+++ b/bookshelf-frontend/src/pages/WishlistPage.jsx
@@ -1,6 +1,5 @@
-import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { WishlistContext } from '../context/WishlistContext.jsx';
+import { useWishlist } from '../hooks/useWishlist.js';
 import { books } from '../data/books.js';
 import BookCard from '../components/BookCard.jsx';
 import './WishlistPage.css';
@@ -12,7 +11,7 @@ import './WishlistPage.css';
  * two navbars once the routes actually resolve.
  */
 export default function WishlistPage() {
-  const { wishlist, loading } = useContext(WishlistContext);
+  const { wishlist, loading } = useWishlist();
   const navigate = useNavigate();
 
   // Find books that are in the wishlist


### PR DESCRIPTION
Closes #299.

## The bug

`WishlistProvider` never cleared its state when the session ended.

```js
const loadLocalWishlist = () => {
  const local = localStorage.getItem('wishlist');
  if (local) {                       // <- null after any login
    setWishlist(JSON.parse(local));  // <- so this never runs
  }
  setLoading(false);
};
```

When `isAuthenticated` flips to `false` the effect calls this. But the login-time merge did `localStorage.removeItem('wishlist')`, so `local` is `null`, the `if` is skipped, and **`setWishlist` is never called**. The array still holds the signed-out user's book ids.

Verified against `main` by rendering its provider directly, signing user A in, then out:

```
AFTER LOGOUT, main shows: "b1,b2"
```

`/wishlist` keeps rendering user A's books while signed out, and every card's heart stays filled. Sign a second user in and the state is still A's until a network round trip happens to overwrite it — and if `loadBackendWishlist` fails, the `catch` only logs, so it never does. Click a heart in that window and `toggleWishlist` posts A's book id against B's account.

Three more problems in the same file:

**The merge is implemented twice, and the copy that runs is the wrong one.** `WishlistContext` exports `mergeLocalWishlist`, which calls the service *and* applies the result with `setWishlist`. Grepping for it outside its own definition returns nothing — it is never called. `AuthContext` has its own private `mergeWishlist` that dynamically imports the service, posts, and throws the response away. That is the one that runs.

**Merge and load race each other.** `login()` calls `setIsAuthenticated(true)` — scheduling `loadBackendWishlist` — and then `await mergeWishlist()` in the same tick. Nothing orders the `GET` against the `POST /merge`. The GET usually wins and returns without the merged items, which then only appear after a full reload.

**A failed merge loses the items.** `localStorage.removeItem('wishlist')` sat outside the `if`, running whether or not the request had succeeded.

## The fix

**State is keyed to an identity.** The user id when signed in, `ANONYMOUS` when signed out, `null` while auth is still resolving — three distinct states, where the old code conflated the last two. When the identity changes the list is emptied **synchronously**, before a single byte is requested for the new one. There is no window in which one user's state is on screen under another user's session.

**Every load carries the identity it was started for.** A load id is bumped on each run and checked before anything is applied, so a slow response for user A cannot land after user B has signed in. Same check in `toggleWishlist`, since a session can end mid-request.

**A failed load shows an empty list, not the previous one.** Deliberately *not* falling back to the local copy: showing a signed-in user a list that is not theirs is the failure being fixed. Empty is wrong but honest, and the local copy stays in storage to be merged on the next successful load.

**One merge, sequenced.** `AuthContext.mergeWishlist` is gone; the provider merges and loads in one awaited sequence — merge *replaces* the load rather than running alongside it, so there is no second request to race. `localStorage` is cleared only once the server has acknowledged the merge.

**`logout` drops the local session even if the request fails.** A logout that leaves the previous user's data on screen because the network was down is the same bug again.

**`useWishlist` (new)**, matching the `useCart` pattern: throws with the real cause instead of returning `undefined` and letting each consumer fail on its destructuring line. The four consumers use it, and `isWishlisted(id)` in place of `wishlist.includes(id)`.

Also hardened along the way: `localStorage` guarded against throwing (Safari private browsing), and both stored and API-returned lists filtered to strings — anything can end up in localStorage.

## Tests

`context/WishlistContext.test.jsx`, 15 cases with the service mocked.

The ones tied to the report:

- `empties the list on logout`
- `does not show one user the previous user list, even for a moment` — holds user B's request open and asserts the list is *already* empty, which is the window where a click wrote to the wrong account
- `does not leak the previous list when the new load fails`
- `drops a response that arrives after the identity moved on`
- `merges a local list first, then applies the merged result` — and asserts no `getWishlist` call to race it
- `keeps the local list when the merge fails`
- `ignores a toggle rather than guessing the identity` while auth is unresolved

```
Test Files  5 passed (5)
     Tests  61 passed (61)
```

(46 before this branch.)

`npx vite build` succeeds. ESLint reports no new problems — the two remaining warnings (`'React' is defined but never used`, `'payload' is assigned but never used`) are pre-existing.

## Verified by hand

Heart two books signed out → log in → they appear immediately, no reload → log out → wishlist is empty and the hearts are clear → log in as a second user → their own list only.

## Notes for review

- `pages/Wishlist.jsx` is not reachable from the route table (`AppRoutes` uses `WishlistPage`). It is updated for consistency rather than left on a context shape that no longer exists. Whether it should be deleted is a separate question — happy to open an issue.
- `count` and `isWishlisted` are added to the context value; `wishlist` and `loading` keep their existing shape, so nothing outside these files needs to change.
- The provider no longer exports `mergeLocalWishlist`. Nothing called it.