### PR TITLE
fix(auth): remove the hardcoded JWT fallback secret and tie the cookie lifetime to the token (closes #305)

### DIFF
--- a/bookshelf-backend/.env.example
+++ b/bookshelf-backend/.env.example
@@ -6,12 +6,22 @@ PORT=5000
 # Mongo connection string. Defaults to a local instance if unset.
 MONGODB_URI=mongodb://127.0.0.1:27017/bookshelf
 
-# Signing secret for the session cookie. Must be set in any deployment:
-# the code falls back to a hardcoded 'fallback_secret' when this is missing,
-# which would let anyone mint a valid token.
+# Signing secret for the session cookie. Required in production: the server
+# refuses to start without it, refuses obvious placeholders (the 'change-me'
+# below and the old hardcoded 'fallback_secret' among them), and refuses
+# anything shorter than 32 characters. Generate one with:
+#
+#   openssl rand -hex 32
+#
+# Outside production, a random secret is generated per process when this is
+# unset so a fresh clone runs with no setup. Sessions do not survive a restart
+# in that case, which is the point — it is never a fixed, guessable value.
 JWT_SECRET=change-me
 
-# Session cookie lifetime, as accepted by jsonwebtoken. Defaults to 7d.
+# Session cookie lifetime, as accepted by jsonwebtoken: a number of seconds, or
+# a value like 30m, 12h, 7d, 2w. Defaults to 7d. Validated at startup rather
+# than on the first login, and the cookie's own expiry is derived from it, so
+# this is the only number to set.
 JWT_EXPIRES_IN=7d
 
 # development | production

--- a/bookshelf-backend/config/jwt.js
+++ b/bookshelf-backend/config/jwt.js
@@ -1,0 +1,265 @@
+import crypto from 'crypto';
+
+/**
+ * Session token configuration, resolved once and validated up front.
+ *
+ * Two things used to be wrong, and both came from reading the environment
+ * inline at the point of use:
+ *
+ *   1. `process.env.JWT_SECRET || 'fallback_secret'` appeared in two files.
+ *      A deployment that forgot the variable signed real sessions with a
+ *      string that is committed to this repository, so anyone could mint a
+ *      token for any account — including one carrying `role: 'admin'`.
+ *
+ *   2. The token's lifetime came from JWT_EXPIRES_IN but the cookie's maxAge
+ *      was hardcoded to seven days. Setting JWT_EXPIRES_IN=1h left the browser
+ *      holding a cookie for another six days that the server rejects on every
+ *      request.
+ *
+ * Both are the same class of bug: a value that has to agree with itself in
+ * more than one place, and no single place that owns it. This module is that
+ * place. Nothing else reads JWT_SECRET or JWT_EXPIRES_IN.
+ */
+
+/**
+ * Values that are syntactically a secret but are obviously not one. The old
+ * hardcoded fallback is on the list so a deployment cannot reintroduce it by
+ * setting it explicitly, and so is the placeholder from .env.example — copying
+ * that file and forgetting to edit it is the likeliest way to end up here.
+ */
+const REJECTED_SECRETS = new Set([
+  'fallback_secret',
+  'change-me',
+  'changeme',
+  'secret',
+  'jwt_secret',
+  'your-secret-here',
+  'your_jwt_secret',
+  'test',
+  'password',
+]);
+
+/**
+ * 32 characters is not a cryptographic argument, it is a floor. A HS256 key
+ * shorter than the 256-bit digest it feeds adds nothing, and anything a human
+ * typed from memory is below it.
+ */
+export const MIN_SECRET_LENGTH = 32;
+
+export const DEFAULT_EXPIRES_IN = '7d';
+
+/**
+ * Thrown for anything wrong with the configuration itself. Distinct from a
+ * request-time error because the only sensible response is to refuse to start.
+ */
+export class ConfigError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ConfigError';
+  }
+}
+
+const UNIT_TO_MS = {
+  ms: 1,
+  millisecond: 1,
+  milliseconds: 1,
+  s: 1000,
+  sec: 1000,
+  secs: 1000,
+  second: 1000,
+  seconds: 1000,
+  m: 60 * 1000,
+  min: 60 * 1000,
+  mins: 60 * 1000,
+  minute: 60 * 1000,
+  minutes: 60 * 1000,
+  h: 60 * 60 * 1000,
+  hr: 60 * 60 * 1000,
+  hrs: 60 * 60 * 1000,
+  hour: 60 * 60 * 1000,
+  hours: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+  day: 24 * 60 * 60 * 1000,
+  days: 24 * 60 * 60 * 1000,
+  w: 7 * 24 * 60 * 60 * 1000,
+  week: 7 * 24 * 60 * 60 * 1000,
+  weeks: 7 * 24 * 60 * 60 * 1000,
+};
+
+/**
+ * Convert a jsonwebtoken-style lifetime to milliseconds.
+ *
+ * The point is not to reimplement `ms` — it is that we need the number to
+ * derive the cookie's maxAge from, and asking jsonwebtoken for it is not
+ * possible without signing a token first. Parsing the same string ourselves
+ * means the cookie and the token cannot drift apart.
+ *
+ * A bare number means seconds, matching jsonwebtoken's own rule. Anything
+ * unparseable throws here, at boot, rather than turning the first login of the
+ * day into a 500.
+ */
+export function parseDuration(value) {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new ConfigError(
+        `JWT lifetime must be a positive number of seconds, received ${value}`
+      );
+    }
+    return Math.floor(value * 1000);
+  }
+
+  if (typeof value !== 'string') {
+    throw new ConfigError(
+      `JWT lifetime must be a string or a number, received ${typeof value}`
+    );
+  }
+
+  const raw = value.trim();
+
+  if (raw === '') {
+    throw new ConfigError('JWT lifetime cannot be empty');
+  }
+
+  if (/^\d+$/.test(raw)) {
+    return Number(raw) * 1000;
+  }
+
+  const match = /^(\d+(?:\.\d+)?)\s*([a-z]+)$/i.exec(raw);
+
+  if (!match) {
+    throw new ConfigError(
+      `JWT lifetime "${value}" is not a recognised duration. ` +
+        'Use a number of seconds, or a value like 30m, 12h, 7d, 2w.'
+    );
+  }
+
+  const amount = Number(match[1]);
+  const unit = match[2].toLowerCase();
+  const multiplier = UNIT_TO_MS[unit];
+
+  if (multiplier === undefined) {
+    throw new ConfigError(
+      `JWT lifetime "${value}" uses an unknown unit "${match[2]}". ` +
+        'Supported units: ms, s, m, h, d, w.'
+    );
+  }
+
+  if (amount <= 0) {
+    throw new ConfigError(
+      `JWT lifetime "${value}" must be greater than zero.`
+    );
+  }
+
+  return Math.floor(amount * multiplier);
+}
+
+/**
+ * Reject a secret that would not actually protect anything.
+ *
+ * Returns the secret so callers can write `const s = assertUsableSecret(...)`.
+ */
+export function assertUsableSecret(secret) {
+  if (typeof secret !== 'string' || secret.trim() === '') {
+    throw new ConfigError(
+      'JWT_SECRET is not set. The API signs session cookies with it, so ' +
+        'starting without one would mean every session is forgeable. ' +
+        'Generate one with: openssl rand -hex 32'
+    );
+  }
+
+  const trimmed = secret.trim();
+
+  if (REJECTED_SECRETS.has(trimmed.toLowerCase())) {
+    throw new ConfigError(
+      `JWT_SECRET is set to "${trimmed}", which is a placeholder that appears ` +
+        'in this repository. Anyone reading the source could sign a token ' +
+        'for any account. Generate a real one with: openssl rand -hex 32'
+    );
+  }
+
+  if (trimmed.length < MIN_SECRET_LENGTH) {
+    throw new ConfigError(
+      `JWT_SECRET is ${trimmed.length} characters; at least ` +
+        `${MIN_SECRET_LENGTH} are required. Generate one with: ` +
+        'openssl rand -hex 32'
+    );
+  }
+
+  return trimmed;
+}
+
+/**
+ * Build the config from an environment.
+ *
+ * Takes `env` as an argument rather than reading process.env directly so the
+ * tests can exercise every branch without mutating global state.
+ *
+ * Outside production a missing secret is replaced with a random one rather
+ * than being fatal, so `npm run dev` still works on a fresh clone with no
+ * setup. That is deliberately not the same as the old behaviour: the old
+ * fallback was a constant every reader of this repo knows, this one is 32
+ * random bytes that exist only for the life of the process. The cost is that
+ * sessions do not survive a restart in development, which is the correct
+ * trade and is said out loud in the warning.
+ */
+export function loadJwtConfig(env = process.env) {
+  const isProduction = env.NODE_ENV === 'production';
+
+  let secret;
+
+  if (!env.JWT_SECRET && !isProduction) {
+    secret = crypto.randomBytes(32).toString('hex');
+    console.warn(
+      '[config] JWT_SECRET is not set. Generated a random one for this ' +
+        'process — sessions will not survive a restart. Set JWT_SECRET in ' +
+        '.env to keep them. This is refused outright in production.'
+    );
+  } else {
+    secret = assertUsableSecret(env.JWT_SECRET);
+  }
+
+  const expiresIn = env.JWT_EXPIRES_IN?.trim() || DEFAULT_EXPIRES_IN;
+  const maxAgeMs = parseDuration(expiresIn);
+
+  return {
+    secret,
+    expiresIn,
+    // Single source of truth for the cookie. Derived, never typed twice.
+    maxAgeMs,
+    isProduction,
+  };
+}
+
+let cached = null;
+
+/**
+ * The resolved config.
+ *
+ * Lazy on purpose. Resolving at import time would mean importing
+ * authMiddleware in a unit test throws unless that test happens to have a
+ * valid JWT_SECRET in its environment, which couples every test file to this
+ * one. `assertJwtConfig()` is called explicitly from server.js so a real boot
+ * still fails fast.
+ */
+export function getJwtConfig() {
+  if (!cached) {
+    cached = loadJwtConfig();
+  }
+  return cached;
+}
+
+/**
+ * Call once at startup. Turns a misconfiguration into a refusal to start with
+ * an actionable message, instead of a 500 on the first login or — worse — a
+ * server that runs happily and issues forgeable tokens.
+ */
+export function assertJwtConfig() {
+  return getJwtConfig();
+}
+
+/** Test seam. Not used by application code. */
+export function resetJwtConfigCache() {
+  cached = null;
+}
+
+export default getJwtConfig;

