### PR TITLE
fix(payments): stop the Stripe webhook trusting a committed secret, and stop it retrying forever (closes #306)

### DIFF
--- a/bookshelf-backend/.env.example
+++ b/bookshelf-backend/.env.example
@@ -25,5 +25,18 @@ FRONTEND_URL=http://localhost:5173
 
 # Stripe. The webhook secret comes from the Stripe dashboard, or from
 # `stripe listen` when testing locally.
+#
+# Both are required. There is no fallback for either, and the placeholder
+# values below are rejected outright rather than quietly accepted.
+#
+# STRIPE_SECRET_KEY is the secret key (sk_...) from
+# https://dashboard.stripe.com/apikeys. Not the publishable key (pk_...) —
+# that one belongs in the frontend as VITE_STRIPE_PUBLISHABLE_KEY.
 STRIPE_SECRET_KEY=sk_test_your_key_here
+
+# STRIPE_WEBHOOK_SECRET (whsec_...) comes from the endpoint page in the Stripe
+# dashboard, or from `stripe listen` when testing locally. Signature
+# verification is the only thing that makes POST /api/payments/webhook safe to
+# expose, so the endpoint refuses to verify anything without it rather than
+# falling back to a default.
 STRIPE_WEBHOOK_SECRET=whsec_your_secret_here

--- a/bookshelf-backend/config/stripe.js
+++ b/bookshelf-backend/config/stripe.js
@@ -1,0 +1,137 @@
+/**
+ * Stripe credentials, resolved once and validated.
+ *
+ * Both credentials used to have a hardcoded fallback:
+ *
+ *   new Stripe(process.env.STRIPE_SECRET_KEY || 'sk_test_mock_stripe_key_123')
+ *   process.env.STRIPE_WEBHOOK_SECRET || 'whsec_test_mock_webhook_secret_123'
+ *
+ * The webhook one is the dangerous half. `POST /api/payments/webhook` is
+ * public and unauthenticated by design — signature verification is the entire
+ * reason to believe a request came from Stripe. Verifying against a string
+ * printed in this repository means anyone can sign their own
+ * `payment_intent.succeeded` and have an order marked paid.
+ *
+ * There is no safe default for either value, so there is no default.
+ */
+
+export class StripeConfigError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'StripeConfigError';
+  }
+}
+
+/**
+ * The exact fallbacks that used to be compiled in. Listed so that setting one
+ * explicitly is not a way to reintroduce the hole.
+ */
+const REJECTED_VALUES = new Set([
+  'sk_test_mock_stripe_key_123',
+  'whsec_test_mock_webhook_secret_123',
+  'sk_test_your_key_here',
+  'whsec_your_secret_here',
+  'change-me',
+]);
+
+function assertNotPlaceholder(name, value) {
+  if (REJECTED_VALUES.has(value)) {
+    throw new StripeConfigError(
+      `${name} is set to "${value}", which is a placeholder from this ` +
+        'repository rather than a real credential. Take the real value from ' +
+        'the Stripe dashboard.'
+    );
+  }
+}
+
+/**
+ * Stripe secret keys are `sk_test_...` or `sk_live_...`. Checking the prefix
+ * catches the common mistake of pasting the *publishable* key (`pk_...`),
+ * which otherwise fails much later as an opaque 401 from Stripe.
+ */
+export function validateSecretKey(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new StripeConfigError(
+      'STRIPE_SECRET_KEY is not set. Payments cannot be created without it. ' +
+        'Copy it from https://dashboard.stripe.com/apikeys.'
+    );
+  }
+
+  const key = value.trim();
+  assertNotPlaceholder('STRIPE_SECRET_KEY', key);
+
+  if (key.startsWith('pk_')) {
+    throw new StripeConfigError(
+      'STRIPE_SECRET_KEY looks like a publishable key (pk_...). The ' +
+        'publishable key belongs in the frontend as ' +
+        'VITE_STRIPE_PUBLISHABLE_KEY; this needs the secret key (sk_...).'
+    );
+  }
+
+  if (!key.startsWith('sk_') && !key.startsWith('rk_')) {
+    throw new StripeConfigError(
+      `STRIPE_SECRET_KEY should start with "sk_" (or "rk_" for a restricted ` +
+        `key). Received a value starting "${key.slice(0, 4)}".`
+    );
+  }
+
+  return key;
+}
+
+/**
+ * Webhook signing secrets are `whsec_...`, from the dashboard or from
+ * `stripe listen` when testing locally.
+ */
+export function validateWebhookSecret(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new StripeConfigError(
+      'STRIPE_WEBHOOK_SECRET is not set. Signature verification is the only ' +
+        'thing that makes the webhook endpoint safe to expose, so it cannot ' +
+        'run without one. Get it from the endpoint page in the Stripe ' +
+        'dashboard, or from `stripe listen` locally.'
+    );
+  }
+
+  const secret = value.trim();
+  assertNotPlaceholder('STRIPE_WEBHOOK_SECRET', secret);
+
+  if (!secret.startsWith('whsec_')) {
+    throw new StripeConfigError(
+      `STRIPE_WEBHOOK_SECRET should start with "whsec_". Received a value ` +
+        `starting "${secret.slice(0, 6)}".`
+    );
+  }
+
+  return secret;
+}
+
+export function loadStripeConfig(env = process.env) {
+  return {
+    secretKey: validateSecretKey(env.STRIPE_SECRET_KEY),
+    webhookSecret: validateWebhookSecret(env.STRIPE_WEBHOOK_SECRET),
+    apiVersion: '2023-10-16',
+  };
+}
+
+let cached = null;
+
+/**
+ * Resolved lazily rather than at import time.
+ *
+ * Importing this module must not throw — `webhook/stripeWebhook.js` is
+ * imported by `app.js`, which unit tests import, and those tests have no
+ * business needing Stripe credentials. The validation happens on first real
+ * use, and the callers below turn a StripeConfigError into a refusal rather
+ * than falling back to anything.
+ */
+export function getStripeConfig() {
+  if (!cached) {
+    cached = loadStripeConfig();
+  }
+  return cached;
+}
+
+/** Test seam. Not used by application code. */
+export function resetStripeConfigCache() {
+  cached = null;
+}

--- a/bookshelf-backend/services/stripeService.js
+++ b/bookshelf-backend/services/stripeService.js
@@ -1,16 +1,39 @@
 import Stripe from 'stripe';
 import dotenv from 'dotenv';
+import { getStripeConfig } from '../config/stripe.js';
 
 dotenv.config();
 
