### PR TITLE
fix(cart): stop one malformed localStorage value white-screening the whole site (closes #309)

### DIFF
--- a/bookshelf-frontend/src/components/ErrorBoundary.css
+++ b/bookshelf-frontend/src/components/ErrorBoundary.css
@@ -1,0 +1,96 @@
+/*
+ * Styled with the same custom properties the rest of the app uses, but every
+ * one has a fallback. The boundary has to render correctly in the case where
+ * something about the app is broken — including, potentially, the theme.
+ */
+
+.error-boundary {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.25rem;
+}
+
+.error-boundary__panel {
+  width: 100%;
+  max-width: 34rem;
+  padding: 2rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.3));
+  background: var(--card-bg, #ffffff);
+  color: var(--text-color, #1a1a1a);
+  text-align: center;
+}
+
+.error-boundary__title {
+  margin: 0 0 0.75rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.error-boundary__message {
+  margin: 0 0 1.5rem;
+  line-height: 1.6;
+  color: var(--text-muted, #555555);
+}
+
+.error-boundary__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.error-boundary__button {
+  padding: 0.6rem 1.2rem;
+  border-radius: 8px;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.3));
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.error-boundary__button:hover {
+  opacity: 0.8;
+}
+
+.error-boundary__button:focus-visible {
+  outline: 2px solid var(--accent-color, #4f46e5);
+  outline-offset: 2px;
+}
+
+.error-boundary__button--primary {
+  background: var(--accent-color, #4f46e5);
+  border-color: var(--accent-color, #4f46e5);
+  color: #ffffff;
+}
+
+.error-boundary__details {
+  margin-top: 1.5rem;
+  text-align: left;
+  font-size: 0.875rem;
+  color: var(--text-muted, #555555);
+}
+
+.error-boundary__details summary {
+  cursor: pointer;
+}
+
+.error-boundary__pre {
+  margin: 0.75rem 0 0;
+  padding: 0.75rem;
+  border-radius: 6px;
+  background: var(--code-bg, rgba(128, 128, 128, 0.12));
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .error-boundary__button {
+    transition: none;
+  }
+}

--- a/bookshelf-frontend/src/components/ErrorBoundary.jsx
+++ b/bookshelf-frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import './ErrorBoundary.css';
+
+/**
+ * Catches render errors and shows something recoverable.
+ *
+ * There was no error boundary anywhere in the tree, and React's default for an
+ * uncaught render error is to unmount the whole thing — `<div id="root">` ends
+ * up empty. That is how one malformed `cart` value in localStorage turned into
+ * a blank page on every route, with the real error visible only in the console.
+ *
+ * The stored-cart problem is fixed at its source in utils/cartStorage.js. This
+ * is here so that the *next* one — whatever it turns out to be — costs a
+ * message and a working button rather than a white screen.
+ *
+ * Class component because that is the only way: there is no hook equivalent of
+ * componentDidCatch.
+ */
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    // Keep the component stack. It is the part that says *which* component
+    // threw, and it is not on the error object itself.
+    console.error('[ErrorBoundary] render failed:', error, info?.componentStack);
+  }
+
+  handleReset = () => {
+    this.setState({ error: null });
+  };
+
+  handleClearStoredData = () => {
+    // The specific escape hatch a user had no way to reach before: if
+    // something in localStorage is what is breaking the page, the only fix
+    // was opening DevTools.
+    try {
+      window.localStorage.clear();
+    } catch (error) {
+      console.warn('[ErrorBoundary] could not clear localStorage:', error);
+    }
+
+    window.location.assign('/');
+  };
+
+  render() {
+    const { error } = this.state;
+
+    if (!error) {
+      return this.props.children;
+    }
+
+    return (
+      <div className="error-boundary" role="alert">
+        <div className="error-boundary__panel">
+          <h1 className="error-boundary__title">Something went wrong</h1>
+
+          <p className="error-boundary__message">
+            This page ran into an error. Trying again often works — if it does
+            not, clearing this site&apos;s saved data (your cart and wishlist)
+            usually does.
+          </p>
+
+          <div className="error-boundary__actions">
+            <button
+              type="button"
+              className="error-boundary__button error-boundary__button--primary"
+              onClick={this.handleReset}
+            >
+              Try again
+            </button>
+
+            <button
+              type="button"
+              className="error-boundary__button"
+              onClick={this.handleClearStoredData}
+            >
+              Clear saved data and reload
+            </button>
+          </div>
+
+          {/*
+            The message is shown but the stack is not — it names internal paths
+            and is in the console anyway, which is where anyone who can act on
+            it will be looking.
+          */}
+          <details className="error-boundary__details">
+            <summary>Technical details</summary>
+            <pre className="error-boundary__pre">{String(error?.message ?? error)}</pre>
+          </details>
+        </div>
+      </div>
+    );
+  }
+}

--- a/bookshelf-frontend/src/components/ErrorBoundary.test.jsx
+++ b/bookshelf-frontend/src/components/ErrorBoundary.test.jsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+
+import ErrorBoundary from './ErrorBoundary.jsx';
+
+function Boom({ shouldThrow = true }) {
+  if (shouldThrow) {
+    throw new Error('cart.reduce is not a function');
+  }
+  return <p>rendered fine</p>;
+}
+
+/** Lets a test flip the child from throwing to not, to exercise "Try again". */
+function Recoverable() {
+  const [broken, setBroken] = useState(true);
+
+  return (
+    <>
+      <button onClick={() => setBroken(false)}>repair</button>
+      <ErrorBoundary>
+        <Boom shouldThrow={broken} />
+      </ErrorBoundary>
+    </>
+  );
+}
+
+let errorSpy;
+
+beforeEach(() => {
+  // React logs the caught error itself; that is expected noise here.
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+describe('ErrorBoundary', () => {
+  it('renders its children when nothing is wrong', () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow={false} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('rendered fine')).toBeInTheDocument();
+  });
+
+  it('shows a message instead of a blank page when a child throws', () => {
+    // Without a boundary React unmounts the whole tree and #root is empty.
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('offers a way out', () => {
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /clear saved data/i })
+    ).toBeInTheDocument();
+  });
+
+  it('shows the message but not the stack', () => {
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('cart.reduce is not a function')).toBeInTheDocument();
+    expect(screen.queryByText(/ErrorBoundary\.test/)).not.toBeInTheDocument();
+  });
+
+  it('logs the component stack, which is not on the error object', () => {
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>
+    );
+
+    const logged = errorSpy.mock.calls.some(
+      (call) => call[0] === '[ErrorBoundary] render failed:'
+    );
+    expect(logged).toBe(true);
+  });
+
+  it('recovers when the underlying problem is gone', async () => {
+    const user = userEvent.setup();
+    render(<Recoverable />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    await user.click(screen.getByText('repair'));
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+
+    expect(screen.getByText('rendered fine')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('clears localStorage from the escape hatch', async () => {
+    const clear = vi.spyOn(Storage.prototype, 'clear').mockImplementation(() => {});
+    const assign = vi.fn();
+    const originalLocation = window.location;
+
+    delete window.location;
+    window.location = { ...originalLocation, assign };
+
+    try {
+      const user = userEvent.setup();
+      render(
+        <ErrorBoundary>
+          <Boom />
+        </ErrorBoundary>
+      );
+
+      await user.click(screen.getByRole('button', { name: /clear saved data/i }));
+
+      expect(clear).toHaveBeenCalled();
+      expect(assign).toHaveBeenCalledWith('/');
+    } finally {
+      window.location = originalLocation;
+      clear.mockRestore();
+    }
+  });
+});

--- a/bookshelf-frontend/src/context/CartContext.jsx
+++ b/bookshelf-frontend/src/context/CartContext.jsx
@@ -1,55 +1,132 @@
-import { createContext, useState, useEffect } from 'react';
+import { createContext, useState, useEffect, useCallback } from 'react';
+
+import {
+  CART_STORAGE_KEY,
+  MAX_CART_ITEMS,
+  MAX_QUANTITY,
+  clampQuantity,
+  normaliseCartItem,
+  readCart,
+  writeCart,
+} from '../utils/cartStorage.js';
 
 export const CartContext = createContext();
 
+/**
+ * The cart.
+ *
+ * Everything that touches localStorage goes through utils/cartStorage.js,
+ * which validates rather than trusting. The previous version handed
+ * `JSON.parse(localStorage.getItem('cart'))` straight to useState — and `{}`
+ * is valid JSON, so a single bad value made `cart.reduce` throw on the first
+ * line of CartDrawer's render, on every route, permanently.
+ */
 export function CartProvider({ children }) {
-  const [cart, setCart] = useState(() => {
-    try {
-      const storedCart = localStorage.getItem('cart');
-      return storedCart ? JSON.parse(storedCart) : [];
-    } catch (error) {
-      console.error('Failed to parse cart from localStorage:', error);
-      return [];
-    }
-  });
+  const [cart, setCart] = useState(() =>
+    readCart(typeof window === 'undefined' ? null : window.localStorage)
+  );
+
   const [isCartOpen, setIsCartOpen] = useState(false);
 
   useEffect(() => {
-    localStorage.setItem('cart', JSON.stringify(cart));
+    // writeCart swallows a failure and reports false. A full quota, or Safari
+    // private browsing where setItem always throws, degrades to a cart that
+    // works for this session — it does not throw out of an effect and take
+    // the tree down.
+    writeCart(window.localStorage, cart);
   }, [cart]);
 
-  function addToCart(book) {
-    setCart((prev) => {
-      const existing = prev.find((item) => item.id === book.id);
-      if (existing) {
-        return prev.map((item) =>
-          item.id === book.id ? { ...item, quantity: item.quantity + 1 } : item
-        );
+  /**
+   * Keep tabs in step.
+   *
+   * Two tabs open, add a book in one, and the other still showed the old cart
+   * — and would overwrite storage with its stale copy on its next write. The
+   * storage event fires in every *other* tab on the same origin, which is
+   * exactly the signal needed.
+   */
+  useEffect(() => {
+    function handleStorage(event) {
+      if (event.key !== null && event.key !== CART_STORAGE_KEY) {
+        return;
       }
-      return [...prev, { ...book, quantity: 1 }];
-    });
-    setIsCartOpen(true);
-  }
 
-  function removeFromCart(bookId) {
-    setCart((prev) => prev.filter((item) => item.id !== bookId));
-  }
+      // Re-read through the same validation as the initial load rather than
+      // trusting event.newValue: another tab running an older build could
+      // have written anything.
+      setCart(readCart(window.localStorage));
+    }
 
-  function updateQuantity(bookId, newQuantity) {
-    if (newQuantity <= 0) {
-      removeFromCart(bookId);
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
+  const addToCart = useCallback((book) => {
+    // A book with no id matched any other book with no id via
+    // `item.id === book.id`, so two different books collapsed into one line.
+    const candidate = normaliseCartItem({ ...book, quantity: 1 });
+
+    if (!candidate) {
+      console.warn('[cart] ignoring an item with no usable id or price:', book);
       return;
     }
-    setCart((prev) =>
-      prev.map((item) =>
-        item.id === bookId ? { ...item, quantity: newQuantity } : item
-      )
-    );
-  }
 
-  function clearCart() {
-    setCart([]);
-  }
+    setCart((prev) => {
+      const existing = prev.find((item) => item.id === candidate.id);
+
+      if (existing) {
+        const nextQuantity = clampQuantity(existing.quantity + 1);
+
+        // Already at the per-line maximum; adding again is a no-op rather
+        // than a silently ignored click that still rewrites storage.
+        if (nextQuantity === null || nextQuantity === existing.quantity) {
+          return prev;
+        }
+
+        return prev.map((item) =>
+          item.id === candidate.id ? { ...item, quantity: nextQuantity } : item
+        );
+      }
+
+      if (prev.length >= MAX_CART_ITEMS) {
+        console.warn(
+          `[cart] the cart already holds ${MAX_CART_ITEMS} different books.`
+        );
+        return prev;
+      }
+
+      return [...prev, candidate];
+    });
+
+    setIsCartOpen(true);
+  }, []);
+
+  const removeFromCart = useCallback((bookId) => {
+    setCart((prev) => prev.filter((item) => item.id !== bookId));
+  }, []);
+
+  const updateQuantity = useCallback(
+    (bookId, newQuantity) => {
+      const quantity = clampQuantity(newQuantity);
+
+      if (quantity === null) {
+        // Covers 0, negatives and NaN. The old guard was
+        // `if (newQuantity <= 0) removeFromCart(...)`, and `NaN <= 0` is
+        // false — so NaN passed through and was stored as the quantity,
+        // which made every total in the app render NaN.
+        if (typeof newQuantity === 'number' && Number.isFinite(newQuantity)) {
+          removeFromCart(bookId);
+        }
+        return;
+      }
+
+      setCart((prev) =>
+        prev.map((item) => (item.id === bookId ? { ...item, quantity } : item))
+      );
+    },
+    [removeFromCart]
+  );
+
+  const clearCart = useCallback(() => setCart([]), []);
 
   return (
     <CartContext.Provider
@@ -60,7 +137,8 @@ export function CartProvider({ children }) {
         updateQuantity,
         clearCart,
         isCartOpen,
-        setIsCartOpen
+        setIsCartOpen,
+        maxQuantity: MAX_QUANTITY,
       }}
     >
       {children}

--- a/bookshelf-frontend/src/context/CartContext.test.jsx
+++ b/bookshelf-frontend/src/context/CartContext.test.jsx
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { CartProvider } from './CartContext.jsx';
+import { useCart } from '../hooks/useCart.js';
+import { CART_STORAGE_KEY, MAX_QUANTITY } from '../utils/cartStorage.js';
+
+/**
+ * Stands in for the parts of CartDrawer and Navbar that matter here.
+ * `cart.reduce` on the first line is deliberate: that is exactly what
+ * CartDrawer does, and it is what threw when the stored cart was not an array.
+ */
+function CartProbe() {
+  const { cart, addToCart, updateQuantity, removeFromCart, clearCart } = useCart();
+  const subtotal = cart.reduce((sum, item) => sum + item.price * item.quantity, 0);
+
+  return (
+    <div>
+      <span data-testid="count">{cart.length}</span>
+      <span data-testid="subtotal">{String(subtotal)}</span>
+      <span data-testid="ids">{cart.map((item) => `${item.id}:${item.quantity}`).join(',')}</span>
+
+      <button onClick={() => addToCart({ id: 'b1', title: 'One', price: 10 })}>add b1</button>
+      <button onClick={() => addToCart({ title: 'No id', price: 10 })}>add broken</button>
+      <button onClick={() => updateQuantity('b1', Number.NaN)}>set NaN</button>
+      <button onClick={() => updateQuantity('b1', 5)}>set 5</button>
+      <button onClick={() => updateQuantity('b1', 0)}>set 0</button>
+      <button onClick={() => updateQuantity('b1', 100000)}>set huge</button>
+      <button onClick={() => removeFromCart('b1')}>remove b1</button>
+      <button onClick={clearCart}>clear</button>
+    </div>
+  );
+}
+
+function renderCart() {
+  return render(
+    <CartProvider>
+      <CartProbe />
+    </CartProvider>
+  );
+}
+
+let warnSpy;
+
+beforeEach(() => {
+  localStorage.clear();
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+  localStorage.clear();
+});
+
+describe('loading a cart from localStorage', () => {
+  it('loads a valid cart', () => {
+    localStorage.setItem(
+      CART_STORAGE_KEY,
+      JSON.stringify([{ id: 'b1', title: 'One', price: 10, quantity: 2 }])
+    );
+
+    renderCart();
+
+    expect(screen.getByTestId('count')).toHaveTextContent('1');
+    expect(screen.getByTestId('subtotal')).toHaveTextContent('20');
+  });
+
+  it('does not crash when the stored cart is an object', () => {
+    // The reported bug. `{}` is valid JSON, so the old try/catch never fired,
+    // and `cart.reduce` threw on the first line of CartDrawer's render — on
+    // every route, because App mounts CartDrawer everywhere.
+    localStorage.setItem(CART_STORAGE_KEY, '{}');
+
+    expect(() => renderCart()).not.toThrow();
+    expect(screen.getByTestId('count')).toHaveTextContent('0');
+  });
+
+  it('does not crash on any of the other shapes that parse', () => {
+    for (const raw of ['"hello"', '42', 'null', 'true', '[1,2,3]']) {
+      localStorage.setItem(CART_STORAGE_KEY, raw);
+
+      const { unmount } = renderCart();
+      expect(screen.getByTestId('count')).toHaveTextContent('0');
+      unmount();
+    }
+  });
+
+  it('does not crash on malformed JSON', () => {
+    localStorage.setItem(CART_STORAGE_KEY, '{not json');
+
+    expect(() => renderCart()).not.toThrow();
+  });
+
+  it('drops an item with no quantity instead of producing a NaN subtotal', () => {
+    localStorage.setItem(
+      CART_STORAGE_KEY,
+      JSON.stringify([{ id: 'b1', title: 'One', price: 10 }])
+    );
+
+    renderCart();
+
+    expect(screen.getByTestId('subtotal')).toHaveTextContent('0');
+    expect(screen.getByTestId('subtotal')).not.toHaveTextContent('NaN');
+  });
+
+  it('keeps the good entries from a partly bad cart', () => {
+    localStorage.setItem(
+      CART_STORAGE_KEY,
+      JSON.stringify([{ id: 'b1', price: 10, quantity: 1 }, 'junk', { nope: true }])
+    );
+
+    renderCart();
+
+    expect(screen.getByTestId('count')).toHaveTextContent('1');
+  });
+});
+
+describe('addToCart', () => {
+  it('adds a book and persists it', async () => {
+    const user = userEvent.setup();
+    renderCart();
+
+    await user.click(screen.getByText('add b1'));
+
+    expect(screen.getByTestId('ids')).toHaveTextContent('b1:1');
+    expect(JSON.parse(localStorage.getItem(CART_STORAGE_KEY))).toHaveLength(1);
+  });
+
+  it('increments an existing line rather than duplicating it', async () => {
+    const user = userEvent.setup();
+    renderCart();
+
+    await user.click(screen.getByText('add b1'));
+    await user.click(screen.getByText('add b1'));
+
+    expect(screen.getByTestId('count')).toHaveTextContent('1');
+    expect(screen.getByTestId('ids')).toHaveTextContent('b1:2');
+  });
+
+  it('refuses a book with no id', async () => {
+    // Two items with `id: undefined` matched each other, so different books
+    // collapsed into a single line.
+    const user = userEvent.setup();
+    renderCart();
+
+    await user.click(screen.getByText('add broken'));
+
+    expect(screen.getByTestId('count')).toHaveTextContent('0');
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe('updateQuantity', () => {
+  it('sets a valid quantity', async () => {
+    const user = userEvent.setup();
+    renderCart();
+
+    await user.click(screen.getByText('add b1'));
+    await user.click(screen.getByText('set 5'));
+
+    expect(screen.getByTestId('ids')).toHaveTextContent('b1:5');
+  });
+
+  it('ignores NaN instead of storing it', async () => {
+    // `NaN <= 0` is false, so NaN passed the old guard and was stored. Every
+    // total then rendered NaN, and it survived a reload because it was
+    // persisted.
+    const user = userEvent.setup();
+    renderCart();
+
+    await user.click(screen.getByText('add b1'));
+    await user.click(screen.getByText('set NaN'));
+
+    expect(screen.getByTestId('ids')).toHaveTextContent('b1:1');
+    expect(screen.getByTestId('subtotal')).toHaveTextContent('10');
+    expect(screen.getByTestId('subtotal')).not.toHaveTextContent('NaN');
+  });
+
+  it('removes the line when the quantity reaches zero', async () => {
+    const user = userEvent.setup();
+    renderCart();
+
+    await user.click(screen.getByText('add b1'));
+    await user.click(screen.getByText('set 0'));
+
+    expect(screen.getByTestId('count')).toHaveTextContent('0');
+  });
+
+  it('caps an absurd quantity', async () => {
+    const user = userEvent.setup();
+    renderCart();
+
+    await user.click(screen.getByText('add b1'));
+    await user.click(screen.getByText('set huge'));
+
+    expect(screen.getByTestId('ids')).toHaveTextContent(`b1:${MAX_QUANTITY}`);
+  });
+});
+
+describe('persistence', () => {
+  it('survives a remount', async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderCart();
+
+    await user.click(screen.getByText('add b1'));
+    await user.click(screen.getByText('set 5'));
+    unmount();
+
+    renderCart();
+    expect(screen.getByTestId('ids')).toHaveTextContent('b1:5');
+  });
+
+  it('does not crash when writing to storage fails', async () => {
+    // Safari private browsing throws on every setItem; a full quota throws
+    // once. Either way the old bare setItem threw out of useEffect.
+    const setItem = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new DOMException('quota', 'QuotaExceededError');
+      });
+
+    try {
+      const user = userEvent.setup();
+      renderCart();
+
+      await user.click(screen.getByText('add b1'));
+
+      // Still works in memory.
+      expect(screen.getByTestId('ids')).toHaveTextContent('b1:1');
+    } finally {
+      setItem.mockRestore();
+    }
+  });
+});
+
+describe('cross-tab sync', () => {
+  it('picks up a cart written by another tab', () => {
+    renderCart();
+    expect(screen.getByTestId('count')).toHaveTextContent('0');
+
+    act(() => {
+      localStorage.setItem(
+        CART_STORAGE_KEY,
+        JSON.stringify([{ id: 'b9', price: 3, quantity: 4 }])
+      );
+      window.dispatchEvent(new StorageEvent('storage', { key: CART_STORAGE_KEY }));
+    });
+
+    expect(screen.getByTestId('ids')).toHaveTextContent('b9:4');
+  });
+
+  it('ignores an unrelated storage key', () => {
+    renderCart();
+
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', { key: 'theme' }));
+    });
+
+    expect(screen.getByTestId('count')).toHaveTextContent('0');
+  });
+
+  it('re-validates what the other tab wrote', () => {
+    // An older build in another tab could have written anything.
+    renderCart();
+
+    act(() => {
+      localStorage.setItem(CART_STORAGE_KEY, '{}');
+      window.dispatchEvent(new StorageEvent('storage', { key: CART_STORAGE_KEY }));
+    });
+
+    expect(screen.getByTestId('count')).toHaveTextContent('0');
+  });
+});

--- a/bookshelf-frontend/src/routes/AppRoutes.jsx
+++ b/bookshelf-frontend/src/routes/AppRoutes.jsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 
 import App from '../App.jsx';
 import ProtectedRoute from '../components/ProtectedRoute.jsx';
+import ErrorBoundary from '../components/ErrorBoundary.jsx';
 
 import Home from '../pages/Home.jsx';
 import BookDetail from '../pages/BookDetail.jsx';
@@ -32,7 +33,21 @@ import NotFound from '../pages/NotFound.jsx';
 export default function AppRoutes() {
   return (
     <Routes>
-      <Route path="/" element={<App />}>
+      {/*
+        The boundary wraps the layout route, so it covers the App shell —
+        navbar, footer, cart drawer — as well as every page. That matters:
+        CartDrawer is mounted on every route, so a throw inside it used to
+        blank the site rather than one page. It sits inside the router so its
+        recovery actions can still navigate.
+      */}
+      <Route
+        path="/"
+        element={
+          <ErrorBoundary>
+            <App />
+          </ErrorBoundary>
+        }
+      >
         {/* Public */}
         <Route index element={<Home />} />
         <Route path="book/:id" element={<BookDetail />} />

--- a/bookshelf-frontend/src/utils/cartStorage.js
+++ b/bookshelf-frontend/src/utils/cartStorage.js
@@ -1,0 +1,241 @@
+/**
+ * Reading and writing the cart, defensively.
+ *
+ * CartContext initialised its state straight from localStorage:
+ *
+ *   const storedCart = localStorage.getItem('cart');
+ *   return storedCart ? JSON.parse(storedCart) : [];
+ *
+ * with a try/catch that only covers JSON.parse *throwing*. Valid JSON that is
+ * not a cart parses fine and is handed to useState — and `{}` is valid JSON.
+ * CartDrawer then calls `cart.reduce(...)` on the first line of its render,
+ * App renders CartDrawer on every route, and React unmounts the tree on an
+ * uncaught render error. One bad value in storage and every page is blank,
+ * with a reload no help because the value is still there.
+ *
+ * So: parsing is not validating. Nothing that comes out of localStorage is
+ * trusted here — not the shape of the array, not the fields on each item, not
+ * the types of those fields.
+ *
+ * A corrupt cart should cost the user their cart. It should not cost them the
+ * site.
+ */
+
+export const CART_STORAGE_KEY = 'cart';
+
+/** Matches the `max` QuantitySelector already enforces. */
+export const MAX_QUANTITY = 99;
+
+/**
+ * A ceiling on distinct lines. There was none; the cart is written to
+ * localStorage on every change, and storage quota is per origin, so an
+ * unbounded cart eventually takes the quota down with it.
+ */
+export const MAX_CART_ITEMS = 100;
+
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+/**
+ * A usable line quantity: a whole number from 1 to MAX_QUANTITY.
+ *
+ * `NaN` is the case worth naming. `updateQuantity`'s guard was
+ * `if (newQuantity <= 0)`, and `NaN <= 0` is `false`, so NaN passed straight
+ * through and was stored — after which every total in the app renders `NaN`,
+ * and the value is persisted so a reload does not clear it. The drawer's +
+ * button reaches this with `item.quantity + 1` whenever a stored item has no
+ * quantity at all.
+ */
+export function isValidQuantity(value) {
+  return isFiniteNumber(value) && Number.isInteger(value) && value >= 1;
+}
+
+/**
+ * Coerce to a usable quantity, or null when there is nothing sensible to use.
+ *
+ * Returning null rather than defaulting to 1 lets the caller decide: reading
+ * from storage drops the item, while an explicit updateQuantity(id, NaN) is
+ * ignored so a stored good value is not replaced by a guess.
+ */
+export function clampQuantity(value) {
+  const numeric = typeof value === 'string' ? Number(value) : value;
+
+  if (!isFiniteNumber(numeric)) {
+    return null;
+  }
+
+  const rounded = Math.floor(numeric);
+
+  if (rounded < 1) {
+    return null;
+  }
+
+  return Math.min(rounded, MAX_QUANTITY);
+}
+
+/**
+ * Validate one cart line.
+ *
+ * Requires an id and a price, because both are load-bearing: `addToCart`
+ * matches on `item.id === book.id`, so two items with `id: undefined` collapse
+ * into one line, and `subtotal` multiplies by price. Everything else —
+ * title, author, cover — is carried through untouched, so this does not have
+ * to know the shape of a book.
+ */
+export function normaliseCartItem(item) {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) {
+    return null;
+  }
+
+  const id =
+    typeof item.id === 'string'
+      ? item.id.trim()
+      : isFiniteNumber(item.id)
+        ? String(item.id)
+        : null;
+
+  if (!id) {
+    return null;
+  }
+
+  const price = typeof item.price === 'string' ? Number(item.price) : item.price;
+
+  if (!isFiniteNumber(price) || price < 0) {
+    return null;
+  }
+
+  const quantity = clampQuantity(item.quantity);
+
+  if (quantity === null) {
+    return null;
+  }
+
+  return { ...item, id, price, quantity };
+}
+
+/**
+ * Turn anything at all into a cart.
+ *
+ * Reports what it threw away so the caller can say so once in the console
+ * rather than failing silently — a cart that quietly loses a line is its own
+ * kind of bug.
+ */
+export function normaliseCart(value) {
+  if (!Array.isArray(value)) {
+    return { items: [], dropped: value === undefined || value === null ? 0 : 1 };
+  }
+
+  const items = [];
+  const seen = new Set();
+  let dropped = 0;
+
+  for (const entry of value) {
+    const item = normaliseCartItem(entry);
+
+    if (!item) {
+      dropped += 1;
+      continue;
+    }
+
+    // A duplicate id would give two lines the cart's own logic can never
+    // separate: removeFromCart filters on id and would drop both.
+    if (seen.has(item.id)) {
+      dropped += 1;
+      continue;
+    }
+
+    if (items.length >= MAX_CART_ITEMS) {
+      dropped += 1;
+      continue;
+    }
+
+    seen.add(item.id);
+    items.push(item);
+  }
+
+  return { items, dropped };
+}
+
+/**
+ * Read the cart. Never throws, and never returns a non-array.
+ */
+export function readCart(storage, logger = console) {
+  let raw;
+
+  try {
+    raw = storage?.getItem(CART_STORAGE_KEY);
+  } catch (error) {
+    // Storage unavailable outright: Safari private browsing, site data
+    // blocked. Not worth taking the page down for.
+    logger.warn('[cart] localStorage is unavailable; starting with an empty cart.', error);
+    return [];
+  }
+
+  if (!raw) {
+    return [];
+  }
+
+  let parsed;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    logger.warn('[cart] stored cart is not valid JSON; discarding it.', error);
+    return [];
+  }
+
+  const { items, dropped } = normaliseCart(parsed);
+
+  if (dropped > 0) {
+    logger.warn(
+      `[cart] discarded ${dropped} unusable ${dropped === 1 ? 'entry' : 'entries'} ` +
+        'from the stored cart.'
+    );
+  }
+
+  return items;
+}
+
+/**
+ * Write the cart. Returns false instead of throwing when it cannot.
+ *
+ * The old effect was a bare `localStorage.setItem(...)` with no try. setItem
+ * throws QuotaExceededError when storage is full, and throws on *every* call
+ * in Safari private browsing — and an exception from inside useEffect takes
+ * the tree down exactly like a render error does. Adding an item to the cart
+ * should not be able to blank the page.
+ */
+export function writeCart(storage, items, logger = console) {
+  try {
+    storage?.setItem(CART_STORAGE_KEY, JSON.stringify(items));
+    return true;
+  } catch (error) {
+    logger.warn(
+      '[cart] could not save the cart; it will work for this session only.',
+      error
+    );
+    return false;
+  }
+}
+
+/** Total price of a cart. Safe against an empty or odd input. */
+export function cartSubtotal(items) {
+  if (!Array.isArray(items)) {
+    return 0;
+  }
+
+  return items.reduce((sum, item) => {
+    const line = (item?.price ?? 0) * (item?.quantity ?? 0);
+    return sum + (Number.isFinite(line) ? line : 0);
+  }, 0);
+}
+
+/** Total number of books, counting quantities. */
+export function cartCount(items) {
+  if (!Array.isArray(items)) {
+    return 0;
+  }
+
+  return items.reduce((sum, item) => sum + (clampQuantity(item?.quantity) ?? 0), 0);
+}

--- a/bookshelf-frontend/src/utils/cartStorage.test.js
+++ b/bookshelf-frontend/src/utils/cartStorage.test.js
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  CART_STORAGE_KEY,
+  MAX_QUANTITY,
+  MAX_CART_ITEMS,
+  isValidQuantity,
+  clampQuantity,
+  normaliseCartItem,
+  normaliseCart,
+  readCart,
+  writeCart,
+  cartSubtotal,
+  cartCount,
+} from './cartStorage.js';
+
+const silent = { warn: () => {}, error: () => {} };
+
+function fakeStorage(initial) {
+  const map = new Map(initial ? [[CART_STORAGE_KEY, initial]] : []);
+  return {
+    map,
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => map.set(key, value),
+  };
+}
+
+function throwingStorage(message = 'The operation is insecure.') {
+  return {
+    getItem() {
+      throw new DOMException(message, 'SecurityError');
+    },
+    setItem() {
+      throw new DOMException(message, 'QuotaExceededError');
+    },
+  };
+}
+
+const book = (overrides = {}) => ({
+  id: 'b1',
+  title: 'A Book',
+  price: 12.5,
+  quantity: 1,
+  ...overrides,
+});
+
+describe('isValidQuantity', () => {
+  it('accepts whole numbers of at least one', () => {
+    expect(isValidQuantity(1)).toBe(true);
+    expect(isValidQuantity(42)).toBe(true);
+  });
+
+  it('rejects NaN — the value that used to pass the guard', () => {
+    // `NaN <= 0` is false, so NaN sailed through `if (newQuantity <= 0)`.
+    expect(isValidQuantity(Number.NaN)).toBe(false);
+  });
+
+  it('rejects zero, negatives, fractions and Infinity', () => {
+    expect(isValidQuantity(0)).toBe(false);
+    expect(isValidQuantity(-1)).toBe(false);
+    expect(isValidQuantity(1.5)).toBe(false);
+    expect(isValidQuantity(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+
+  it('rejects non-numbers', () => {
+    expect(isValidQuantity('2')).toBe(false);
+    expect(isValidQuantity(null)).toBe(false);
+    expect(isValidQuantity(undefined)).toBe(false);
+  });
+});
+
+describe('clampQuantity', () => {
+  it('passes a good quantity through', () => {
+    expect(clampQuantity(3)).toBe(3);
+  });
+
+  it('caps at the maximum', () => {
+    expect(clampQuantity(999999999)).toBe(MAX_QUANTITY);
+  });
+
+  it('floors a fraction', () => {
+    expect(clampQuantity(2.9)).toBe(2);
+  });
+
+  it('accepts a numeric string', () => {
+    expect(clampQuantity('4')).toBe(4);
+  });
+
+  it('returns null for anything unusable', () => {
+    expect(clampQuantity(Number.NaN)).toBeNull();
+    expect(clampQuantity(0)).toBeNull();
+    expect(clampQuantity(-5)).toBeNull();
+    expect(clampQuantity('abc')).toBeNull();
+    expect(clampQuantity(undefined)).toBeNull();
+    expect(clampQuantity(null)).toBeNull();
+    expect(clampQuantity({})).toBeNull();
+  });
+});
+
+describe('normaliseCartItem', () => {
+  it('keeps a valid item and its extra fields', () => {
+    const item = normaliseCartItem(book({ author: 'Someone', cover: '/x.png' }));
+
+    expect(item).toMatchObject({
+      id: 'b1',
+      price: 12.5,
+      quantity: 1,
+      author: 'Someone',
+      cover: '/x.png',
+    });
+  });
+
+  it('rejects an item with no id', () => {
+    // Two items with `id: undefined` matched each other via
+    // `item.id === book.id`, so different books collapsed into one line.
+    expect(normaliseCartItem(book({ id: undefined }))).toBeNull();
+    expect(normaliseCartItem(book({ id: '' }))).toBeNull();
+    expect(normaliseCartItem(book({ id: '   ' }))).toBeNull();
+    expect(normaliseCartItem(book({ id: null }))).toBeNull();
+  });
+
+  it('accepts a numeric id and stores it as a string', () => {
+    expect(normaliseCartItem(book({ id: 7 })).id).toBe('7');
+  });
+
+  it('rejects an item with no usable price', () => {
+    expect(normaliseCartItem(book({ price: undefined }))).toBeNull();
+    expect(normaliseCartItem(book({ price: Number.NaN }))).toBeNull();
+    expect(normaliseCartItem(book({ price: -1 }))).toBeNull();
+    expect(normaliseCartItem(book({ price: 'free' }))).toBeNull();
+  });
+
+  it('accepts a price of zero and a numeric string price', () => {
+    expect(normaliseCartItem(book({ price: 0 })).price).toBe(0);
+    expect(normaliseCartItem(book({ price: '9.99' })).price).toBe(9.99);
+  });
+
+  it('rejects an item with no quantity — the NaN subtotal case', () => {
+    // `item.price * item.quantity` with quantity undefined is NaN, and the
+    // drawer's + button then does `undefined + 1`.
+    expect(normaliseCartItem({ id: 'b1', price: 10 })).toBeNull();
+  });
+
+  it('rejects things that are not objects', () => {
+    expect(normaliseCartItem(null)).toBeNull();
+    expect(normaliseCartItem('b1')).toBeNull();
+    expect(normaliseCartItem(42)).toBeNull();
+    expect(normaliseCartItem(['b1'])).toBeNull();
+  });
+});
+
+describe('normaliseCart', () => {
+  it('keeps a valid cart intact', () => {
+    const { items, dropped } = normaliseCart([book(), book({ id: 'b2' })]);
+
+    expect(items).toHaveLength(2);
+    expect(dropped).toBe(0);
+  });
+
+  it('turns the values that used to white-screen the app into an empty cart', () => {
+    // Each of these is valid JSON, so the old try/catch never fired, and each
+    // made `cart.reduce` throw on CartDrawer's first line.
+    for (const value of [{}, 'hello', 42, null, true]) {
+      expect(normaliseCart(value).items).toEqual([]);
+    }
+  });
+
+  it('drops only the bad entries from a mixed cart', () => {
+    const { items, dropped } = normaliseCart([
+      book(),
+      { id: 'b2' },
+      'nonsense',
+      book({ id: 'b3' }),
+    ]);
+
+    expect(items.map((item) => item.id)).toEqual(['b1', 'b3']);
+    expect(dropped).toBe(2);
+  });
+
+  it('drops duplicate ids', () => {
+    // removeFromCart filters on id, so two lines sharing one would both go.
+    const { items, dropped } = normaliseCart([book(), book({ quantity: 5 })]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].quantity).toBe(1);
+    expect(dropped).toBe(1);
+  });
+
+  it('caps the number of lines', () => {
+    const many = Array.from({ length: MAX_CART_ITEMS + 10 }, (_, i) =>
+      book({ id: `b${i}` })
+    );
+    const { items, dropped } = normaliseCart(many);
+
+    expect(items).toHaveLength(MAX_CART_ITEMS);
+    expect(dropped).toBe(10);
+  });
+
+  it('clamps an absurd quantity rather than dropping the line', () => {
+    const { items } = normaliseCart([book({ quantity: 999999999 })]);
+    expect(items[0].quantity).toBe(MAX_QUANTITY);
+  });
+});
+
+describe('readCart', () => {
+  it('reads a valid cart', () => {
+    const cart = readCart(fakeStorage(JSON.stringify([book()])), silent);
+    expect(cart).toHaveLength(1);
+  });
+
+  it('returns an empty array when nothing is stored', () => {
+    expect(readCart(fakeStorage(), silent)).toEqual([]);
+  });
+
+  it('returns an empty array for malformed JSON', () => {
+    expect(readCart(fakeStorage('{not json'), silent)).toEqual([]);
+  });
+
+  it('returns an empty array for JSON that is not a cart', () => {
+    expect(readCart(fakeStorage('{}'), silent)).toEqual([]);
+    expect(readCart(fakeStorage('"hello"'), silent)).toEqual([]);
+    expect(readCart(fakeStorage('42'), silent)).toEqual([]);
+  });
+
+  it('never returns a non-array', () => {
+    for (const raw of ['{}', '"x"', '42', 'null', 'true', '[1,2,3]']) {
+      expect(Array.isArray(readCart(fakeStorage(raw), silent))).toBe(true);
+    }
+  });
+
+  it('survives storage being unavailable', () => {
+    expect(readCart(throwingStorage(), silent)).toEqual([]);
+    expect(readCart(undefined, silent)).toEqual([]);
+  });
+
+  it('says once what it discarded', () => {
+    const logger = { warn: vi.fn(), error: vi.fn() };
+    readCart(fakeStorage(JSON.stringify([book(), 'junk', 'more junk'])), logger);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn.mock.calls[0][0]).toMatch(/discarded 2 unusable entries/);
+  });
+});
+
+describe('writeCart', () => {
+  it('writes and reports success', () => {
+    const storage = fakeStorage();
+
+    expect(writeCart(storage, [book()], silent)).toBe(true);
+    expect(JSON.parse(storage.map.get(CART_STORAGE_KEY))).toHaveLength(1);
+  });
+
+  it('returns false instead of throwing when the quota is exceeded', () => {
+    // The old effect had no try. An exception out of useEffect takes the tree
+    // down exactly like a render error — adding to the cart blanked the page.
+    expect(() => writeCart(throwingStorage(), [book()], silent)).not.toThrow();
+    expect(writeCart(throwingStorage(), [book()], silent)).toBe(false);
+  });
+
+  it('round-trips through readCart', () => {
+    const storage = fakeStorage();
+    writeCart(storage, [book(), book({ id: 'b2', quantity: 3 })], silent);
+
+    const read = readCart(storage, silent);
+    expect(read.map((item) => [item.id, item.quantity])).toEqual([
+      ['b1', 1],
+      ['b2', 3],
+    ]);
+  });
+});
+
+describe('cartSubtotal', () => {
+  it('adds up price times quantity', () => {
+    expect(cartSubtotal([book({ price: 10, quantity: 2 }), book({ id: 'b2', price: 5 })])).toBe(25);
+  });
+
+  it('is zero for an empty or invalid cart', () => {
+    expect(cartSubtotal([])).toBe(0);
+    expect(cartSubtotal({})).toBe(0);
+    expect(cartSubtotal(undefined)).toBe(0);
+  });
+
+  it('never returns NaN, even given a malformed line', () => {
+    expect(cartSubtotal([{ id: 'b1' }, { id: 'b2', price: 5, quantity: 2 }])).toBe(10);
+  });
+});
+
+describe('cartCount', () => {
+  it('counts quantities, not lines', () => {
+    expect(cartCount([book({ quantity: 2 }), book({ id: 'b2', quantity: 3 })])).toBe(5);
+  });
+
+  it('ignores unusable quantities', () => {
+    expect(cartCount([{ id: 'b1', quantity: Number.NaN }, book({ id: 'b2' })])).toBe(1);
+  });
+
+  it('is zero for anything that is not a cart', () => {
+    expect(cartCount(null)).toBe(0);
+    expect(cartCount({})).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #309.

## The crash

```js
const [cart, setCart] = useState(() => {
  try {
    const storedCart = localStorage.getItem('cart');
    return storedCart ? JSON.parse(storedCart) : [];
  } catch (error) { ... return []; }
});
```

The `catch` only covers `JSON.parse` **throwing**. Parsing is not validating — valid JSON that is not a cart parses fine and goes straight into `useState`. And `{}` is valid JSON.

`CartDrawer` then does this on its first line, before any early return:

```js
// components/CartDrawer.jsx:12
const subtotal = cart.reduce((sum, item) => sum + item.price * item.quantity, 0);
```

`App.jsx` renders `<CartDrawer />` on every route, and React's default for an uncaught render error is to unmount the whole tree — `<div id="root">` ends up empty. So **every** page is blank, and reloading does not help because the bad value is still in storage. The only fix available to a user was opening DevTools.

Getting there does not take malice: a half-written value, another app on the same origin using the key `cart`, a browser extension, or one poke at DevTools. `"hello"`, `42`, `null` and `true` all do it too.

## What this does

Everything that touches storage goes through **`src/utils/cartStorage.js`**, which validates the array, then each item, then each field. An item needs an `id` and a `price` — both are load-bearing:

- `addToCart` matches on `item.id === book.id`, so two items with `id: undefined` match each other and different books collapse into one line
- `subtotal` multiplies by `price`

Everything else (title, author, cover) is carried through untouched, so the validator does not need to know the shape of a book.

A corrupt cart should cost the user their cart. It should not cost them the site.

## Quantities

```js
if (newQuantity <= 0) { removeFromCart(bookId); return; }
```

`NaN <= 0` is `false`, so `NaN` sailed past this and was stored as the quantity. Every total downstream rendered `NaN`, and it was persisted so it survived a reload.

Correcting my own wording in the issue: `CartDrawer` uses +/− buttons, not a text input, so there is no way to *type* a bad quantity. The reachable path is a stored item with no `quantity` field — `subtotal` is `NaN` immediately, and clicking + does `updateQuantity(id, undefined + 1)`, which is `updateQuantity(id, NaN)`.

Quantities are now clamped to a whole number within `MAX_QUANTITY` (99, matching what `QuantitySelector` already enforces). `NaN` is **ignored** rather than defaulting to 1 — replacing a good stored value with a guess is its own bug. `0` and negatives still remove the line, as before.

There was also no upper bound: `quantity: 999999999` was accepted, persisted, and sent to checkout, where `paymentController` multiplies it by the price to build a Stripe amount.

## The write side

```js
useEffect(() => {
  localStorage.setItem('cart', JSON.stringify(cart));
}, [cart]);
```

No `try`. `setItem` throws `QuotaExceededError` when storage is full and throws on *every* call in Safari private browsing — and an exception thrown from inside `useEffect` takes the tree down exactly like a render error. Adding an item to the cart could blank the page. It now degrades to a cart that works for the session, with one warning.

## Cross-tab sync

Two tabs never agreed: add a book in one and the other still showed the old cart, then overwrote storage with its stale copy on its next write. Added a `storage` listener. It re-reads through the same validation rather than trusting `event.newValue`, because another tab could be running an older build.

## The error boundary

There was no boundary anywhere in the tree. The stored-cart problem is fixed at its source, but the *next* render error would cost a white screen the same way — so `ErrorBoundary` now wraps the layout route in `AppRoutes.jsx`. That placement covers the App shell (navbar, footer, cart drawer) as well as every page, which matters because CartDrawer is mounted everywhere. It sits inside the router so its recovery actions can navigate.

It offers "Try again" and "Clear saved data and reload" — the escape hatch a user previously had no way to reach. It shows `error.message` but not the stack; the stack names internal paths and is in the console anyway.

## Tests

63 new cases across three files.

The important one: **restoring the old `CartContext.jsx` fails 9 of them**, each with the exact production error:

```
TypeError: cart.reduce is not a function
⎯⎯⎯ Failed Tests 9 ⎯⎯⎯
```

`CartContext.test.jsx` drives the provider through a probe component that calls `cart.reduce` on its first line — the same thing `CartDrawer` does — so the tests fail the way the app failed, not the way a unit test failed. Covers every stored shape that parses, the NaN quantity, the quota-exceeded write, and cross-tab sync.

```console
$ npm test
 Test Files  7 passed (7)
      Tests  109 passed (109)
```

Was 46 before this branch. `npm run build` and `eslint` both clean.

## Notes for review

- The context's exported value is unchanged apart from an added `maxQuantity`, so `CartDrawer`, `Navbar` and `BookCard` need no edit — and I deliberately did not touch `BookCard.jsx`, since #284 and #304 both already do.
- `AppRoutes.jsx` is the mount point rather than `main.jsx` specifically to stay out of #301's way.
- I did not rewire `CartDrawer` to use `cartSubtotal()` from the new module. It would be a fair follow-up, but it is not what this fixes.
- I corrected the NaN reproduction steps in #309; the original said there was a quantity input, and there is not.