--- a/bookshelf-backend/controllers/authController.js
+++ b/bookshelf-backend/controllers/authController.js
@@ -1,5 +1,9 @@
 import userRepository from '../repositories/userRepository.js';
 import generateToken from '../utils/generateToken.js';
+import {
+  SESSION_COOKIE_NAME,
+  clearSessionCookieOptions,
+} from '../utils/cookies.js';
 
 // @desc    Auth user & get token
 // @route   POST /api/auth/login
@@ -78,10 +82,12 @@ export const registerUser = async (req, res, next) => {
 // @route   POST /api/auth/logout
 // @access  Public
 export const logoutUser = (req, res) => {
-  res.cookie('token', '', {
-    httpOnly: true,
-    expires: new Date(0),
-  });
+  // A browser only replaces a cookie when name, domain and path all match the
+  // one it already has. Deriving these from the same helper that sets the
+  // cookie is what guarantees they do — the inline `{ httpOnly, expires }`
+  // that used to be here matched only by coincidence, and would have stopped
+  // matching the moment the setter grew a `domain`.
+  res.cookie(SESSION_COOKIE_NAME, '', clearSessionCookieOptions());
 
   res.status(200).json({ message: 'Logged out successfully' });
 };

--- a/bookshelf-backend/middleware/authMiddleware.js
+++ b/bookshelf-backend/middleware/authMiddleware.js
@@ -1,6 +1,8 @@
 import jwt from 'jsonwebtoken';
 import User from '../models/User.js';
 import { isAdmin } from '../utils/roles.js';
+import { getJwtConfig } from '../config/jwt.js';
+import { SESSION_COOKIE_NAME } from '../utils/cookies.js';
 
 /**
  * Requires a valid session cookie.
@@ -12,7 +14,7 @@ import { isAdmin } from '../utils/roles.js';
 export const protect = async (req, res, next) => {
   // req.cookies is undefined if cookie-parser has not run, so guard it
   // rather than throwing a TypeError inside auth middleware.
-  const token = req.cookies?.token;
+  const token = req.cookies?.[SESSION_COOKIE_NAME];
 
   if (!token) {
     res.status(401);
@@ -20,10 +22,12 @@ export const protect = async (req, res, next) => {
   }
 
   try {
-    const decoded = jwt.verify(
-      token,
-      process.env.JWT_SECRET || 'fallback_secret'
-    );
+    // The secret comes from config/jwt.js, which has already established that
+    // there is a real one. The `|| 'fallback_secret'` that used to be here
+    // meant a server started without JWT_SECRET would happily *verify* tokens
+    // signed with a constant published in this repository.
+    const { secret } = getJwtConfig();
+    const decoded = jwt.verify(token, secret);
 
     const user = await User.findById(decoded.userId).select('-password');
 

--- a/bookshelf-backend/server.js
+++ b/bookshelf-backend/server.js
@@ -3,9 +3,30 @@ dotenv.config();
 
 import mongoose from 'mongoose';
 import app from './app.js';
+import { assertJwtConfig, ConfigError } from './config/jwt.js';
 
 const PORT = process.env.PORT || 5000;
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/bookshelf';
+
+/**
+ * Validate configuration before anything else happens.
+ *
+ * This runs before the Mongo connection on purpose. A bad JWT_SECRET is not
+ * something to discover on the first login of the day — at that point the
+ * process is already accepting traffic, and in the specific case of a missing
+ * secret it would have been accepting traffic while signing sessions anyone
+ * could forge. Refusing to start is the only safe answer, and the message has
+ * to say what to do about it.
+ */
+try {
+  assertJwtConfig();
+} catch (error) {
+  if (error instanceof ConfigError) {
+    console.error(`Configuration error: ${error.message}`);
+    process.exit(1);
+  }
+  throw error;
+}
 
 mongoose.connect(MONGODB_URI)
   .then(() => {

--- a/bookshelf-backend/tests/jwt.test.js
+++ b/bookshelf-backend/tests/jwt.test.js
@@ -1,0 +1,279 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseDuration,
+  assertUsableSecret,
+  loadJwtConfig,
+  ConfigError,
+  MIN_SECRET_LENGTH,
+  DEFAULT_EXPIRES_IN,
+} from '../config/jwt.js';
+
+// A secret that passes every rule, so tests about other things are not
+// accidentally testing the secret rules.
+const GOOD_SECRET = 'a'.repeat(MIN_SECRET_LENGTH);
+
+/**
+ * Runs `fn` with console.warn silenced and returns what it wrote.
+ * loadJwtConfig warns on the development path and the test output should not
+ * be full of it.
+ */
+function captureWarnings(fn) {
+  const original = console.warn;
+  const lines = [];
+  console.warn = (...args) => lines.push(args.join(' '));
+  try {
+    const result = fn();
+    return { result, lines };
+  } finally {
+    console.warn = original;
+  }
+}
+
+test('parseDuration', async (t) => {
+  await t.test('reads a bare number as seconds, matching jsonwebtoken', () => {
+    assert.equal(parseDuration('60'), 60 * 1000);
+    assert.equal(parseDuration('1'), 1000);
+  });
+
+  await t.test('accepts a number argument as seconds', () => {
+    assert.equal(parseDuration(90), 90 * 1000);
+  });
+
+  await t.test('handles every short unit', () => {
+    assert.equal(parseDuration('500ms'), 500);
+    assert.equal(parseDuration('30s'), 30 * 1000);
+    assert.equal(parseDuration('15m'), 15 * 60 * 1000);
+    assert.equal(parseDuration('12h'), 12 * 60 * 60 * 1000);
+    assert.equal(parseDuration('7d'), 7 * 24 * 60 * 60 * 1000);
+    assert.equal(parseDuration('2w'), 14 * 24 * 60 * 60 * 1000);
+  });
+
+  await t.test('handles the long unit spellings jsonwebtoken allows', () => {
+    assert.equal(parseDuration('2 days'), 2 * 24 * 60 * 60 * 1000);
+    assert.equal(parseDuration('1 hour'), 60 * 60 * 1000);
+    assert.equal(parseDuration('45 minutes'), 45 * 60 * 1000);
+  });
+
+  await t.test('is case insensitive and tolerates surrounding space', () => {
+    assert.equal(parseDuration('  7D '), 7 * 24 * 60 * 60 * 1000);
+    assert.equal(parseDuration('12H'), 12 * 60 * 60 * 1000);
+  });
+
+  await t.test('accepts a fractional amount', () => {
+    assert.equal(parseDuration('1.5h'), 90 * 60 * 1000);
+  });
+
+  await t.test('rejects an unknown unit rather than guessing', () => {
+    assert.throws(() => parseDuration('7 fortnights'), ConfigError);
+    assert.throws(() => parseDuration('10y'), ConfigError);
+  });
+
+  await t.test('does not require a space before a long unit', () => {
+    assert.equal(parseDuration('7days'), 7 * 24 * 60 * 60 * 1000);
+    assert.equal(parseDuration('90mins'), 90 * 60 * 1000);
+  });
+
+  await t.test('rejects the shapes that used to reach jsonwebtoken', () => {
+    // The point of parsing here is that these are caught at boot. Before this
+    // module existed, jsonwebtoken threw on them inside the login handler and
+    // the operator found out from a 500.
+    assert.throws(() => parseDuration('soon'), ConfigError);
+    assert.throws(() => parseDuration('d7'), ConfigError); // unit before amount
+    assert.throws(() => parseDuration('7d5h'), ConfigError); // compound
+    assert.throws(() => parseDuration(''), ConfigError);
+    assert.throws(() => parseDuration('  '), ConfigError);
+  });
+
+  await t.test('rejects zero and negative lifetimes', () => {
+    assert.throws(() => parseDuration('0h'), ConfigError);
+    assert.throws(() => parseDuration(-5), ConfigError);
+    assert.throws(() => parseDuration(0), ConfigError);
+  });
+
+  await t.test('rejects non-finite numbers', () => {
+    assert.throws(() => parseDuration(Number.NaN), ConfigError);
+    assert.throws(() => parseDuration(Number.POSITIVE_INFINITY), ConfigError);
+  });
+
+  await t.test('rejects types that are neither string nor number', () => {
+    assert.throws(() => parseDuration(null), ConfigError);
+    assert.throws(() => parseDuration({ days: 7 }), ConfigError);
+  });
+});
+
+test('assertUsableSecret', async (t) => {
+  await t.test('returns a good secret, trimmed', () => {
+    assert.equal(assertUsableSecret(`  ${GOOD_SECRET}  `), GOOD_SECRET);
+  });
+
+  await t.test('rejects a missing secret', () => {
+    assert.throws(() => assertUsableSecret(undefined), ConfigError);
+    assert.throws(() => assertUsableSecret(''), ConfigError);
+    assert.throws(() => assertUsableSecret('   '), ConfigError);
+  });
+
+  await t.test('rejects the old hardcoded fallback by name', () => {
+    // The exact string that used to be compiled into generateToken.js and
+    // authMiddleware.js. Setting it explicitly must not be a way back in.
+    assert.throws(
+      () => assertUsableSecret('fallback_secret'),
+      (error) =>
+        error instanceof ConfigError && /placeholder/i.test(error.message)
+    );
+  });
+
+  await t.test('rejects the placeholder from .env.example', () => {
+    assert.throws(() => assertUsableSecret('change-me'), ConfigError);
+    assert.throws(() => assertUsableSecret('CHANGE-ME'), ConfigError);
+  });
+
+  await t.test('rejects other obvious placeholders, case insensitively', () => {
+    for (const value of ['secret', 'password', 'JWT_SECRET', 'Test']) {
+      assert.throws(
+        () => assertUsableSecret(value),
+        ConfigError,
+        `expected "${value}" to be rejected`
+      );
+    }
+  });
+
+  await t.test('rejects a secret that is merely short', () => {
+    const short = 'x'.repeat(MIN_SECRET_LENGTH - 1);
+    assert.throws(
+      () => assertUsableSecret(short),
+      (error) =>
+        error instanceof ConfigError &&
+        error.message.includes(String(MIN_SECRET_LENGTH))
+    );
+  });
+
+  await t.test('accepts a secret of exactly the minimum length', () => {
+    assert.equal(assertUsableSecret(GOOD_SECRET), GOOD_SECRET);
+  });
+
+  await t.test('tells the reader how to generate one', () => {
+    assert.throws(
+      () => assertUsableSecret(undefined),
+      (error) => error.message.includes('openssl rand -hex 32')
+    );
+  });
+});
+
+test('loadJwtConfig', async (t) => {
+  await t.test('uses the configured secret and lifetime', () => {
+    const config = loadJwtConfig({
+      NODE_ENV: 'production',
+      JWT_SECRET: GOOD_SECRET,
+      JWT_EXPIRES_IN: '12h',
+    });
+
+    assert.equal(config.secret, GOOD_SECRET);
+    assert.equal(config.expiresIn, '12h');
+    assert.equal(config.isProduction, true);
+  });
+
+  await t.test('derives maxAgeMs from expiresIn — the bug this fixes', () => {
+    // The cookie used to be pinned at 7 days no matter what the token said.
+    const oneHour = loadJwtConfig({
+      NODE_ENV: 'production',
+      JWT_SECRET: GOOD_SECRET,
+      JWT_EXPIRES_IN: '1h',
+    });
+    assert.equal(oneHour.maxAgeMs, 60 * 60 * 1000);
+
+    const thirtyDays = loadJwtConfig({
+      NODE_ENV: 'production',
+      JWT_SECRET: GOOD_SECRET,
+      JWT_EXPIRES_IN: '30d',
+    });
+    assert.equal(thirtyDays.maxAgeMs, 30 * 24 * 60 * 60 * 1000);
+
+    assert.notEqual(oneHour.maxAgeMs, thirtyDays.maxAgeMs);
+  });
+
+  await t.test('defaults the lifetime to 7d when unset', () => {
+    const config = loadJwtConfig({
+      NODE_ENV: 'production',
+      JWT_SECRET: GOOD_SECRET,
+    });
+
+    assert.equal(config.expiresIn, DEFAULT_EXPIRES_IN);
+    assert.equal(config.maxAgeMs, 7 * 24 * 60 * 60 * 1000);
+  });
+
+  await t.test('treats a blank JWT_EXPIRES_IN as unset', () => {
+    const config = loadJwtConfig({
+      NODE_ENV: 'production',
+      JWT_SECRET: GOOD_SECRET,
+      JWT_EXPIRES_IN: '   ',
+    });
+
+    assert.equal(config.expiresIn, DEFAULT_EXPIRES_IN);
+  });
+
+  await t.test('refuses to start in production without a secret', () => {
+    assert.throws(
+      () => loadJwtConfig({ NODE_ENV: 'production' }),
+      (error) => error instanceof ConfigError && /JWT_SECRET/.test(error.message)
+    );
+  });
+
+  await t.test('refuses a placeholder secret in production', () => {
+    assert.throws(
+      () => loadJwtConfig({ NODE_ENV: 'production', JWT_SECRET: 'fallback_secret' }),
+      ConfigError
+    );
+  });
+
+  await t.test('refuses a short secret in production', () => {
+    assert.throws(
+      () => loadJwtConfig({ NODE_ENV: 'production', JWT_SECRET: 'short' }),
+      ConfigError
+    );
+  });
+
+  await t.test('generates a random dev secret rather than using a constant', () => {
+    const { result: first, lines } = captureWarnings(() =>
+      loadJwtConfig({ NODE_ENV: 'development' })
+    );
+    const { result: second } = captureWarnings(() =>
+      loadJwtConfig({ NODE_ENV: 'development' })
+    );
+
+    // The important property: not a constant. The old fallback was the same
+    // string on every machine and in every clone of this repo.
+    assert.notEqual(first.secret, second.secret);
+    assert.notEqual(first.secret, 'fallback_secret');
+    assert.equal(first.secret.length, 64); // 32 random bytes, hex encoded
+    assert.equal(first.isProduction, false);
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /JWT_SECRET is not set/);
+  });
+
+  await t.test('still validates an explicit secret outside production', () => {
+    // Supplying a bad one is a mistake worth reporting even in development.
+    assert.throws(
+      () => loadJwtConfig({ NODE_ENV: 'development', JWT_SECRET: 'secret' }),
+      ConfigError
+    );
+  });
+
+  await t.test('treats an unset NODE_ENV as not production', () => {
+    const { result } = captureWarnings(() => loadJwtConfig({}));
+    assert.equal(result.isProduction, false);
+  });
+
+  await t.test('reports a malformed lifetime at load, not at first login', () => {
+    assert.throws(
+      () =>
+        loadJwtConfig({
+          NODE_ENV: 'production',
+          JWT_SECRET: GOOD_SECRET,
+          JWT_EXPIRES_IN: '7 fortnights',
+        }),
+      ConfigError
+    );
+  });
+});

--- a/bookshelf-backend/tests/sessionCookie.test.js
+++ b/bookshelf-backend/tests/sessionCookie.test.js
@@ -1,0 +1,200 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import jwt from 'jsonwebtoken';
+
+import { resetJwtConfigCache, MIN_SECRET_LENGTH } from '../config/jwt.js';
+import {
+  SESSION_COOKIE_NAME,
+  sessionCookieOptions,
+  clearSessionCookieOptions,
+} from '../utils/cookies.js';
+import generateToken from '../utils/generateToken.js';
+import { logoutUser } from '../controllers/authController.js';
+
+const SECRET = 'b'.repeat(MIN_SECRET_LENGTH);
+
+/**
+ * Point the config at a known environment. node --test gives each test file
+ * its own process, so mutating process.env here cannot leak into another file.
+ */
+function configure({ expiresIn, nodeEnv = 'test' } = {}) {
+  process.env.JWT_SECRET = SECRET;
+  process.env.NODE_ENV = nodeEnv;
+
+  if (expiresIn === undefined) {
+    delete process.env.JWT_EXPIRES_IN;
+  } else {
+    process.env.JWT_EXPIRES_IN = expiresIn;
+  }
+
+  resetJwtConfigCache();
+}
+
+/** The two bits of the Express response that generateToken touches. */
+function fakeResponse() {
+  const cookies = [];
+  return {
+    cookies,
+    cookie(name, value, options) {
+      cookies.push({ name, value, options });
+      return this;
+    },
+    statusCode: 200,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    },
+  };
+}
+
+test('sessionCookieOptions', async (t) => {
+  await t.test('is httpOnly and same-site strict', () => {
+    configure();
+    const options = sessionCookieOptions({ maxAgeMs: 1000 });
+
+    assert.equal(options.httpOnly, true);
+    assert.equal(options.sameSite, 'strict');
+  });
+
+  await t.test('states path explicitly so set and clear cannot drift', () => {
+    configure();
+    assert.equal(sessionCookieOptions().path, '/');
+    assert.equal(clearSessionCookieOptions().path, '/');
+  });
+
+  await t.test('sets secure only in production', () => {
+    configure({ nodeEnv: 'production' });
+    assert.equal(sessionCookieOptions().secure, true);
+
+    configure({ nodeEnv: 'development' });
+    assert.equal(sessionCookieOptions().secure, false);
+  });
+
+  await t.test('omits maxAge when none is given', () => {
+    configure();
+    assert.ok(!('maxAge' in sessionCookieOptions()));
+  });
+
+  await t.test('clear options expire in the past and carry no maxAge', () => {
+    configure();
+    const options = clearSessionCookieOptions();
+
+    assert.equal(options.expires.getTime(), 0);
+    assert.ok(!('maxAge' in options));
+  });
+
+  await t.test('clear options match the set options attribute for attribute', () => {
+    configure({ nodeEnv: 'production' });
+    const set = sessionCookieOptions({ maxAgeMs: 5000 });
+    const clear = clearSessionCookieOptions();
+
+    // Everything a browser keys a cookie on has to be identical, or logout
+    // adds a second cookie instead of replacing the first.
+    for (const key of ['httpOnly', 'secure', 'sameSite', 'path']) {
+      assert.equal(clear[key], set[key], `${key} differs between set and clear`);
+    }
+  });
+});
+
+test('generateToken', async (t) => {
+  await t.test('signs a token the configured secret verifies', () => {
+    configure();
+    const res = fakeResponse();
+
+    generateToken(res, 'user-1', 'a@example.com', 'user');
+
+    assert.equal(res.cookies.length, 1);
+    assert.equal(res.cookies[0].name, SESSION_COOKIE_NAME);
+
+    const decoded = jwt.verify(res.cookies[0].value, SECRET);
+    assert.equal(decoded.userId, 'user-1');
+    assert.equal(decoded.email, 'a@example.com');
+    assert.equal(decoded.role, 'user');
+  });
+
+  await t.test('the old hardcoded secret no longer verifies anything', () => {
+    configure();
+    const res = fakeResponse();
+
+    generateToken(res, 'user-1', 'a@example.com', 'user');
+
+    assert.throws(() => jwt.verify(res.cookies[0].value, 'fallback_secret'));
+  });
+
+  await t.test('cookie maxAge tracks JWT_EXPIRES_IN', () => {
+    configure({ expiresIn: '1h' });
+    const res = fakeResponse();
+
+    generateToken(res, 'user-1', 'a@example.com', 'user');
+
+    // Previously this was 7 * 24 * 60 * 60 * 1000 regardless.
+    assert.equal(res.cookies[0].options.maxAge, 60 * 60 * 1000);
+  });
+
+  await t.test('cookie expiry and token expiry describe the same moment', () => {
+    configure({ expiresIn: '2h' });
+    const res = fakeResponse();
+
+    generateToken(res, 'user-1', 'a@example.com', 'user');
+
+    const { exp, iat } = jwt.decode(res.cookies[0].value);
+    const tokenLifetimeMs = (exp - iat) * 1000;
+
+    assert.equal(res.cookies[0].options.maxAge, tokenLifetimeMs);
+  });
+
+  await t.test('defaults to a seven day cookie when JWT_EXPIRES_IN is unset', () => {
+    configure();
+    const res = fakeResponse();
+
+    generateToken(res, 'user-1', 'a@example.com', 'user');
+
+    assert.equal(res.cookies[0].options.maxAge, 7 * 24 * 60 * 60 * 1000);
+  });
+
+  await t.test('carries the role, so admin checks have something to read', () => {
+    configure();
+    const res = fakeResponse();
+
+    generateToken(res, 'user-9', 'admin@example.com', 'admin');
+
+    assert.equal(jwt.verify(res.cookies[0].value, SECRET).role, 'admin');
+  });
+});
+
+test('logoutUser', async (t) => {
+  await t.test('clears the cookie with the attributes it was set with', () => {
+    configure({ nodeEnv: 'production' });
+
+    const setRes = fakeResponse();
+    generateToken(setRes, 'user-1', 'a@example.com', 'user');
+
+    const logoutRes = fakeResponse();
+    logoutUser({}, logoutRes);
+
+    const set = setRes.cookies[0];
+    const cleared = logoutRes.cookies[0];
+
+    assert.equal(cleared.name, set.name);
+    assert.equal(cleared.value, '');
+    assert.equal(cleared.options.expires.getTime(), 0);
+
+    for (const key of ['httpOnly', 'secure', 'sameSite', 'path']) {
+      assert.equal(cleared.options[key], set.options[key]);
+    }
+  });
+
+  await t.test('answers 200', () => {
+    configure();
+    const res = fakeResponse();
+
+    logoutUser({}, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.message, 'Logged out successfully');
+  });
+});