-// Using placeholder secret key if environment variable is missing
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || 'sk_test_mock_stripe_key_123', {
-  apiVersion: '2023-10-16',
-});
+let client = null;
+
+/**
+ * The Stripe client, built on first use.
+ *
+ * This used to be constructed at module load with a fallback key:
+ *
+ *   new Stripe(process.env.STRIPE_SECRET_KEY || 'sk_test_mock_stripe_key_123')
+ *
+ * `sk_test_mock_stripe_key_123` is not a real key, so the failure landed on
+ * whichever customer first tried to check out, as a 500 carrying a raw Stripe
+ * error message. Constructing lazily off a validated config means the failure
+ * says what is actually wrong, and says it once.
+ */
+export function getStripeClient() {
+  if (!client) {
+    const { secretKey, apiVersion } = getStripeConfig();
+    client = new Stripe(secretKey, { apiVersion });
+  }
+  return client;
+}
+
+/** Test seam. Not used by application code. */
+export function resetStripeClient() {
+  client = null;
+}
 
 export const createPaymentIntent = async (amount, currency = 'usd', metadata = {}) => {
   try {
-    const paymentIntent = await stripe.paymentIntents.create({
+    const paymentIntent = await getStripeClient().paymentIntents.create({
       amount: Math.round(amount * 100), // Stripe expects amounts in cents
       currency,
       automatic_payment_methods: {
@@ -24,12 +47,28 @@ export const createPaymentIntent = async (amount, currency = 'usd', metadata = {
   }
 };
 
-export const verifyWebhookSignature = (payload, signature, secret) => {
+/**
+ * Verify a webhook signature against the configured signing secret.
+ *
+ * The secret is no longer a parameter. It was, and the one caller passed
+ * `process.env.STRIPE_WEBHOOK_SECRET || 'whsec_test_mock_webhook_secret_123'`
+ * — a value published in this repository. Signature verification is the only
+ * thing standing between the public webhook endpoint and a forged
+ * `payment_intent.succeeded`, so the secret is read from validated config here
+ * and cannot be supplied, defaulted or overridden by a caller.
+ */
+export const verifyWebhookSignature = (payload, signature) => {
+  const { webhookSecret } = getStripeConfig();
+
   try {
-    return stripe.webhooks.constructEvent(payload, signature, secret);
+    return getStripeClient().webhooks.constructEvent(
+      payload,
+      signature,
+      webhookSecret
+    );
   } catch (err) {
     throw new Error(`Webhook signature verification failed: ${err.message}`);
   }
 };
 
-export default stripe;
+export default { getStripeClient, createPaymentIntent, verifyWebhookSignature };

--- a/bookshelf-backend/tests/stripeConfig.test.js
+++ b/bookshelf-backend/tests/stripeConfig.test.js
@@ -1,0 +1,120 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  validateSecretKey,
+  validateWebhookSecret,
+  loadStripeConfig,
+  StripeConfigError,
+} from '../config/stripe.js';
+
+// Deliberately short and underscore-separated. A realistic-looking Stripe key
+// here trips GitHub's push protection, and the validator only inspects the
+// prefix anyway.
+const GOOD_KEY = 'sk_test_fixture_key';
+const GOOD_WEBHOOK_SECRET = 'whsec_fixture_secret';
+
+test('validateSecretKey', async (t) => {
+  await t.test('accepts a test key and a live key', () => {
+    assert.equal(validateSecretKey(GOOD_KEY), GOOD_KEY);
+    assert.equal(validateSecretKey('sk_live_fixture_key'), 'sk_live_fixture_key');
+  });
+
+  await t.test('accepts a restricted key', () => {
+    assert.equal(validateSecretKey('rk_test_restricted'), 'rk_test_restricted');
+  });
+
+  await t.test('trims', () => {
+    assert.equal(validateSecretKey(`  ${GOOD_KEY} `), GOOD_KEY);
+  });
+
+  await t.test('rejects a missing key', () => {
+    assert.throws(() => validateSecretKey(undefined), StripeConfigError);
+    assert.throws(() => validateSecretKey(''), StripeConfigError);
+    assert.throws(() => validateSecretKey('   '), StripeConfigError);
+  });
+
+  await t.test('rejects the old hardcoded fallback by name', () => {
+    assert.throws(
+      () => validateSecretKey('sk_test_mock_stripe_key_123'),
+      (error) =>
+        error instanceof StripeConfigError && /placeholder/i.test(error.message)
+    );
+  });
+
+  await t.test('rejects the placeholder from .env.example', () => {
+    assert.throws(() => validateSecretKey('sk_test_your_key_here'), StripeConfigError);
+  });
+
+  await t.test('names the mistake when given a publishable key', () => {
+    // Easy to do, and otherwise surfaces much later as an opaque 401.
+    assert.throws(
+      () => validateSecretKey('pk_test_fixture_key'),
+      (error) => /publishable key/i.test(error.message)
+    );
+  });
+
+  await t.test('rejects something that is not a Stripe key at all', () => {
+    assert.throws(() => validateSecretKey('hunter2'), StripeConfigError);
+  });
+});
+
+test('validateWebhookSecret', async (t) => {
+  await t.test('accepts a whsec_ value', () => {
+    assert.equal(validateWebhookSecret(GOOD_WEBHOOK_SECRET), GOOD_WEBHOOK_SECRET);
+  });
+
+  await t.test('rejects a missing secret and explains why it matters', () => {
+    assert.throws(
+      () => validateWebhookSecret(undefined),
+      (error) =>
+        error instanceof StripeConfigError &&
+        /signature verification/i.test(error.message)
+    );
+  });
+
+  await t.test('rejects the exact fallback that used to be compiled in', () => {
+    // This is the value that made forged payment_intent.succeeded events
+    // possible on any deployment that forgot the variable.
+    assert.throws(
+      () => validateWebhookSecret('whsec_test_mock_webhook_secret_123'),
+      StripeConfigError
+    );
+  });
+
+  await t.test('rejects the placeholder from .env.example', () => {
+    assert.throws(() => validateWebhookSecret('whsec_your_secret_here'), StripeConfigError);
+  });
+
+  await t.test('rejects a value with the wrong prefix', () => {
+    assert.throws(() => validateWebhookSecret('sk_test_something'), StripeConfigError);
+    assert.throws(() => validateWebhookSecret('random-string'), StripeConfigError);
+  });
+});
+
+test('loadStripeConfig', async (t) => {
+  await t.test('reads both credentials and pins the API version', () => {
+    const config = loadStripeConfig({
+      STRIPE_SECRET_KEY: GOOD_KEY,
+      STRIPE_WEBHOOK_SECRET: GOOD_WEBHOOK_SECRET,
+    });
+
+    assert.equal(config.secretKey, GOOD_KEY);
+    assert.equal(config.webhookSecret, GOOD_WEBHOOK_SECRET);
+    assert.equal(config.apiVersion, '2023-10-16');
+  });
+
+  await t.test('has no fallback for either value', () => {
+    assert.throws(() => loadStripeConfig({}), StripeConfigError);
+
+    assert.throws(
+      () => loadStripeConfig({ STRIPE_SECRET_KEY: GOOD_KEY }),
+      StripeConfigError
+    );
+
+    assert.throws(
+      () => loadStripeConfig({ STRIPE_WEBHOOK_SECRET: GOOD_WEBHOOK_SECRET }),
+      StripeConfigError
+    );
+  });
+});

--- a/bookshelf-backend/tests/stripeWebhook.test.js
+++ b/bookshelf-backend/tests/stripeWebhook.test.js
@@ -1,0 +1,295 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createStripeWebhookHandler } from '../webhook/stripeWebhook.js';
+import { StripeConfigError } from '../config/stripe.js';
+import { ProcessedEventStore } from '../utils/webhookEvents.js';
+
+const ORDER_ID = '507f1f77bcf86cd799439011';
+
+function paymentEvent(type, overrides = {}) {
+  return {
+    id: overrides.id ?? 'evt_1',
+    type,
+    data: {
+      object: {
+        id: 'pi_1',
+        metadata:
+          'metadata' in overrides ? overrides.metadata : { orderId: ORDER_ID },
+      },
+    },
+  };
+}
+
+function fakeResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+const silentLogger = { log() {}, warn() {}, error() {} };
+
+/**
+ * Build a handler with everything faked, and hand back the fakes so a test
+ * can assert on what the handler did to them.
+ */
+function harness({ event, verifyThrows, order, saveThrows, findThrows } = {}) {
+  const saved = [];
+
+  const orders = {
+    async findById(id) {
+      if (findThrows) throw findThrows;
+      return id === ORDER_ID ? order ?? null : null;
+    },
+    async save(document) {
+      if (saveThrows) throw saveThrows;
+      saved.push(document);
+      return document;
+    },
+  };
+
+  const store = new ProcessedEventStore();
+
+  const handler = createStripeWebhookHandler({
+    verify() {
+      if (verifyThrows) throw verifyThrows;
+      return event;
+    },
+    orders,
+    store,
+    logger: silentLogger,
+  });
+
+  const req = { headers: { 'stripe-signature': 't=1,v1=abc' }, body: Buffer.from('{}') };
+
+  return { handler, req, saved, store };
+}
+
+test('signature verification', async (t) => {
+  await t.test('a bad signature is 400 and nothing is written', async () => {
+    const { handler, req, saved } = harness({
+      verifyThrows: new Error('Webhook signature verification failed: no match'),
+    });
+    const res = fakeResponse();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(saved.length, 0);
+  });
+
+  await t.test('the response does not echo the internal error', async () => {
+    const { handler, req } = harness({
+      verifyThrows: new Error('Webhook signature verification failed: secrets differ'),
+    });
+    const res = fakeResponse();
+
+    await handler(req, res);
+
+    assert.equal(res.body.message, 'Signature verification failed');
+    assert.ok(!JSON.stringify(res.body).includes('secrets differ'));
+  });
+
+  await t.test('a missing signing secret refuses rather than falling back', async () => {
+    // The whole point of the change: with no configured secret the endpoint
+    // stops working. It does not verify against a repository constant.
+    const { handler, req, saved } = harness({
+      verifyThrows: new StripeConfigError('STRIPE_WEBHOOK_SECRET is not set.'),
+    });
+    const res = fakeResponse();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 500);
+    assert.equal(res.body.message, 'Webhook is not configured');
+    assert.equal(saved.length, 0);
+  });
+});
+
+test('events Stripe should stop resending get a 2xx', async (t) => {
+  await t.test('an event type we do not handle', async () => {
+    const { handler, req } = harness({ event: paymentEvent('charge.refunded') });
+    const res = fakeResponse();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.handled, false);
+  });
+
+  await t.test('metadata with no orderId', async () => {
+    const { handler, req } = harness({
+      event: paymentEvent('payment_intent.succeeded', { metadata: {} }),
+    });
+    const res = fakeResponse();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.match(res.body.reason, /no orderId/);
+  });
+
+  await t.test('an orderId that is not an ObjectId — the old retry loop', async () => {
+    // This used to be: findById -> CastError -> 500 -> Stripe retries for
+    // three days -> same CastError every time.
+    const { handler, req } = harness({
+      event: paymentEvent('payment_intent.succeeded', {
+        metadata: { orderId: 'not-an-objectid' },
+      }),
+    });
+    const res = fakeResponse();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.match(res.body.reason, /not a valid ObjectId/);
+  });
+
+  await t.test('an order that does not exist', async () => {
+    const { handler, req } = harness({
+      event: paymentEvent('payment_intent.succeeded'),
+      order: null,
+    });
+    const res = fakeResponse();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.match(res.body.reason, /not found/);
+  });
+});
+
+test('applying an event', async (t) => {
+  await t.test('marks a pending order paid and saves once', async () => {
+    const order = { paymentStatus: 'pending', status: 'pending' };
+    const { handler, req, saved } = harness({
+      event: paymentEvent('payment_intent.succeeded'),
+      order,
+    });
+    const res = fakeResponse();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.handled, true);
+    assert.equal(saved.length, 1);
+    assert.equal(saved[0].paymentStatus, 'paid');
+    assert.equal(saved[0].status, 'confirmed');
+    assert.ok(saved[0].receiptNumber);
+    assert.ok(saved[0].paidAt instanceof Date);
+  });
+
+  await t.test('refuses to cancel a paid order', async () => {
+    const order = { paymentStatus: 'paid', status: 'confirmed' };
+    const { handler, req, saved } = harness({
+      event: paymentEvent('payment_intent.canceled'),
+      order,
+    });
+    const res = fakeResponse();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.handled, false);
+    assert.equal(saved.length, 0, 'nothing should have been written');
+    assert.equal(order.paymentStatus, 'paid');
+    assert.equal(order.status, 'confirmed');
+  });
+
+  await t.test('refuses to fail a paid order', async () => {
+    const order = { paymentStatus: 'paid', status: 'confirmed' };
+    const { handler, req, saved } = harness({
+      event: paymentEvent('payment_intent.payment_failed'),
+      order,
+    });
+
+    await handler(req, fakeResponse());
+
+    assert.equal(saved.length, 0);
+    assert.equal(order.paymentStatus, 'paid');
+  });
+});
+
+test('duplicate delivery', async (t) => {
+  await t.test('the same event id is applied once', async () => {
+    const order = { paymentStatus: 'pending', status: 'pending' };
+    const { handler, req, saved } = harness({
+      event: paymentEvent('payment_intent.succeeded'),
+      order,
+    });
+
+    const first = fakeResponse();
+    await handler(req, first);
+
+    const second = fakeResponse();
+    await handler(req, second);
+
+    assert.equal(first.body.handled, true);
+    assert.equal(second.statusCode, 200);
+    assert.equal(second.body.handled, false);
+    assert.match(second.body.reason, /duplicate/);
+    assert.equal(saved.length, 1);
+  });
+
+  await t.test('an unusable event is remembered too', async () => {
+    const { handler, req, store } = harness({
+      event: paymentEvent('payment_intent.succeeded', { metadata: {} }),
+    });
+
+    await handler(req, fakeResponse());
+
+    assert.equal(store.has('evt_1'), true);
+  });
+});
+
+test('transient failures', async (t) => {
+  await t.test('a database read failure is a 500 so Stripe retries', async () => {
+    const { handler, req } = harness({
+      event: paymentEvent('payment_intent.succeeded'),
+      findThrows: new Error('connection timed out'),
+    });
+    const res = fakeResponse();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 500);
+  });
+
+  await t.test('a write failure is a 500 and is not marked processed', async () => {
+    // Marking it processed would mean the retry is discarded as a duplicate
+    // and the payment is never recorded.
+    const { handler, req, store } = harness({
+      event: paymentEvent('payment_intent.succeeded'),
+      order: { paymentStatus: 'pending', status: 'pending' },
+      saveThrows: new Error('write concern error'),
+    });
+    const res = fakeResponse();
+
+    await handler(req, res);
+
+    assert.equal(res.statusCode, 500);
+    assert.equal(store.has('evt_1'), false);
+  });
+
+  await t.test('the 500 body does not leak the database error', async () => {
+    const { handler, req } = harness({
+      event: paymentEvent('payment_intent.succeeded'),
+      findThrows: new Error('mongodb://user:password@host failed'),
+    });
+    const res = fakeResponse();
+
+    await handler(req, res);
+
+    assert.equal(res.body.message, 'Failed to process event');
+    assert.ok(!JSON.stringify(res.body).includes('password'));
+  });
+});

--- a/bookshelf-backend/tests/webhookEvents.test.js
+++ b/bookshelf-backend/tests/webhookEvents.test.js
@@ -1,0 +1,310 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  HANDLED_EVENT_TYPES,
+  isHandledEventType,
+  extractPaymentContext,
+  decideTransition,
+  generateReceiptNumber,
+  isValidObjectId,
+  ProcessedEventStore,
+} from '../utils/webhookEvents.js';
+
+const ORDER_ID = '507f1f77bcf86cd799439011';
+
+function paymentEvent(type, overrides = {}) {
+  return {
+    id: overrides.id ?? 'evt_test_1',
+    type,
+    data: {
+      object: {
+        id: overrides.paymentIntentId ?? 'pi_test_1',
+        metadata: 'metadata' in overrides ? overrides.metadata : { orderId: ORDER_ID },
+      },
+    },
+  };
+}
+
+test('isValidObjectId', async (t) => {
+  await t.test('accepts 24 hex characters', () => {
+    assert.equal(isValidObjectId(ORDER_ID), true);
+    assert.equal(isValidObjectId('AAAAAAAAAAAAAAAAAAAAAAAA'.toLowerCase()), true);
+  });
+
+  await t.test('rejects the shapes that used to reach Mongoose', () => {
+    // Each of these produced a CastError -> 500 -> Stripe retry loop.
+    assert.equal(isValidObjectId('not-an-objectid'), false);
+    assert.equal(isValidObjectId(''), false);
+    assert.equal(isValidObjectId('507f1f77bcf86cd79943901'), false); // 23 chars
+    assert.equal(isValidObjectId('507f1f77bcf86cd7994390111'), false); // 25
+    assert.equal(isValidObjectId('507f1f77bcf86cd79943901z'), false); // non-hex
+    assert.equal(isValidObjectId(undefined), false);
+    assert.equal(isValidObjectId(null), false);
+    assert.equal(isValidObjectId(12345), false);
+  });
+});
+
+test('isHandledEventType', async (t) => {
+  await t.test('accepts the three payment intent events', () => {
+    for (const type of HANDLED_EVENT_TYPES) {
+      assert.equal(isHandledEventType(type), true, type);
+    }
+  });
+
+  await t.test('rejects everything else', () => {
+    assert.equal(isHandledEventType('charge.refunded'), false);
+    assert.equal(isHandledEventType('customer.created'), false);
+    assert.equal(isHandledEventType(undefined), false);
+  });
+});
+
+test('extractPaymentContext', async (t) => {
+  await t.test('pulls the order id and payment intent id', () => {
+    const context = extractPaymentContext(paymentEvent('payment_intent.succeeded'));
+
+    assert.equal(context.ok, true);
+    assert.equal(context.orderId, ORDER_ID);
+    assert.equal(context.paymentIntentId, 'pi_test_1');
+  });
+
+  await t.test('reports a missing payment intent object', () => {
+    const context = extractPaymentContext({ type: 'payment_intent.succeeded', data: {} });
+
+    assert.equal(context.ok, false);
+    assert.match(context.reason, /no payment intent/i);
+  });
+
+  await t.test('reports missing metadata', () => {
+    const context = extractPaymentContext(
+      paymentEvent('payment_intent.succeeded', { metadata: undefined })
+    );
+
+    assert.equal(context.ok, false);
+    assert.match(context.reason, /no orderId/i);
+  });
+
+  await t.test('reports an orderId that is not an ObjectId', () => {
+    // The retry-loop bug: this used to go straight to findById.
+    const context = extractPaymentContext(
+      paymentEvent('payment_intent.succeeded', { metadata: { orderId: 'nope' } })
+    );
+
+    assert.equal(context.ok, false);
+    assert.match(context.reason, /not a valid ObjectId/);
+  });
+
+  await t.test('survives a completely empty event', () => {
+    assert.equal(extractPaymentContext({}).ok, false);
+    assert.equal(extractPaymentContext(undefined).ok, false);
+  });
+});
+
+test('decideTransition — payment_intent.succeeded', async (t) => {
+  await t.test('marks a pending order paid', () => {
+    const order = { paymentStatus: 'pending', status: 'pending' };
+    const decision = decideTransition(
+      order,
+      paymentEvent('payment_intent.succeeded'),
+      { paymentIntentId: 'pi_abc', now: new Date('2026-01-02T03:04:05Z') }
+    );
+
+    assert.equal(decision.action, 'apply');
+    assert.equal(decision.changes.paymentStatus, 'paid');
+    assert.equal(decision.changes.status, 'confirmed');
+    assert.equal(decision.changes.transactionId, 'pi_abc');
+    assert.equal(decision.changes.paidAt.toISOString(), '2026-01-02T03:04:05.000Z');
+    assert.match(decision.changes.receiptNumber, /^RCPT-2026-[0-9A-F]{10}$/);
+  });
+
+  await t.test('is idempotent — a redelivery changes nothing', () => {
+    const order = { paymentStatus: 'paid', status: 'confirmed' };
+    const decision = decideTransition(order, paymentEvent('payment_intent.succeeded'));
+
+    assert.equal(decision.action, 'skip');
+    assert.match(decision.reason, /already paid/);
+  });
+
+  await t.test('keeps an existing receipt number rather than reissuing', () => {
+    const order = {
+      paymentStatus: 'failed',
+      status: 'payment_failed',
+      receiptNumber: 'RCPT-2025-ORIGINAL',
+    };
+    const decision = decideTransition(order, paymentEvent('payment_intent.succeeded'));
+
+    assert.equal(decision.changes.receiptNumber, 'RCPT-2025-ORIGINAL');
+  });
+
+  await t.test('recovers an order that had been marked failed', () => {
+    // A failed attempt followed by a successful retry is normal.
+    const order = { paymentStatus: 'failed', status: 'payment_failed' };
+    const decision = decideTransition(order, paymentEvent('payment_intent.succeeded'));
+
+    assert.equal(decision.action, 'apply');
+    assert.equal(decision.changes.paymentStatus, 'paid');
+  });
+
+  await t.test('does not mutate the order it is given', () => {
+    const order = { paymentStatus: 'pending', status: 'pending' };
+    decideTransition(order, paymentEvent('payment_intent.succeeded'));
+
+    assert.equal(order.paymentStatus, 'pending');
+    assert.equal(order.status, 'pending');
+  });
+});
+
+test('decideTransition — payment_intent.payment_failed', async (t) => {
+  await t.test('marks a pending order failed', () => {
+    const order = { paymentStatus: 'pending', status: 'pending' };
+    const decision = decideTransition(order, paymentEvent('payment_intent.payment_failed'));
+
+    assert.equal(decision.action, 'apply');
+    assert.equal(decision.changes.paymentStatus, 'failed');
+    assert.equal(decision.changes.status, 'payment_failed');
+  });
+
+  await t.test('refuses to mark a paid order failed', () => {
+    // Out-of-order delivery: a failed first attempt arriving after the
+    // successful second one. The old handler applied this unconditionally.
+    const order = { paymentStatus: 'paid', status: 'confirmed' };
+    const decision = decideTransition(order, paymentEvent('payment_intent.payment_failed'));
+
+    assert.equal(decision.action, 'skip');
+    assert.match(decision.reason, /paid order failed/);
+  });
+
+  await t.test('is idempotent', () => {
+    const order = { paymentStatus: 'failed', status: 'payment_failed' };
+    assert.equal(
+      decideTransition(order, paymentEvent('payment_intent.payment_failed')).action,
+      'skip'
+    );
+  });
+});
+
+test('decideTransition — payment_intent.canceled', async (t) => {
+  await t.test('cancels a pending order', () => {
+    const order = { paymentStatus: 'pending', status: 'pending' };
+    const decision = decideTransition(order, paymentEvent('payment_intent.canceled'));
+
+    assert.equal(decision.action, 'apply');
+    assert.equal(decision.changes.paymentStatus, 'canceled');
+    assert.equal(decision.changes.status, 'canceled');
+  });
+
+  await t.test('refuses to cancel a paid order — the bug from the issue', () => {
+    const order = { paymentStatus: 'paid', status: 'confirmed' };
+    const decision = decideTransition(order, paymentEvent('payment_intent.canceled'));
+
+    assert.equal(decision.action, 'skip');
+    assert.match(decision.reason, /cancel a paid order/);
+  });
+
+  await t.test('is idempotent', () => {
+    const order = { paymentStatus: 'canceled', status: 'canceled' };
+    assert.equal(
+      decideTransition(order, paymentEvent('payment_intent.canceled')).action,
+      'skip'
+    );
+  });
+});
+
+test('decideTransition — general', async (t) => {
+  await t.test('skips when the order does not exist', () => {
+    const decision = decideTransition(null, paymentEvent('payment_intent.succeeded'));
+
+    assert.equal(decision.action, 'skip');
+    assert.match(decision.reason, /not found/);
+  });
+
+  await t.test('skips an event type it does not handle', () => {
+    const order = { paymentStatus: 'pending' };
+    const decision = decideTransition(order, paymentEvent('charge.refunded'));
+
+    assert.equal(decision.action, 'skip');
+    assert.match(decision.reason, /unhandled event type/);
+  });
+
+  await t.test(
+    'succeeded then canceled then succeeded leaves the order paid',
+    () => {
+      // Replay a plausible out-of-order sequence end to end.
+      const order = { paymentStatus: 'pending', status: 'pending' };
+
+      const apply = (event) => {
+        const decision = decideTransition(order, event, { paymentIntentId: 'pi_1' });
+        if (decision.action === 'apply') Object.assign(order, decision.changes);
+      };
+
+      apply(paymentEvent('payment_intent.succeeded'));
+      apply(paymentEvent('payment_intent.canceled'));
+      apply(paymentEvent('payment_intent.payment_failed'));
+      apply(paymentEvent('payment_intent.succeeded'));
+
+      assert.equal(order.paymentStatus, 'paid');
+      assert.equal(order.status, 'confirmed');
+    }
+  );
+});
+
+test('generateReceiptNumber', async (t) => {
+  await t.test('has the documented shape', () => {
+    assert.match(generateReceiptNumber(2026), /^RCPT-2026-[0-9A-F]{10}$/);
+  });
+
+  await t.test('does not collide across many draws', () => {
+    // The old Math.random() version drew from roughly 36^6 with no unique
+    // index behind it.
+    const seen = new Set();
+    for (let i = 0; i < 5000; i += 1) {
+      seen.add(generateReceiptNumber(2026));
+    }
+    assert.equal(seen.size, 5000);
+  });
+
+  await t.test('defaults to the current year', () => {
+    const year = new Date().getFullYear();
+    assert.ok(generateReceiptNumber().startsWith(`RCPT-${year}-`));
+  });
+});
+
+test('ProcessedEventStore', async (t) => {
+  await t.test('recognises a repeat', () => {
+    const store = new ProcessedEventStore();
+
+    assert.equal(store.add('evt_1'), true);
+    assert.equal(store.has('evt_1'), true);
+    assert.equal(store.add('evt_1'), false);
+  });
+
+  await t.test('does not record an empty id', () => {
+    const store = new ProcessedEventStore();
+
+    assert.equal(store.add(undefined), false);
+    assert.equal(store.add(''), false);
+    assert.equal(store.size, 0);
+  });
+
+  await t.test('stays bounded, dropping oldest first', () => {
+    const store = new ProcessedEventStore({ maxSize: 3 });
+
+    store.add('a');
+    store.add('b');
+    store.add('c');
+    store.add('d');
+
+    assert.equal(store.size, 3);
+    assert.equal(store.has('a'), false, 'oldest should have been evicted');
+    assert.equal(store.has('d'), true);
+  });
+
+  await t.test('clears', () => {
+    const store = new ProcessedEventStore();
+    store.add('evt_1');
+    store.clear();
+
+    assert.equal(store.size, 0);
+    assert.equal(store.has('evt_1'), false);
+  });
+});

