### PR TITLE
fix(frontend): repair the theme bootstrap script in index.html, which has never run (closes #308)

### DIFF
--- a/bookshelf-frontend/index.html
+++ b/bookshelf-frontend/index.html
@@ -10,23 +10,36 @@
       href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,500;0,9..144,600;1,9..144,500&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@500&display=swap"
       rel="stylesheet"
     />
+    <!--
+      Sets data-theme before the browser paints, so a returning visitor never
+      sees a flash of the wrong theme while the bundle loads.
+
+      This has to run before any module exists, so it cannot import
+      src/utils/themeBoot.js. It implements the same rule, and
+      src/utils/themeBoot.test.js executes this exact block and asserts the two
+      agree — the previous version of this script was a SyntaxError that the
+      browser discarded whole, and nothing caught it because an inline script
+      is invisible to both ESLint and the bundler.
+
+      It reads localStorage and never writes to it. Recording the resolved
+      value here would turn "no preference, follow the OS" into an explicit
+      choice on first load.
+    -->
     <script>
-      (function() {
+      (function () {
+        var theme = 'light';
         try {
-          var savedTheme = localStorage.getItem('theme');
-          var systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-          var isDark = savedTheme === 'dark' || (!savedTheme && systemPrefersDark);
-          if (isDark) {
-            document.documentElement.setAttribute('data-theme', 'dark');
-          } else {
-            document.documentElement.setAttribute('data-theme', 'light');
-          if (savedTheme === 'light' || savedTheme === 'dark') {
-            document.documentElement.setAttribute('data-theme', savedTheme);
-          } else {
-            var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-            document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+          var saved = localStorage.getItem('theme');
+          if (saved === 'light' || saved === 'dark') {
+            theme = saved;
+          } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            theme = 'dark';
           }
-        } catch (e) {}
+        } catch (e) {
+          // Storage can be unavailable outright — Safari private browsing, or
+          // site data blocked. Fall through with the light default.
+        }
+        document.documentElement.setAttribute('data-theme', theme);
       })();
     </script>
   </head>

--- a/bookshelf-frontend/src/utils/themeBoot.js
+++ b/bookshelf-frontend/src/utils/themeBoot.js
@@ -1,0 +1,89 @@
+/**
+ * The theme decision, in one place.
+ *
+ * The `<script>` in index.html has to make this decision before the browser
+ * paints anything, which means it has to run before the bundle exists — so it
+ * cannot import this module. What it can do is implement the same three lines,
+ * and be tested against this one. `themeBoot.test.js` reads the inline script
+ * out of index.html, executes it, and asserts it agrees with `resolveTheme`
+ * for every input.
+ *
+ * That test exists because of what happened to the original: two attempts at
+ * this logic got stacked on top of each other in a merge, leaving an `else {`
+ * that was never closed. The whole block was a SyntaxError, so the browser
+ * discarded it and `data-theme` was simply absent until React mounted. The
+ * `try { } catch (e) {}` around it looked like the errors were handled — but a
+ * syntax error happens at compile time, before the `try` exists, so it never
+ * entered the block.
+ *
+ * An inline script in index.html is invisible to ESLint, is not part of the
+ * bundle, and had no test touching it. That is how it reached main.
+ */
+
+export const THEME_STORAGE_KEY = 'theme';
+
+export const THEMES = Object.freeze({ LIGHT: 'light', DARK: 'dark' });
+
+export function isValidTheme(value) {
+  return value === THEMES.LIGHT || value === THEMES.DARK;
+}
+
+/**
+ * Which theme to paint with.
+ *
+ * An explicit saved choice always wins. Anything else — never set, cleared, or
+ * a stale value from an older version of the app — falls back to the operating
+ * system preference.
+ */
+export function resolveTheme({ savedTheme, prefersDark } = {}) {
+  if (isValidTheme(savedTheme)) {
+    return savedTheme;
+  }
+
+  return prefersDark ? THEMES.DARK : THEMES.LIGHT;
+}
+
+/**
+ * Read the saved theme without letting storage failures escape.
+ *
+ * `localStorage` is not always there to be read: Safari in private browsing
+ * throws on access, and so does any browser with site data blocked. A theme
+ * preference is not worth taking the page down for.
+ */
+export function readSavedTheme(storage) {
+  try {
+    const value = storage?.getItem(THEME_STORAGE_KEY);
+    return isValidTheme(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readPrefersDark(win) {
+  try {
+    return Boolean(win?.matchMedia?.('(prefers-color-scheme: dark)')?.matches);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve and apply, returning what was applied.
+ *
+ * Deliberately does not *write* to storage. Recording the resolved value would
+ * turn "I have no preference, follow the OS" into an explicit choice on first
+ * load, and the app would stop following the OS from then on without the user
+ * ever having chosen anything.
+ */
+export function applyInitialTheme(doc = document, win = window) {
+  const theme = resolveTheme({
+    savedTheme: readSavedTheme(win?.localStorage),
+    prefersDark: readPrefersDark(win),
+  });
+
+  doc.documentElement.setAttribute('data-theme', theme);
+
+  return theme;
+}
+
+export default applyInitialTheme;

--- a/bookshelf-frontend/src/utils/themeBoot.test.js
+++ b/bookshelf-frontend/src/utils/themeBoot.test.js
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  THEMES,
+  THEME_STORAGE_KEY,
+  isValidTheme,
+  resolveTheme,
+  readSavedTheme,
+  readPrefersDark,
+  applyInitialTheme,
+} from './themeBoot.js';
+
+const INDEX_HTML = path.resolve(__dirname, '../../index.html');
+
+/**
+ * Pull the first inline <script> — the theme bootstrap — out of index.html.
+ * Only inline scripts; the module script at the bottom has a src.
+ */
+function readBootScript() {
+  const html = fs.readFileSync(INDEX_HTML, 'utf8');
+  const match = html.match(/<script>([\s\S]*?)<\/script>/);
+
+  if (!match) {
+    throw new Error('No inline <script> found in index.html');
+  }
+
+  return match[1];
+}
+
+/**
+ * A localStorage stand-in. `throws: true` models Safari private browsing and
+ * a browser with site data blocked, where even reading throws.
+ */
+function fakeStorage({ value, throws = false } = {}) {
+  return {
+    getItem(key) {
+      if (throws) {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      }
+      return key === THEME_STORAGE_KEY ? (value ?? null) : null;
+    },
+    setItem() {
+      if (throws) {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      }
+    },
+  };
+}
+
+function fakeWindow({ savedTheme, prefersDark = false, storageThrows = false } = {}) {
+  return {
+    localStorage: fakeStorage({ value: savedTheme, throws: storageThrows }),
+    matchMedia: (query) => ({
+      matches: query === '(prefers-color-scheme: dark)' ? prefersDark : false,
+      media: query,
+    }),
+  };
+}
+
+/** A bare document with just the root element the script touches. */
+function fakeDocument() {
+  const attributes = new Map();
+  return {
+    attributes,
+    documentElement: {
+      setAttribute: (name, value) => attributes.set(name, value),
+      getAttribute: (name) => attributes.get(name) ?? null,
+    },
+  };
+}
+
+/**
+ * Run the real inline script from index.html against fake globals.
+ *
+ * The script refers to bare `localStorage`, `window` and `document`, so they
+ * are passed as parameters of the wrapper function.
+ */
+function runBootScript({ savedTheme, prefersDark = false, storageThrows = false } = {}) {
+  const source = readBootScript();
+  const win = fakeWindow({ savedTheme, prefersDark, storageThrows });
+  const doc = fakeDocument();
+
+  // eslint-disable-next-line no-new-func
+  const run = new Function('window', 'document', 'localStorage', source);
+  run(win, doc, win.localStorage);
+
+  return doc.documentElement.getAttribute('data-theme');
+}
+
+describe('the inline theme script in index.html', () => {
+  it('parses — this is the regression the whole file exists for', () => {
+    // Before the fix this threw `SyntaxError: Unexpected token 'catch'`: an
+    // `else {` was never closed, so the browser discarded the whole block and
+    // data-theme was never set. Nothing caught it, because an inline script in
+    // index.html is not linted and not bundled.
+    expect(() => new Function(readBootScript())).not.toThrow();
+  });
+
+  it('applies a saved dark theme', () => {
+    expect(runBootScript({ savedTheme: 'dark' })).toBe('dark');
+  });
+
+  it('applies a saved light theme even when the OS prefers dark', () => {
+    // An explicit choice beats the system preference. The old script computed
+    // `isDark = saved === 'dark' || (!saved && prefersDark)` first, which got
+    // this right, and then a second copy of the logic overwrote it.
+    expect(runBootScript({ savedTheme: 'light', prefersDark: true })).toBe('light');
+  });
+
+  it('follows the OS when nothing is saved', () => {
+    expect(runBootScript({ prefersDark: true })).toBe('dark');
+    expect(runBootScript({ prefersDark: false })).toBe('light');
+  });
+
+  it('ignores a saved value that is not a theme', () => {
+    expect(runBootScript({ savedTheme: 'purple', prefersDark: true })).toBe('dark');
+    expect(runBootScript({ savedTheme: '', prefersDark: false })).toBe('light');
+  });
+
+  it('still sets an attribute when storage throws', () => {
+    // Safari private browsing, or site data blocked. The page must still have
+    // a defined theme rather than none.
+    expect(runBootScript({ storageThrows: true })).toBe('light');
+  });
+
+  it('always sets data-theme, whatever the inputs', () => {
+    const cases = [
+      { savedTheme: 'dark' },
+      { savedTheme: 'light' },
+      { savedTheme: undefined, prefersDark: true },
+      { savedTheme: 'nonsense' },
+      { storageThrows: true },
+    ];
+
+    for (const options of cases) {
+      expect(runBootScript(options)).toMatch(/^(light|dark)$/);
+    }
+  });
+
+  it('does not write to localStorage', () => {
+    // Recording the resolved value would turn "no preference, follow the OS"
+    // into an explicit choice on first load, and the app would stop following
+    // the OS without the user ever having chosen anything.
+    const writes = [];
+    const source = readBootScript();
+    const win = fakeWindow({ prefersDark: true });
+    win.localStorage.setItem = (key, value) => writes.push([key, value]);
+
+    // eslint-disable-next-line no-new-func
+    new Function('window', 'document', 'localStorage', source)(
+      win,
+      fakeDocument(),
+      win.localStorage
+    );
+
+    expect(writes).toEqual([]);
+  });
+
+  it('agrees with resolveTheme() for every combination', () => {
+    // The inline script cannot import the module, so this is what keeps the
+    // two implementations honest.
+    for (const savedTheme of ['light', 'dark', undefined, 'bogus']) {
+      for (const prefersDark of [true, false]) {
+        expect(runBootScript({ savedTheme, prefersDark })).toBe(
+          resolveTheme({ savedTheme, prefersDark })
+        );
+      }
+    }
+  });
+});
+
+describe('resolveTheme', () => {
+  it('prefers an explicit saved choice', () => {
+    expect(resolveTheme({ savedTheme: 'dark', prefersDark: false })).toBe('dark');
+    expect(resolveTheme({ savedTheme: 'light', prefersDark: true })).toBe('light');
+  });
+
+  it('falls back to the system preference', () => {
+    expect(resolveTheme({ prefersDark: true })).toBe(THEMES.DARK);
+    expect(resolveTheme({ prefersDark: false })).toBe(THEMES.LIGHT);
+  });
+
+  it('treats an unrecognised saved value as no preference', () => {
+    expect(resolveTheme({ savedTheme: 'purple', prefersDark: true })).toBe('dark');
+    expect(resolveTheme({ savedTheme: null, prefersDark: false })).toBe('light');
+  });
+
+  it('defaults to light with no arguments at all', () => {
+    expect(resolveTheme()).toBe(THEMES.LIGHT);
+  });
+});
+
+describe('isValidTheme', () => {
+  it('accepts only the two themes', () => {
+    expect(isValidTheme('light')).toBe(true);
+    expect(isValidTheme('dark')).toBe(true);
+    expect(isValidTheme('Dark')).toBe(false);
+    expect(isValidTheme('')).toBe(false);
+    expect(isValidTheme(null)).toBe(false);
+    expect(isValidTheme(undefined)).toBe(false);
+  });
+});
+
+describe('readSavedTheme', () => {
+  it('reads a valid value', () => {
+    expect(readSavedTheme(fakeStorage({ value: 'dark' }))).toBe('dark');
+  });
+
+  it('returns null for an invalid value', () => {
+    expect(readSavedTheme(fakeStorage({ value: 'chartreuse' }))).toBeNull();
+  });
+
+  it('returns null rather than throwing when storage is unavailable', () => {
+    expect(readSavedTheme(fakeStorage({ throws: true }))).toBeNull();
+    expect(readSavedTheme(undefined)).toBeNull();
+  });
+});
+
+describe('readPrefersDark', () => {
+  it('reports the media query result', () => {
+    expect(readPrefersDark(fakeWindow({ prefersDark: true }))).toBe(true);
+    expect(readPrefersDark(fakeWindow({ prefersDark: false }))).toBe(false);
+  });
+
+  it('returns false when matchMedia is missing', () => {
+    expect(readPrefersDark({})).toBe(false);
+    expect(readPrefersDark(undefined)).toBe(false);
+  });
+});
+
+describe('applyInitialTheme', () => {
+  let originalTheme;
+
+  beforeEach(() => {
+    originalTheme = document.documentElement.getAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    if (originalTheme === null) {
+      document.documentElement.removeAttribute('data-theme');
+    } else {
+      document.documentElement.setAttribute('data-theme', originalTheme);
+    }
+  });
+
+  it('sets the attribute and returns what it set', () => {
+    const doc = fakeDocument();
+    const applied = applyInitialTheme(doc, fakeWindow({ savedTheme: 'dark' }));
+
+    expect(applied).toBe('dark');
+    expect(doc.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('works against a real document', () => {
+    applyInitialTheme(document, fakeWindow({ savedTheme: 'dark' }));
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+});


### PR DESCRIPTION
Closes #308.

## The bug

The inline `<script>` in `index.html` — the one whose entire job is to set `data-theme` before first paint — has unbalanced braces. Two attempts at the same three lines got stacked on top of each other in a merge:

```js
if (isDark) {
  document.documentElement.setAttribute('data-theme', 'dark');
} else {
  document.documentElement.setAttribute('data-theme', 'light');
if (savedTheme === 'light' || savedTheme === 'dark') {   // <- second copy starts here
  ...
} else {
  ...
}
} catch (e) {}     // <- parser is still inside the unclosed `else`
```

That is a syntax error, and an HTML parser discards a `<script>` that fails to compile — whole. None of it has ever run:

```console
$ node -e "
const fs=require('fs');
const m=fs.readFileSync('bookshelf-frontend/index.html','utf8').match(/<script>([\s\S]*?)<\/script>/);
try { new Function(m[1]); console.log('parses'); } catch(e){ console.log('SYNTAX ERROR ->', e.message); }
"
SYNTAX ERROR -> Unexpected token 'catch'
```

The `try { } catch (e) {}` wrapper is why it went unnoticed. It looks like the errors are being handled — but a **syntax** error happens at compile time, before the `try` exists, so it never enters the block. It goes to the console as an uncaught `SyntaxError` and the page carries on.

## What it costs

The whole point of a blocking inline script in `<head>` is that it runs before the browser paints, so the right theme is on `<html>` from the first frame. With it dead, `data-theme` is simply absent until React mounts — and nothing else fills the gap. `src/hooks/useTheme.js` reads the saved theme into state but only writes the attribute from inside `setTheme`, which only a click calls.

So for a returning visitor who chose dark: no `data-theme` → light first paint → React mounts → state says `"dark"` → page still renders light, because nothing touched the attribute. A white flash on every load, on every dark-mode machine.

This is separate from the duplicate-theme-owner problem in #296. Whatever fix lands there can only run once the JS bundle has parsed; preventing the flash requires a working head script.

## The fix

```js
(function () {
  var theme = 'light';
  try {
    var saved = localStorage.getItem('theme');
    if (saved === 'light' || saved === 'dark') {
      theme = saved;
    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
      theme = 'dark';
    }
  } catch (e) {
    // Storage can be unavailable outright — Safari private browsing, or site
    // data blocked. Fall through with the light default.
  }
  document.documentElement.setAttribute('data-theme', theme);
})();
```

Two deliberate properties:

- **It reads storage and never writes.** Recording the resolved value would turn "no preference, follow the OS" into an explicit choice on first load, and the app would stop following the OS without the user having chosen anything. (That is the same trap `useTheme`'s system listener falls into — noted in #296, not touched here.)
- **A storage failure still leaves a defined theme.** It sets `light` rather than nothing.

## Why there is a test, and what it does

An inline script in `index.html` is invisible to ESLint, is not part of the bundle, and had nothing testing it. That is *precisely* how a syntax error reached `main`, so fixing the braces without a guard would leave the door open.

`src/utils/themeBoot.test.js` reads this exact block back out of `index.html`, executes it against fake globals, and checks:

- **that it parses** — the direct regression
- that it applies a saved theme, that an explicit choice beats the OS preference, that an unrecognised saved value falls back
- that it still sets an attribute when `localStorage` throws
- that it never calls `setItem`
- that it agrees with `resolveTheme()` in `src/utils/themeBoot.js` for **every** combination of saved theme and system preference

The script cannot import the module — it has to run before any module exists — so the two implementations are checked against each other rather than shared.

Restoring the old `index.html` fails 9 of the 21 new tests, the first with the original error:

```
AssertionError: expected [Function] to not throw an error
but 'SyntaxError: Unexpected token 'catch'' was thrown
```

## Tests

```console
$ npm test
 Test Files  5 passed (5)
      Tests  67 passed (67)
```

Was 46 before this branch. `npm run build` verified; the fixed script is inlined into `dist/index.html` as expected.

## Notes for review

- Only `index.html` changes, plus two new files under `src/utils/`. No overlap with #301, which does not touch `index.html`.
- I did not commit the regenerated `dist/` artifacts — the build was only run to confirm the script survives it.
- The test needs the frontend suite to actually run in CI to be worth anything. #284 is the change that makes that true.