--- a/bookshelf-backend/utils/cookies.js
+++ b/bookshelf-backend/utils/cookies.js
@@ -1,0 +1,53 @@
+import { getJwtConfig } from '../config/jwt.js';
+
+export const SESSION_COOKIE_NAME = 'token';
+
+/**
+ * The attributes the session cookie is set with.
+ *
+ * These live here rather than inline at the two call sites because a cookie is
+ * only cleared if the clearing call matches the setting call. `logout` used to
+ * send `{ httpOnly: true, expires: new Date(0) }` while `generateToken` sent
+ * httpOnly, secure, sameSite and maxAge — they happened to still match on the
+ * fields browsers key on (name, domain, path), but nothing kept them that way.
+ * Adding a `domain` to one and not the other would have produced a logout that
+ * silently leaves the user logged in.
+ *
+ * `path` is stated explicitly for the same reason. It defaults to '/', but a
+ * default that has to agree across two files is a default worth writing down.
+ */
+export function sessionCookieOptions({ maxAgeMs } = {}) {
+  const { isProduction } = getJwtConfig();
+
+  const options = {
+    httpOnly: true,
+    // Never send the session over plaintext HTTP in production. Left off in
+    // development because localhost is not served over TLS and the browser
+    // would drop the cookie entirely.
+    secure: isProduction,
+    // The frontend is a separate origin but a same-site deployment; 'strict'
+    // is what the app has always used and nothing here needs cross-site POSTs
+    // to carry the session.
+    sameSite: 'strict',
+    path: '/',
+  };
+
+  if (maxAgeMs !== undefined) {
+    options.maxAge = maxAgeMs;
+  }
+
+  return options;
+}
+
+/**
+ * Options for removing the cookie.
+ *
+ * Same attributes, no maxAge, an expiry in the past. Derived from the setter
+ * so the two cannot drift.
+ */
+export function clearSessionCookieOptions() {
+  return {
+    ...sessionCookieOptions(),
+    expires: new Date(0),
+  };
+}