--- a/bookshelf-backend/utils/webhookEvents.js
+++ b/bookshelf-backend/utils/webhookEvents.js
@@ -1,0 +1,248 @@
+import crypto from 'crypto';
+
+/**
+ * Decision logic for Stripe webhook events, as pure functions.
+ *
+ * The handler that used to live in webhook/stripeWebhook.js made three
+ * mistakes that are all easier to see — and to test — once the decisions are
+ * separated from the database calls:
+ *
+ *   1. Only the success branch checked the order's current state. A
+ *      `payment_intent.canceled` arriving after a `payment_intent.succeeded`
+ *      flipped a genuinely paid order to cancelled. Stripe does not guarantee
+ *      event ordering, so that is not a hypothetical.
+ *
+ *   2. Every failure became a 500. Stripe reads a non-2xx as "retry me", so a
+ *      deterministic failure — an orderId in the metadata that is not a valid
+ *      ObjectId, say — became a retry loop that Stripe would keep running for
+ *      three days before disabling the endpoint, at which point real payments
+ *      stop being recorded.
+ *
+ *   3. Nothing tracked which events had already been handled, so a retry of a
+ *      delivery whose response was lost did the work twice.
+ *
+ * The distinction that drives all of this: "I cannot process this **yet**"
+ * (database down — 500, please retry) versus "I will never be able to process
+ * this" (unknown order, malformed id, event type we do not handle — 2xx, stop
+ * sending it).
+ */
+
+export const HANDLED_EVENT_TYPES = Object.freeze([
+  'payment_intent.succeeded',
+  'payment_intent.payment_failed',
+  'payment_intent.canceled',
+]);
+
+/**
+ * Once an order is paid it does not become unpaid because a late event says
+ * so. Refunds are a separate flow with their own events.
+ */
+export const TERMINAL_PAYMENT_STATUSES = Object.freeze(['paid']);
+
+/** Mongo ObjectIds are 24 hex characters. Anything else will CastError. */
+const OBJECT_ID_PATTERN = /^[0-9a-fA-F]{24}$/;
+
+export function isValidObjectId(value) {
+  return typeof value === 'string' && OBJECT_ID_PATTERN.test(value);
+}
+
+/**
+ * Receipt numbers.
+ *
+ * Was `Math.random().toString(36).substring(2, 8)` — about 36^6 values from a
+ * PRNG that makes no uniqueness promise, with no unique index behind it. Two
+ * orders sharing a receipt number is a support problem rather than a security
+ * one, but there is no reason to accept it when crypto.randomUUID() is free.
+ */
+export function generateReceiptNumber(year = new Date().getFullYear()) {
+  const unique = crypto.randomUUID().replace(/-/g, '').slice(0, 10).toUpperCase();
+  return `RCPT-${year}-${unique}`;
+}
+
+/**
+ * Whether this is an event we act on.
+ *
+ * An unhandled type is not an error. Stripe sends whatever the endpoint is
+ * subscribed to, and answering anything other than 2xx to a type we simply
+ * do not care about generates retries for no reason.
+ */
+export function isHandledEventType(type) {
+  return HANDLED_EVENT_TYPES.includes(type);
+}
+
+/**
+ * Pull the bits of a payment intent event we need, and say plainly when they
+ * are not usable.
+ */
+export function extractPaymentContext(event) {
+  const paymentIntent = event?.data?.object;
+
+  if (!paymentIntent || typeof paymentIntent !== 'object') {
+    return { ok: false, reason: 'event carried no payment intent object' };
+  }
+
+  const orderId = paymentIntent.metadata?.orderId;
+
+  if (!orderId) {
+    return { ok: false, reason: 'payment intent metadata has no orderId' };
+  }
+
+  if (!isValidObjectId(orderId)) {
+    // The old handler passed this straight to findById, which threw a
+    // CastError, which became a 500, which Stripe retried forever.
+    return {
+      ok: false,
+      reason: `metadata.orderId "${orderId}" is not a valid ObjectId`,
+    };
+  }
+
+  return {
+    ok: true,
+    orderId,
+    paymentIntentId: paymentIntent.id,
+  };
+}
+
+/**
+ * Decide what an event should do to an order.
+ *
+ * Returns either `{ action: 'skip', reason }` or `{ action: 'apply', changes }`.
+ * Never mutates the order it is given — the caller applies `changes` and
+ * saves, which keeps this function testable without a database.
+ */
+export function decideTransition(order, event, context = {}) {
+  const { paymentIntentId, now = new Date() } = context;
+
+  if (!order) {
+    return { action: 'skip', reason: 'order not found' };
+  }
+
+  const alreadyPaid = TERMINAL_PAYMENT_STATUSES.includes(order.paymentStatus);
+
+  switch (event.type) {
+    case 'payment_intent.succeeded': {
+      if (alreadyPaid) {
+        // Idempotent: a redelivery of an event we already applied.
+        return { action: 'skip', reason: 'order is already paid' };
+      }
+
+      return {
+        action: 'apply',
+        changes: {
+          paymentStatus: 'paid',
+          status: 'confirmed',
+          transactionId: paymentIntentId,
+          paidAt: now,
+          receiptNumber: order.receiptNumber || generateReceiptNumber(now.getFullYear()),
+        },
+      };
+    }
+
+    case 'payment_intent.payment_failed': {
+      if (alreadyPaid) {
+        // A failed attempt that predates the successful one. Applying it
+        // would mark a paid order failed and the money would be invisible.
+        return {
+          action: 'skip',
+          reason: 'refusing to mark a paid order failed',
+        };
+      }
+
+      if (order.paymentStatus === 'failed') {
+        return { action: 'skip', reason: 'order is already marked failed' };
+      }
+
+      return {
+        action: 'apply',
+        changes: { paymentStatus: 'failed', status: 'payment_failed' },
+      };
+    }
+
+    case 'payment_intent.canceled': {
+      if (alreadyPaid) {
+        // The specific bug in the issue: an out-of-order cancel used to
+        // overwrite a successful payment.
+        return {
+          action: 'skip',
+          reason: 'refusing to cancel a paid order',
+        };
+      }
+
+      if (order.paymentStatus === 'canceled') {
+        return { action: 'skip', reason: 'order is already canceled' };
+      }
+
+      return {
+        action: 'apply',
+        changes: { paymentStatus: 'canceled', status: 'canceled' },
+      };
+    }
+
+    default:
+      return { action: 'skip', reason: `unhandled event type ${event.type}` };
+  }
+}
+
+/**
+ * Remembers which event ids have been processed.
+ *
+ * Stripe retries the *same* event id, so an id is enough to recognise a
+ * redelivery. Bounded so it cannot grow without limit; oldest entries are
+ * dropped first, which is the right direction — a retry of something from two
+ * days ago is far less likely than a retry of something from two minutes ago.
+ *
+ * In process memory, with the same caveat as middleware/rateLimiter.js: on
+ * more than one instance each has its own view. That is a real limitation and
+ * not the last line of defence — `decideTransition` refuses to move an order
+ * out of a paid state regardless, so a redelivery that slips past this store
+ * still cannot do damage. Moving to Redis only means replacing this class.
+ */
+export class ProcessedEventStore {
+  constructor({ maxSize = 1000 } = {}) {
+    this.maxSize = maxSize;
+    this.seen = new Set();
+  }
+
+  has(eventId) {
+    return this.seen.has(eventId);
+  }
+
+  /** Returns false when the id was already present. */
+  add(eventId) {
+    if (!eventId) {
+      return false;
+    }
+
+    if (this.seen.has(eventId)) {
+      return false;
+    }
+
+    this.seen.add(eventId);
+
+    // Set preserves insertion order, so the first key is the oldest.
+    while (this.seen.size > this.maxSize) {
+      const oldest = this.seen.values().next().value;
+      this.seen.delete(oldest);
+    }
+
+    return true;
+  }
+
+  get size() {
+    return this.seen.size;
+  }
+
+  clear() {
+    this.seen.clear();
+  }
+}
+
+export default {
+  HANDLED_EVENT_TYPES,
+  isHandledEventType,
+  extractPaymentContext,
+  decideTransition,
+  generateReceiptNumber,
+  isValidObjectId,
+  ProcessedEventStore,
+};