--- a/bookshelf-backend/utils/generateToken.js
+++ b/bookshelf-backend/utils/generateToken.js
@@ -1,16 +1,29 @@
 import jwt from 'jsonwebtoken';
+import { getJwtConfig } from '../config/jwt.js';
+import { SESSION_COOKIE_NAME, sessionCookieOptions } from './cookies.js';
 
+/**
+ * Sign a session token and attach it as an httpOnly cookie.
+ *
+ * The secret and the lifetime both come from config/jwt.js. That module has
+ * already refused to start the process if the secret is missing, too short or
+ * a known placeholder, so there is no `|| 'fallback_secret'` to fall through
+ * to here — the previous version of this file would sign real sessions with a
+ * constant published in this repository whenever JWT_SECRET was unset.
+ *
+ * The cookie's maxAge is the token's own lifetime in milliseconds rather than
+ * a hardcoded seven days. They were two independent numbers before, so
+ * JWT_EXPIRES_IN=1h produced a cookie the browser kept for a week and the
+ * server rejected for all but the first hour of it.
+ */
 const generateToken = (res, userId, email, role) => {
-  const token = jwt.sign({ userId, email, role }, process.env.JWT_SECRET || 'fallback_secret', {
-    expiresIn: process.env.JWT_EXPIRES_IN || '7d',
-  });
+  const { secret, expiresIn, maxAgeMs } = getJwtConfig();
 
-  res.cookie('token', token, {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'strict',
-    maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
-  });
+  const token = jwt.sign({ userId, email, role }, secret, { expiresIn });
+
+  res.cookie(SESSION_COOKIE_NAME, token, sessionCookieOptions({ maxAgeMs }));
+
+  return token;
 };
 
 export default generateToken;


### PR DESCRIPTION
Closes #305.

## What was wrong

Two bugs sharing one cause — the values were read from `process.env` at the point of use, so nothing owned them.

**1. The signing key had a committed fallback.** `process.env.JWT_SECRET || 'fallback_secret'` was in `utils/generateToken.js` and `middleware/authMiddleware.js`. A deployment that forgot the variable started with no complaint and signed real sessions with a string that is in this repository. `protect` trusts `decoded.userId`, so anyone who read the source could sign a token for any account — including `role: 'admin'`, which the `admin` middleware then accepts for `GET /api/orders`.

`.env.example` already spelled the risk out in a comment. A comment does not stop a deploy.

**2. The cookie outlived the token.** `expiresIn` came from `JWT_EXPIRES_IN`; `maxAge` was hardcoded to `7 * 24 * 60 * 60 * 1000`. Set `JWT_EXPIRES_IN=1h` and the browser keeps sending a cookie for another six days that the server rejects on every request. The UI looks logged in, `/api/auth/me` 401s, and it reads to the user as being logged out at random.

## What this does

**`config/jwt.js` (new)** is the only module that reads `JWT_SECRET` or `JWT_EXPIRES_IN`.

- Rejects a missing secret, a known placeholder, or anything under 32 characters. `fallback_secret` and `change-me` are on the reject list by name, so setting them explicitly is not a way back in.
- Parses the lifetime at load. `JWT_EXPIRES_IN=7days` is now a refusal to start instead of a 500 on the first login of the day. Supports the same shapes `jsonwebtoken` does — bare seconds, `30m`, `12h`, `7d`, `2w`, and the long spellings.
- Derives `maxAgeMs` from that parse. One number, one place.