--- a/bookshelf-backend/webhook/stripeWebhook.js
+++ b/bookshelf-backend/webhook/stripeWebhook.js
@@ -1,85 +1,144 @@
+import dotenv from 'dotenv';
 import orderRepository from '../repositories/orderRepository.js';
 import { verifyWebhookSignature } from '../services/stripeService.js';
-import dotenv from 'dotenv';
+import { StripeConfigError } from '../config/stripe.js';
+import {
+  isHandledEventType,
+  extractPaymentContext,
+  decideTransition,
+  ProcessedEventStore,
+} from '../utils/webhookEvents.js';
 
 dotenv.config();
 
-const stripeWebhookHandler = async (req, res) => {
-  const signature = req.headers['stripe-signature'];
-  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET || 'whsec_test_mock_webhook_secret_123';
+/**
+ * Events already applied, so a redelivery is a no-op.
+ *
+ * Module scope on purpose: one store for the life of the process, the same
+ * shape as the counters in middleware/rateLimiter.js.
+ */
+export const processedEvents = new ProcessedEventStore({ maxSize: 1000 });
 
-  let event;
-  try {
-    event = verifyWebhookSignature(req.body, signature, webhookSecret);
-  } catch (error) {
-    console.error(`Webhook signature verification failed: ${error.message}`);
-    return res.status(400).send(`Webhook Error: ${error.message}`);
-  }
+/**
+ * How this endpoint answers, and why.
+ *
+ * Stripe reads the status code as an instruction. Anything outside 2xx means
+ * "I could not take this, send it again", and it will keep sending — with
+ * backoff, for up to three days, and then it disables the endpoint. Once the
+ * endpoint is disabled, real payments stop being recorded. The status code is
+ * not a formality here, it is flow control.
+ *
+ *   400  the signature did not verify. Not from Stripe, or the wrong secret.
+ *        Never accepted.
+ *   200  handled, or permanently unhandleable — an event type we do not act
+ *        on, metadata with no orderId or a malformed one, an order that does
+ *        not exist, a redelivery already applied. Retrying any of these
+ *        produces the identical answer forever, so the honest reply is
+ *        "received, nothing to do".
+ *   500  a transient failure on our side, in practice the database. This is
+ *        the only case a retry can fix, so it is the only case that asks for
+ *        one.
+ *
+ * The previous handler answered 500 to every one of these. An `orderId` in the
+ * metadata that was not a valid ObjectId made Mongoose throw a CastError,
+ * which became a 500, which Stripe retried, which threw the same CastError.
+ *
+ * Built as a factory so the tests can drive it with a fake verifier and a fake
+ * repository. Application code uses the default export below, which wires in
+ * the real ones.
+ */
+export function createStripeWebhookHandler({
+  verify = verifyWebhookSignature,
+  orders = orderRepository,
+  store = processedEvents,
+  logger = console,
+} = {}) {
+  return async function stripeWebhookHandler(req, res) {
+    const signature = req.headers['stripe-signature'];
 
-  try {
-    switch (event.type) {
-      case 'payment_intent.succeeded': {
-        const paymentIntent = event.data.object;
-        const orderId = paymentIntent.metadata.orderId;
-        
-        if (orderId) {
-          const order = await orderRepository.findById(orderId);
-          if (order && order.paymentStatus !== 'paid') {
-            order.paymentStatus = 'paid';
-            order.status = 'confirmed';
-            order.transactionId = paymentIntent.id;
-            order.paidAt = new Date();
-            
-            // Generate receipt number
-            const receiptPrefix = 'RCPT-' + new Date().getFullYear() + '-';
-            const randomString = Math.random().toString(36).substring(2, 8).toUpperCase();
-            order.receiptNumber = receiptPrefix + randomString;
+    let event;
+    try {
+      // No secret argument, and no fallback behind it. The secret comes from
+      // validated config inside the service.
+      event = verify(req.body, signature);
+    } catch (error) {
+      if (error instanceof StripeConfigError) {
+        // Refusing to verify is the right move when there is no real secret.
+        // The alternative is what this code used to do: verify against a
+        // constant printed in this repository, and accept forged events.
+        // 500 so Stripe retries once the deployment is fixed.
+        logger.error(`[webhook] not configured: ${error.message}`);
+        return res.status(500).json({ message: 'Webhook is not configured' });
+      }
 
-            await orderRepository.save(order);
-            console.log(`Order ${orderId} successfully paid.`);
-          }
-        }
-        break;
-      }
-      case 'payment_intent.payment_failed': {
-        const paymentIntent = event.data.object;
-        const orderId = paymentIntent.metadata.orderId;
-        
-        if (orderId) {
-          const order = await orderRepository.findById(orderId);
-          if (order) {
-            order.paymentStatus = 'failed';
-            order.status = 'payment_failed';
-            await orderRepository.save(order);
-            console.log(`Order ${orderId} payment failed.`);
-          }
-        }
-        break;
-      }
-      case 'payment_intent.canceled': {
-        const paymentIntent = event.data.object;
-        const orderId = paymentIntent.metadata.orderId;
-        
-        if (orderId) {
-          const order = await orderRepository.findById(orderId);
-          if (order) {
-            order.paymentStatus = 'canceled';
-            order.status = 'canceled';
-            await orderRepository.save(order);
-            console.log(`Order ${orderId} payment canceled.`);
-          }
-        }
-        break;
-      }
-      default:
-        console.log(`Unhandled event type ${event.type}`);
+      logger.error(`[webhook] signature verification failed: ${error.message}`);
+      return res.status(400).json({ message: 'Signature verification failed' });
     }
 
-    res.status(200).json({ received: true });
-  } catch (error) {
-    console.error(`Webhook handler error: ${error.message}`);
-    res.status(500).send(`Webhook Handler Error: ${error.message}`);
-  }
-};
+    if (!isHandledEventType(event.type)) {
+      // Subscribed to something we do not act on. Not an error.
+      return res.status(200).json({ received: true, handled: false });
+    }
+
+    if (store.has(event.id)) {
+      return res
+        .status(200)
+        .json({ received: true, handled: false, reason: 'duplicate event' });
+    }
+
+    const context = extractPaymentContext(event);
+
+    if (!context.ok) {
+      // Deterministically unusable. Worth logging — it means something
+      // upstream is writing bad metadata — but not worth a retry.
+      logger.warn(`[webhook] ignoring ${event.id}: ${context.reason}`);
+      store.add(event.id);
+      return res
+        .status(200)
+        .json({ received: true, handled: false, reason: context.reason });
+    }
+
+    try {
+      const order = await orders.findById(context.orderId);
+
+      const decision = decideTransition(order, event, {
+        paymentIntentId: context.paymentIntentId,
+      });
+
+      if (decision.action === 'skip') {
+        logger.log(
+          `[webhook] ${event.type} for order ${context.orderId}: ${decision.reason}`
+        );
+        store.add(event.id);
+        return res
+          .status(200)
+          .json({ received: true, handled: false, reason: decision.reason });
+      }
+
+      Object.assign(order, decision.changes);
+      await orders.save(order);
+
+      store.add(event.id);
+
+      logger.log(
+        `[webhook] ${event.type} applied to order ${context.orderId} ` +
+          `(paymentStatus=${decision.changes.paymentStatus})`
+      );
+
+      return res.status(200).json({ received: true, handled: true });
+    } catch (error) {
+      // Reaching here means the database refused, not that the event was bad
+      // — every bad-event path returned 200 above. This is the case a retry
+      // can actually fix, so it is the case that gets a 500. The event id is
+      // deliberately not recorded as processed.
+      logger.error(
+        `[webhook] failed to apply ${event.id} (${event.type}): ${error.message}`
+      );
+      return res.status(500).json({ message: 'Failed to process event' });
+    }
+  };
+}
+
+const stripeWebhookHandler = createStripeWebhookHandler();
 
 export default stripeWebhookHandler;


### PR DESCRIPTION
Closes #306.

Three problems in the one endpoint that decides whether an order is paid.

## 1. Signature verification had a committed fallback

```js
const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET || 'whsec_test_mock_webhook_secret_123';
```

`POST /api/payments/webhook` is public and unauthenticated by design — it is mounted in `app.js` ahead of every auth middleware, and it has to be. `constructEvent()` succeeding is therefore the *entire* reason to believe a request came from Stripe.

Any deployment that forgot the variable was verifying against a string printed in this repository. Sign your own `payment_intent.succeeded` with it, POST it, and the handler marks the order paid, stamps `paidAt` and issues a receipt number. The inventory was already decremented back at intent creation, so that is a completed order for free.

`STRIPE_SECRET_KEY` had the same shape (`|| 'sk_test_mock_stripe_key_123'`). Less dangerous — the key is invalid, so it fails — but it failed at request time as a 500 carrying a raw Stripe message, which means the operator hears about it from a customer.

**`config/stripe.js` (new)** validates both and has no default. The two old fallbacks and both `.env.example` placeholders are on the reject list by name, so setting one explicitly is not a way back in. It also catches pasting the publishable key into the secret key slot, which otherwise surfaces much later as an opaque 401.

Resolution is lazy rather than at import time: `app.js` imports the webhook module and unit tests import `app.js`, so importing must not throw for want of Stripe credentials. With no valid secret the endpoint refuses to verify anything and answers 500 — it does not fall back.

## 2. Every failure was a 500, and Stripe reads that as "send it again"

```js
} catch (error) {
  res.status(500).send(`Webhook Handler Error: ${error.message}`);
}
```

`orderRepository.findById(orderId)` took `orderId` straight from `paymentIntent.metadata`, which is a free-form string map. A value that is not a valid ObjectId made Mongoose throw a `CastError` → 500 → Stripe retries → identical `CastError`. Stripe keeps that up with backoff for three days and then disables the endpoint, and once the endpoint is disabled **real** payments stop being recorded.

The status code is flow control here, not a formality. It now distinguishes:

| | |
|---|---|
| `400` | signature did not verify — not from Stripe, or the wrong secret |
| `200` | handled, **or permanently unhandleable** — unsubscribed event type, no `orderId`, malformed `orderId`, unknown order, already-applied redelivery |
| `500` | transient on our side, in practice the database — the only case a retry can fix |

## 3. Only the success branch checked the order's state

```js
if (order && order.paymentStatus !== 'paid') { ... }   // succeeded — guarded
if (order) { order.paymentStatus = 'failed'; ... }     // payment_failed — not
if (order) { order.paymentStatus = 'canceled'; ... }   // canceled — not
```

Stripe does not promise event ordering. A `payment_intent.canceled` arriving after a `payment_intent.succeeded` — a retry of an earlier attempt, an out-of-order delivery, a manual cancel of a superseded intent — flipped a genuinely paid order to `status: 'canceled'`. Money taken, order reads as cancelled, and nothing distinguishes it from a real cancellation.

All three transitions now refuse to move an order out of a paid state. Event ids are recorded in a bounded store so a redelivery is a no-op — and on a *write* failure the id is deliberately **not** recorded, because otherwise Stripe's retry would be discarded as a duplicate and the payment never recorded at all.

## 4. Minor

Receipt numbers move from `Math.random().toString(36).substring(2, 8)` to `crypto.randomUUID()`. There is no unique index behind that field, so collisions were silent.

## Shape of the change

Decision logic is pure functions in **`utils/webhookEvents.js`** — classify the event, extract and validate the context, decide the transition. None of it touches a database, so all of it is directly testable.

The handler is a factory:

```js
export function createStripeWebhookHandler({ verify, orders, store, logger } = {}) { ... }
const stripeWebhookHandler = createStripeWebhookHandler();   // real deps
export default stripeWebhookHandler;
```

This is what lets the response-code policy be tested with a fake verifier and a fake repository. I went this way rather than `mock.module` specifically because that needs `--experimental-test-module-mocks` on the test script, and #284 is already changing `package.json`.

## Tests

77 new cases across `webhookEvents.test.js`, `stripeConfig.test.js` and `stripeWebhook.test.js`:

- every rejection path for both credentials, including the two old fallbacks by name
- every `orderId` shape that used to reach Mongoose
- each transition from each starting state, including the succeeded → canceled → failed → succeeded replay, which must end paid
- the full status-code policy — bad signature 400, unusable event 200, database failure 500
- that a duplicate is applied once, and that a failed write is *not* marked processed
- that neither the 400 nor the 500 body echoes the internal error

```console
$ npm test
# tests 175
# pass 175
# fail 0
```

Was 98 before this branch.

## Notes for review

- A deployment currently running **without** `STRIPE_WEBHOOK_SECRET` will stop accepting webhooks. That is the fix, not a side effect.
- `verifyWebhookSignature` lost its `secret` parameter. Only one caller, and letting a caller supply the secret is how the fallback got there.
- The processed-event store is in process memory, same caveat as `middleware/rateLimiter.js`: on more than one instance each has its own view. It is deliberately not the last line of defence — `decideTransition` refuses to demote a paid order regardless, so a redelivery that slips past the store still cannot do damage. Moving to Redis means replacing one class.
- The `|| 'fallback_secret'` pattern in the JWT code is the same species of bug, filed and fixed separately in #305 / #310. No file overlap between the two branches.