**Development still works with no setup.** With `NODE_ENV` unset and no `JWT_SECRET`, the config generates 32 random bytes for the life of the process and warns. Sessions do not survive a restart — that is the trade, and it is stated in the warning. The distinction that matters: random-per-process is not the same thing as a constant every clone of this repo shares.

**`server.js`** calls `assertJwtConfig()` before connecting to Mongo:

```console
$ NODE_ENV=production node server.js
Configuration error: JWT_SECRET is not set. The API signs session cookies with it,
so starting without one would mean every session is forgeable.
Generate one with: openssl rand -hex 32
$ echo $?
1
```

```console
$ NODE_ENV=production JWT_SECRET=change-me node server.js
Configuration error: JWT_SECRET is set to "change-me", which is a placeholder that
appears in this repository. [...]
```

```console
$ NODE_ENV=production JWT_SECRET=<real> JWT_EXPIRES_IN="7 fortnights" node server.js
Configuration error: JWT lifetime "7 fortnights" uses an unknown unit "fortnights".
Supported units: ms, s, m, h, d, w.
```

The config resolves lazily rather than at import time, so importing `authMiddleware` in a unit test does not require a valid secret in that test's environment. `assertJwtConfig()` in `server.js` is what makes a real boot fail fast.

**`utils/cookies.js` (new)** holds the cookie attributes. `logoutUser` was building its own `{ httpOnly: true, expires: new Date(0) }` inline while `generateToken` sent httpOnly + secure + sameSite + maxAge. They happened to still match on the fields browsers key a cookie on (name, domain, path) — but nothing kept them matching, and adding a `domain` to one side would have produced a logout that silently leaves the user logged in. Both sides now derive from one function, and there is a test asserting they agree attribute for attribute.

## Tests

`tests/jwt.test.js` and `tests/sessionCookie.test.js`, 51 new cases:

- every duration shape, including the ones that used to blow up inside the login handler
- every secret rejection path, and that the error tells you `openssl rand -hex 32`
- that the dev secret differs between two loads — the property the old fallback did not have
- that `maxAge` changes when `JWT_EXPIRES_IN` changes, and that cookie expiry and token `exp - iat` describe the same moment
- that `fallback_secret` no longer verifies a token this code issues
- that logout's cookie options match generateToken's

```console
$ npm test
# tests 149
# pass 149
# fail 0
```

Was 98 before this branch.

## Notes for review

- No behaviour change for a correctly configured deployment. `JWT_SECRET` set to something real and `JWT_EXPIRES_IN` left at `7d` produces exactly the cookie it did before.
- A deployment currently running **without** `JWT_SECRET` will stop starting. That is intended and is the point of the change; the error message says what to set.
- `.env.example` updated to describe what is enforced rather than what used to be tolerated.
- `services/stripeService.js` and `webhook/stripeWebhook.js` have the same fallback-to-a-committed-credential shape. Left alone here — filed separately as #306 because the blast radius and the fix are different.