### PR TITLE
fix(checkout): send the real cart instead of a hardcoded sample book (closes #315)

### DIFF
--- a/bookshelf-frontend/src/components/CheckoutForm.jsx
+++ b/bookshelf-frontend/src/components/CheckoutForm.jsx
@@ -1,55 +1,140 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
   PaymentElement,
   useStripe,
-  useElements
+  useElements,
 } from '@stripe/react-stripe-js';
 import { useNavigate } from 'react-router-dom';
 
-const CheckoutForm = ({ orderId }) => {
+/**
+ * The Stripe payment step.
+ *
+ * Two things were wrong here (#315).
+ *
+ * First, the result of `confirmPayment` was read as `const { error } = …` and
+ * then dereferenced immediately:
+ *
+ *     if (error.type === 'card_error' || error.type === 'validation_error')
+ *
+ * `confirmPayment` resolves with an object that has *no* `error` property
+ * whenever the payment did not fail — which is the successful path. That line
+ * threw `TypeError: Cannot read properties of undefined (reading 'type')`, so
+ * the component that a customer sees immediately after paying was the one
+ * guaranteed to crash.
+ *
+ * Second, nothing emptied the cart. A customer who paid came back to a full
+ * cart and could pay for the same books again.
+ *
+ * `redirect: 'if_required'` is what makes the second fixable: card payments
+ * that need no 3-D Secure step resolve here rather than navigating away, so
+ * there is a moment in which the success is known and the cart can be
+ * cleared. Payment methods that *do* redirect still leave via `return_url`.
+ */
+const CheckoutForm = ({ orderId, onPaid, onNavigate }) => {
   const stripe = useStripe();
   const elements = useElements();
-  const navigate = useNavigate();
+  const routerNavigate = useNavigate();
+  const navigate = onNavigate ?? routerNavigate;
 
   const [message, setMessage] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
+  const confirmationPath = orderId
+    ? `/order-confirmation?orderId=${encodeURIComponent(orderId)}`
+    : '/order-confirmation';
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
 
     if (!stripe || !elements) {
-      // Stripe.js has not yet loaded.
+      // Stripe.js has not finished loading.
       return;
     }
 
     setIsLoading(true);
+    setMessage(null);
 
-    const { error } = await stripe.confirmPayment({
-      elements,
-      confirmParams: {
-        // Make sure to change this to your payment completion page
-        return_url: `${window.location.origin}/order-confirmation?orderId=${orderId}`,
-      },
-    });
+    let result;
 
-    if (error.type === 'card_error' || error.type === 'validation_error') {
-      setMessage(error.message);
-    } else {
-      setMessage('An unexpected error occurred.');
+    try {
+      result = await stripe.confirmPayment({
+        elements,
+        confirmParams: {
+          return_url: `${window.location.origin}${confirmationPath}`,
+        },
+        redirect: 'if_required',
+      });
+    } catch (thrown) {
+      // confirmPayment rejects rather than resolving when Stripe.js itself
+      // fails — a blocked network, mostly. Without this the rejection is
+      // unhandled and the button stays disabled forever.
+      console.error('[checkout] confirmPayment threw:', thrown);
+      setMessage('We could not reach the payment provider. Please try again.');
+      setIsLoading(false);
+      return;
     }
 
+    const { error, paymentIntent } = result ?? {};
+
+    if (error) {
+      // card_error and validation_error carry a message written for the
+      // customer. Anything else is ours to explain, not Stripe's.
+      setMessage(
+        error.type === 'card_error' || error.type === 'validation_error'
+          ? error.message
+          : 'An unexpected error occurred. Your card has not been charged.'
+      );
+      setIsLoading(false);
+      return;
+    }
+
+    if (paymentIntent?.status === 'succeeded') {
+      onPaid?.(paymentIntent);
+      navigate(confirmationPath, { replace: true });
+      return;
+    }
+
+    if (paymentIntent?.status === 'processing') {
+      // Asynchronous methods settle later. The order exists and the webhook
+      // will finish it, so the cart is done with either way.
+      onPaid?.(paymentIntent);
+      navigate(confirmationPath, { replace: true });
+      return;
+    }
+
+    if (paymentIntent?.status === 'requires_payment_method') {
+      setMessage('That payment did not go through. Please try another method.');
+      setIsLoading(false);
+      return;
+    }
+
+    // No error, no intent: Stripe has redirected, or is about to. Leave the
+    // button disabled rather than inviting a second confirmation.
     setIsLoading(false);
   };
 
   return (
-    <form id="payment-form" onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+    <form
+      id="payment-form"
+      onSubmit={handleSubmit}
+      className="checkout__payment-form"
+    >
       <PaymentElement id="payment-element" />
-      <button disabled={isLoading || !stripe || !elements} id="submit" style={{ padding: '12px', background: 'var(--leather)', color: '#fff', border: 'none', borderRadius: '8px', cursor: 'pointer', fontWeight: 'bold' }}>
-        <span id="button-text">
-          {isLoading ? <div className="spinner" id="spinner">Processing...</div> : 'Pay now'}
-        </span>
+
+      <button
+        className="checkout__submit"
+        disabled={isLoading || !stripe || !elements}
+        id="submit"
+        type="submit"
+      >
+        {isLoading ? 'Processing…' : 'Pay now'}
       </button>
-      {message && <div id="payment-message" style={{ color: 'red' }}>{message}</div>}
+
+      {message && (
+        <div id="payment-message" className="checkout__error" role="alert">
+          {message}
+        </div>
+      )}
     </form>
   );
 };

--- a/bookshelf-frontend/src/components/CheckoutForm.test.jsx
+++ b/bookshelf-frontend/src/components/CheckoutForm.test.jsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const confirmPayment = vi.fn();
+const stripe = { confirmPayment };
+const elements = {};
+
+vi.mock('@stripe/react-stripe-js', () => ({
+  PaymentElement: () => <div data-testid="payment-element" />,
+  useStripe: () => stripe,
+  useElements: () => elements,
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+import CheckoutForm from './CheckoutForm.jsx';
+
+function renderForm(props = {}) {
+  const onPaid = vi.fn();
+  const onNavigate = vi.fn();
+  render(
+    <CheckoutForm orderId="order-1" onPaid={onPaid} onNavigate={onNavigate} {...props} />
+  );
+  return { onPaid, onNavigate };
+}
+
+async function pay() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: /pay now/i }));
+}
+
+describe('CheckoutForm', () => {
+  beforeEach(() => {
+    confirmPayment.mockReset();
+  });
+
+  it('does not throw when confirmPayment resolves without an error', async () => {
+    // The regression from #315: the old code read `error.type` unconditionally,
+    // and the successful path is exactly the one where `error` is absent.
+    confirmPayment.mockResolvedValue({
+      paymentIntent: { id: 'pi_1', status: 'succeeded' },
+    });
+
+    const { onPaid, onNavigate } = renderForm();
+    await pay();
+
+    await waitFor(() => expect(onPaid).toHaveBeenCalledTimes(1));
+    expect(onNavigate).toHaveBeenCalledWith(
+      '/order-confirmation?orderId=order-1',
+      { replace: true }
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('clears the cart only after the payment actually succeeds', async () => {
+    confirmPayment.mockResolvedValue({
+      error: { type: 'card_error', message: 'Your card was declined.' },
+    });
+
+    const { onPaid, onNavigate } = renderForm();
+    await pay();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Your card was declined.'
+    );
+    expect(onPaid).not.toHaveBeenCalled();
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does not show a raw Stripe message for errors not written for customers', async () => {
+    confirmPayment.mockResolvedValue({
+      error: { type: 'api_connection_error', message: 'Request to Stripe failed: ECONNRESET' },
+    });
+
+    renderForm();
+    await pay();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/unexpected error/i);
+    expect(alert).not.toHaveTextContent('ECONNRESET');
+  });
+
+  it('treats a processing intent as done — the webhook finishes it', async () => {
+    confirmPayment.mockResolvedValue({
+      paymentIntent: { id: 'pi_2', status: 'processing' },
+    });
+
+    const { onPaid, onNavigate } = renderForm();
+    await pay();
+
+    await waitFor(() => expect(onPaid).toHaveBeenCalled());
+    expect(onNavigate).toHaveBeenCalled();
+  });
+
+  it('re-enables the button when the intent still needs a payment method', async () => {
+    confirmPayment.mockResolvedValue({
+      paymentIntent: { id: 'pi_3', status: 'requires_payment_method' },
+    });
+
+    const { onPaid } = renderForm();
+    await pay();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/did not go through/i);
+    expect(onPaid).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /pay now/i })).toBeEnabled()
+    );
+  });
+
+  it('recovers when Stripe.js rejects rather than resolving', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    confirmPayment.mockRejectedValue(new Error('network down'));
+
+    const { onPaid } = renderForm();
+    await pay();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /could not reach the payment provider/i
+    );
+    expect(onPaid).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /pay now/i })).toBeEnabled()
+    );
+  });
+
+  it('percent-encodes the order id it puts in the return url', async () => {
+    confirmPayment.mockResolvedValue({
+      paymentIntent: { id: 'pi_4', status: 'succeeded' },
+    });
+
+    const { onNavigate } = renderForm({ orderId: 'order/1 &2' });
+    await pay();
+
+    await waitFor(() => expect(onNavigate).toHaveBeenCalled());
+    expect(onNavigate.mock.calls[0][0]).toBe(
+      '/order-confirmation?orderId=order%2F1%20%262'
+    );
+    expect(confirmPayment.mock.calls[0][0].confirmParams.return_url).toContain(
+      'order%2F1%20%262'
+    );
+  });
+
+  it('asks Stripe not to redirect unless the payment method requires it', async () => {
+    confirmPayment.mockResolvedValue({
+      paymentIntent: { id: 'pi_5', status: 'succeeded' },
+    });
+
+    renderForm();
+    await pay();
+
+    expect(confirmPayment.mock.calls[0][0].redirect).toBe('if_required');
+  });
+});

--- a/bookshelf-frontend/src/pages/Checkout.css
+++ b/bookshelf-frontend/src/pages/Checkout.css
@@ -342,3 +342,208 @@
     gap: 10px;
   }
 }
+
+/* ─── Checkout page shell (#315) ─────────────────────────────────────────
+ *
+ * The page used to carry its layout in inline `style` objects, including a
+ * hardcoded `background: '#fff'` and `color: '#221e19'`. That made the
+ * checkout the one page in the app the theme from #296 could not reach — it
+ * stayed cream-on-white under `data-theme="dark"`. Everything below goes
+ * through the same custom properties the rest of the app uses.
+ *
+ * The `.checkout-*` rules above belong to the earlier multi-step checkout
+ * layout and are left untouched.
+ */
+
+.checkout {
+  max-width: 1040px;
+  margin: 48px auto;
+  padding: 0 20px 80px;
+}
+
+.checkout__title {
+  font-family: var(--font-display);
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  color: var(--ink);
+  margin: 0 0 28px;
+}
+
+.checkout__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+@media (max-width: 860px) {
+  .checkout__layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.checkout__panel {
+  background: var(--paper-dim);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 28px;
+}
+
+.checkout__panel--message {
+  max-width: 520px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.checkout__panel--message p {
+  color: var(--ink-soft);
+  margin: 12px 0 24px;
+}
+
+.checkout__section-title {
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  color: var(--ink);
+  margin: 0 0 20px;
+}
+
+.checkout__form,
+.checkout__payment-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.checkout__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.checkout__label {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--ink-soft);
+}
+
+.checkout__input {
+  padding: 11px 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 15px;
+}
+
+.checkout__input:focus-visible {
+  outline: 2px solid var(--leather);
+  outline-offset: 1px;
+}
+
+.checkout__input--invalid {
+  border-color: #c0392b;
+}
+
+.checkout__error {
+  color: #c0392b;
+  font-size: 13px;
+}
+
+.checkout__error--form {
+  margin: 0;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: rgba(192, 57, 43, 0.1);
+}
+
+.checkout__submit,
+.checkout__link-btn {
+  display: inline-block;
+  padding: 13px 20px;
+  border: none;
+  border-radius: 8px;
+  background: var(--leather);
+  color: #fff;
+  font-family: var(--font-body);
+  font-size: 15px;
+  font-weight: 700;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.checkout__submit:hover:not(:disabled),
+.checkout__link-btn:hover {
+  background: var(--leather-deep);
+}
+
+.checkout__submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.checkout__lines {
+  list-style: none;
+  margin: 0 0 20px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.checkout__line {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 14px;
+  color: var(--ink);
+}
+
+.checkout__line-qty {
+  color: var(--ink-soft);
+}
+
+.checkout__line-price {
+  white-space: nowrap;
+  font-family: var(--font-mono);
+}
+
+.checkout__totals {
+  margin: 0;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.checkout__total-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  color: var(--ink);
+}
+
+.checkout__total-row dt,
+.checkout__total-row dd {
+  margin: 0;
+}
+
+.checkout__total-row dd {
+  font-family: var(--font-mono);
+}
+
+.checkout__total-row--grand {
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.checkout__note {
+  margin: 16px 0 0;
+  font-size: 13px;
+  color: var(--ink-soft);
+}

--- a/bookshelf-frontend/src/pages/Checkout.jsx
+++ b/bookshelf-frontend/src/pages/Checkout.jsx
@@ -1,58 +1,290 @@
-import React, { useState, useEffect } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { loadStripe } from '@stripe/stripe-js';
 import { Elements } from '@stripe/react-stripe-js';
+
 import paymentService from '../services/paymentService.js';
 import CheckoutForm from '../components/CheckoutForm.jsx';
+import { useCart } from '../hooks/useCart.js';
+import {
+  ADDRESS_FIELDS,
+  EMPTY_ADDRESS,
+  cartSubtotal,
+  countItems,
+  describeCheckoutError,
+  normaliseAddress,
+  toOrderItems,
+  validateAddress,
+} from '../utils/checkoutValidation.js';
+import './Checkout.css';
 
-// Make sure to call loadStripe outside of a component’s render to avoid
-// recreating the Stripe object on every render.
-const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY || 'pk_test_mock_stripe_key_123');
+/**
+ * loadStripe is called once at module scope, not per render — the Stripe
+ * object is expensive and recreating it on every render breaks Elements.
+ *
+ * No `|| 'pk_test_mock_stripe_key_123'` fallback. A publishable key is not a
+ * secret, but a *fake* one fails at the point where a customer is trying to
+ * pay, which is the worst place to discover a missing environment variable.
+ * Missing means missing, and the page says so.
+ */
+const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY;
+const stripePromise = publishableKey ? loadStripe(publishableKey) : null;
 
+const formatRupees = (amount) =>
+  `₹${Number(amount ?? 0).toLocaleString('en-IN', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+
+/**
+ * Checkout, in two steps.
+ *
+ * Step one collects the shipping address. Step two mounts Stripe Elements
+ * against the client secret that came back. Nothing is sent to the API until
+ * the address validates, and nothing is sent at all if the cart is empty —
+ * previously the effect fired on mount unconditionally and created a
+ * server-side order for a customer who had not filled anything in and might
+ * not have had a cart. See #315.
+ */
 export default function Checkout() {
+  const { cart, clearCart } = useCart();
+  const navigate = useNavigate();
+
+  const [address, setAddress] = useState(EMPTY_ADDRESS);
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [formError, setFormError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
   const [clientSecret, setClientSecret] = useState('');
   const [orderId, setOrderId] = useState('');
+  const [amount, setAmount] = useState(null);
 
-  useEffect(() => {
-    // In a real app, you would pass the actual cart items here
-    const fetchPaymentIntent = async () => {
-      try {
-        const data = await paymentService.createPaymentIntent({
-          items: [{ id: 'book-1', title: 'Sample Book', price: 19.99, quantity: 1 }],
-          shippingAddress: {
-            name: 'Jane Doe',
-            address: '123 Main St',
-            city: 'Anytown',
-            postalCode: '12345',
-            country: 'US'
-          }
-        });
-        setClientSecret(data.clientSecret);
-        setOrderId(data.orderId);
-      } catch (error) {
-        console.error("Failed to initialize checkout:", error);
+  const items = useMemo(() => toOrderItems(cart), [cart]);
+  const bookCount = useMemo(() => countItems(cart), [cart]);
+  const subtotal = useMemo(() => cartSubtotal(cart), [cart]);
+
+  const handleFieldChange = useCallback((name, value) => {
+    setAddress((previous) => ({ ...previous, [name]: value }));
+    // Clear this field's error as soon as the customer edits it. Leaving it
+    // on screen while they type reads as "still wrong" when it may not be.
+    setFieldErrors((previous) => {
+      if (!previous[name]) {
+        return previous;
       }
-    };
-    fetchPaymentIntent();
+      const next = { ...previous };
+      delete next[name];
+      return next;
+    });
   }, []);
 
-  const appearance = {
-    theme: 'stripe',
-  };
-  const options = {
-    clientSecret,
-    appearance,
+  const handleSubmitAddress = async (event) => {
+    event.preventDefault();
+
+    const normalised = normaliseAddress(address);
+    setAddress(normalised);
+
+    const errors = validateAddress(normalised);
+    setFieldErrors(errors);
+    setFormError('');
+
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+
+    if (items.length === 0) {
+      setFormError('Your cart is empty.');
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      // The cart, not a sample book. Only ids and quantities travel; the
+      // server prices every line from the catalogue.
+      const data = await paymentService.createPaymentIntent({
+        items,
+        shippingAddress: normalised,
+      });
+
+      if (!data?.clientSecret) {
+        throw new Error('The payment could not be prepared. Please try again.');
+      }
+
+      setClientSecret(data.clientSecret);
+      setOrderId(data.orderId ?? '');
+      setAmount(data.amount ?? null);
+    } catch (error) {
+      // The old page swallowed this into console.error and left the customer
+      // on a spinner forever. Say what happened and let them retry.
+      console.error('[checkout] could not create the payment intent:', error);
+      setFormError(describeCheckoutError(error));
+    } finally {
+      setSubmitting(false);
+    }
   };
 
+  const handlePaid = useCallback(() => {
+    // Only once the payment is actually confirmed. Clearing earlier loses the
+    // cart of anyone whose card is declined.
+    clearCart();
+  }, [clearCart]);
+
+  if (!stripePromise) {
+    return (
+      <main className="checkout">
+        <div className="checkout__panel checkout__panel--message">
+          <h1 className="checkout__title">Checkout unavailable</h1>
+          <p>
+            Payments are not configured for this deployment. Set{' '}
+            <code>VITE_STRIPE_PUBLISHABLE_KEY</code> and rebuild the frontend.
+          </p>
+          <Link className="checkout__link-btn" to="/">
+            Back to the shop
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  if (items.length === 0 && !clientSecret) {
+    return (
+      <main className="checkout">
+        <div className="checkout__panel checkout__panel--message">
+          <h1 className="checkout__title">Your cart is empty</h1>
+          <p>Add a book before checking out.</p>
+          <Link className="checkout__link-btn" to="/">
+            Browse the shelf
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
   return (
-    <div className="checkout-page" style={{ maxWidth: '500px', margin: '4rem auto', padding: '2rem', background: '#fff', borderRadius: '12px', boxShadow: '0 4px 6px rgba(0,0,0,0.1)' }}>
-      <h2 style={{ textAlign: 'center', marginBottom: '1.5rem', color: '#221e19' }}>Secure Checkout</h2>
-      {clientSecret ? (
-        <Elements options={options} stripe={stripePromise}>
-          <CheckoutForm orderId={orderId} />
-        </Elements>
-      ) : (
-        <div style={{ textAlign: 'center', padding: '2rem' }}>Loading checkout...</div>
-      )}
-    </div>
+    <main className="checkout">
+      <h1 className="checkout__title">Secure checkout</h1>
+
+      <div className="checkout__layout">
+        <section className="checkout__panel" aria-labelledby="checkout-details">
+          <h2 id="checkout-details" className="checkout__section-title">
+            {clientSecret ? 'Payment' : 'Shipping address'}
+          </h2>
+
+          {clientSecret ? (
+            <Elements
+              stripe={stripePromise}
+              options={{ clientSecret, appearance: { theme: 'stripe' } }}
+            >
+              <CheckoutForm
+                orderId={orderId}
+                onPaid={handlePaid}
+                onNavigate={navigate}
+              />
+            </Elements>
+          ) : (
+            <form className="checkout__form" onSubmit={handleSubmitAddress} noValidate>
+              {ADDRESS_FIELDS.map((field) => {
+                const errorId = `${field.name}-error`;
+                const error = fieldErrors[field.name];
+
+                return (
+                  <label className="checkout__field" key={field.name}>
+                    <span className="checkout__label">{field.label}</span>
+                    <input
+                      className={`checkout__input ${
+                        error ? 'checkout__input--invalid' : ''
+                      }`}
+                      name={field.name}
+                      type="text"
+                      value={address[field.name]}
+                      autoComplete={field.autoComplete}
+                      placeholder={field.placeholder}
+                      maxLength={field.maxLength}
+                      aria-invalid={error ? 'true' : 'false'}
+                      aria-describedby={error ? errorId : undefined}
+                      onChange={(event) =>
+                        handleFieldChange(field.name, event.target.value)
+                      }
+                    />
+                    {error && (
+                      <span className="checkout__error" id={errorId} role="alert">
+                        {error}
+                      </span>
+                    )}
+                  </label>
+                );
+              })}
+
+              {formError && (
+                <p className="checkout__error checkout__error--form" role="alert">
+                  {formError}
+                </p>
+              )}
+
+              <button
+                className="checkout__submit"
+                type="submit"
+                disabled={submitting}
+              >
+                {submitting ? 'Preparing payment…' : 'Continue to payment'}
+              </button>
+            </form>
+          )}
+        </section>
+
+        <aside className="checkout__panel checkout__summary" aria-label="Order summary">
+          <h2 className="checkout__section-title">Order summary</h2>
+
+          <ul className="checkout__lines">
+            {cart.map((item) => (
+              <li className="checkout__line" key={item.id ?? item.bookId}>
+                <span className="checkout__line-title">
+                  {item.title}
+                  <span className="checkout__line-qty"> × {item.quantity}</span>
+                </span>
+                <span className="checkout__line-price">
+                  {formatRupees(Number(item.price ?? 0) * Number(item.quantity ?? 0))}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <dl className="checkout__totals">
+            <div className="checkout__total-row">
+              <dt>Subtotal ({bookCount} {bookCount === 1 ? 'book' : 'books'})</dt>
+              <dd>{formatRupees(amount ? amount.subtotal : subtotal)}</dd>
+            </div>
+
+            {/*
+              Tax and shipping are decided by the server, so they only appear
+              once it has told us what they are. Showing a guess next to a
+              real card form is how a customer ends up disputing a charge.
+            */}
+            {amount && (
+              <>
+                <div className="checkout__total-row">
+                  <dt>Tax</dt>
+                  <dd>{formatRupees(amount.tax)}</dd>
+                </div>
+                <div className="checkout__total-row">
+                  <dt>Shipping</dt>
+                  <dd>{formatRupees(amount.shipping)}</dd>
+                </div>
+                <div className="checkout__total-row checkout__total-row--grand">
+                  <dt>Total</dt>
+                  <dd>{formatRupees(amount.total)}</dd>
+                </div>
+              </>
+            )}
+          </dl>
+
+          {!amount && (
+            <p className="checkout__note">
+              Tax and shipping are calculated at the next step.
+            </p>
+          )}
+        </aside>
+      </div>
+    </main>
   );
 }

--- a/bookshelf-frontend/src/pages/Checkout.test.jsx
+++ b/bookshelf-frontend/src/pages/Checkout.test.jsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+/*
+ * Stripe is mocked wholesale. The point of these tests is *what gets sent to
+ * the payment API* — which was the entire bug in #315 — and that question is
+ * answered before Stripe.js is involved at all.
+ */
+vi.mock('@stripe/stripe-js', () => ({
+  loadStripe: vi.fn(() => Promise.resolve({ id: 'stripe' })),
+}));
+
+vi.mock('@stripe/react-stripe-js', () => ({
+  Elements: ({ children }) => <div data-testid="stripe-elements">{children}</div>,
+  PaymentElement: () => <div data-testid="payment-element" />,
+  useStripe: () => null,
+  useElements: () => null,
+}));
+
+const createPaymentIntent = vi.fn();
+
+vi.mock('../services/paymentService.js', () => ({
+  default: {
+    createPaymentIntent: (...args) => createPaymentIntent(...args),
+  },
+}));
+
+const CART = [
+  { id: 'b1', title: 'The Quiet Ones', price: 349, quantity: 2, cover: '#7A2E2E' },
+  { id: 'b3', title: 'Half Moon Bay', price: 399, quantity: 1, cover: '#B85C2C' },
+];
+
+const ADDRESS = {
+  name: 'A. Sharma',
+  address: '221B Baker Street',
+  city: 'Mumbai',
+  postalCode: '400001',
+  country: 'India',
+};
+
+let Checkout;
+let CartProvider;
+
+async function loadCheckout({ publishableKey = 'pk_test_fake' } = {}) {
+  vi.resetModules();
+  vi.stubEnv('VITE_STRIPE_PUBLISHABLE_KEY', publishableKey);
+  // Imported after the env is stubbed: the module reads the key at load time
+  // so that loadStripe is called once rather than once per render. The cart
+  // provider has to come from the same fresh module graph, or the page reads
+  // a different CartContext instance than the test rendered.
+  Checkout = (await import('./Checkout.jsx')).default;
+  CartProvider = (await import('../context/CartContext.jsx')).CartProvider;
+}
+
+function renderCheckout(cart = CART) {
+  window.localStorage.setItem('cart', JSON.stringify(cart));
+
+  return render(
+    <MemoryRouter initialEntries={['/checkout']}>
+      <CartProvider>
+        <Checkout />
+      </CartProvider>
+    </MemoryRouter>
+  );
+}
+
+async function fillAddress(user, overrides = {}) {
+  const values = { ...ADDRESS, ...overrides };
+
+  for (const [label, value] of [
+    ['Full name', values.name],
+    ['Street address', values.address],
+    ['City', values.city],
+    ['Postal code', values.postalCode],
+    ['Country', values.country],
+  ]) {
+    const input = screen.getByLabelText(label);
+    await user.clear(input);
+    if (value) {
+      await user.type(input, value);
+    }
+  }
+}
+
+describe('Checkout', () => {
+  beforeEach(async () => {
+    window.localStorage.clear();
+    createPaymentIntent.mockReset();
+    await loadCheckout();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('does not contact the payment API on mount', async () => {
+    renderCheckout();
+
+    // The old page fired the request from a mount effect, so an order was
+    // created before the customer had typed anything.
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /shipping address/i })).toBeInTheDocument()
+    );
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it('shows an empty-cart state instead of checking out with nothing', async () => {
+    renderCheckout([]);
+
+    expect(screen.getByRole('heading', { name: /your cart is empty/i })).toBeInTheDocument();
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it('refuses to submit an incomplete address and names each missing field', async () => {
+    const user = userEvent.setup();
+    renderCheckout();
+
+    await user.click(screen.getByRole('button', { name: /continue to payment/i }));
+
+    const alerts = await screen.findAllByRole('alert');
+    expect(alerts).toHaveLength(5);
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it('sends the real cart contents, not a hardcoded sample book', async () => {
+    const user = userEvent.setup();
+    createPaymentIntent.mockResolvedValue({
+      clientSecret: 'pi_secret_123',
+      orderId: 'order-1',
+      amount: { subtotal: 1097, tax: 54.85, shipping: 5.99, total: 1157.84 },
+    });
+
+    renderCheckout();
+    await fillAddress(user);
+    await user.click(screen.getByRole('button', { name: /continue to payment/i }));
+
+    await waitFor(() => expect(createPaymentIntent).toHaveBeenCalledTimes(1));
+
+    const payload = createPaymentIntent.mock.calls[0][0];
+
+    expect(payload.items).toEqual([
+      { bookId: 'b1', quantity: 2 },
+      { bookId: 'b3', quantity: 1 },
+    ]);
+    expect(JSON.stringify(payload)).not.toMatch(/Sample Book|book-1|Jane Doe/);
+  });
+
+  it('sends the address the customer typed', async () => {
+    const user = userEvent.setup();
+    createPaymentIntent.mockResolvedValue({ clientSecret: 'pi_secret_123' });
+
+    renderCheckout();
+    await fillAddress(user, { city: '  Pune  ' });
+    await user.click(screen.getByRole('button', { name: /continue to payment/i }));
+
+    await waitFor(() => expect(createPaymentIntent).toHaveBeenCalled());
+
+    expect(createPaymentIntent.mock.calls[0][0].shippingAddress).toEqual({
+      ...ADDRESS,
+      city: 'Pune',
+    });
+  });
+
+  it('mounts the payment step once the API returns a client secret', async () => {
+    const user = userEvent.setup();
+    createPaymentIntent.mockResolvedValue({
+      clientSecret: 'pi_secret_123',
+      orderId: 'order-1',
+      amount: { subtotal: 1097, tax: 54.85, shipping: 5.99, total: 1157.84 },
+    });
+
+    renderCheckout();
+    await fillAddress(user);
+    await user.click(screen.getByRole('button', { name: /continue to payment/i }));
+
+    expect(await screen.findByTestId('payment-element')).toBeInTheDocument();
+    // Server-calculated amounts, shown only once the server has calculated them.
+    expect(screen.getByText('₹1,157.84')).toBeInTheDocument();
+  });
+
+  it('surfaces a rejected cart instead of hanging on a spinner forever', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    createPaymentIntent.mockRejectedValue({
+      status: 400,
+      original: {
+        response: {
+          data: {
+            message: 'Invalid checkout request',
+            errors: [{ field: 'items[0].bookId', message: 'Book not found: book-1' }],
+          },
+        },
+      },
+    });
+
+    renderCheckout();
+    await fillAddress(user);
+    await user.click(screen.getByRole('button', { name: /continue to payment/i }));
+
+    expect(await screen.findByText(/no longer available/i)).toBeInTheDocument();
+    // Still on the address step, with the button usable again.
+    expect(
+      screen.getByRole('button', { name: /continue to payment/i })
+    ).toBeEnabled();
+  });
+
+  it('says so when no publishable key was built in, rather than using a fake one', async () => {
+    await loadCheckout({ publishableKey: '' });
+    renderCheckout();
+
+    expect(
+      screen.getByRole('heading', { name: /checkout unavailable/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/bookshelf-frontend/src/pages/OrderConfirmation.jsx
+++ b/bookshelf-frontend/src/pages/OrderConfirmation.jsx
@@ -1,11 +1,22 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useStripe, Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import { useSearchParams, Link } from 'react-router-dom';
 
+import { useCart } from '../hooks/useCart.js';
+import './Checkout.css';
+
+const STATUS_MESSAGES = {
+  succeeded: 'Payment succeeded. Thank you for your order.',
+  processing: 'Your payment is processing. We will email you when it settles.',
+  requires_payment_method:
+    'Your payment was not successful. Please try again with another method.',
+};
+
 const OrderConfirmationContent = () => {
   const stripe = useStripe();
   const [searchParams] = useSearchParams();
+  const { clearCart } = useCart();
   const [message, setMessage] = useState(null);
 
   const clientSecret = searchParams.get('payment_intent_client_secret');
@@ -16,40 +27,89 @@ const OrderConfirmationContent = () => {
       return;
     }
 
-    stripe.retrievePaymentIntent(clientSecret).then(({ paymentIntent }) => {
-      switch (paymentIntent.status) {
-        case 'succeeded':
-          setMessage('Payment succeeded! Thank you for your order.');
-          break;
-        case 'processing':
-          setMessage('Your payment is processing.');
-          break;
-        case 'requires_payment_method':
-          setMessage('Your payment was not successful, please try again.');
-          break;
-        default:
-          setMessage('Something went wrong.');
-          break;
-      }
-    });
-  }, [stripe, clientSecret]);
+    let cancelled = false;
+
+    stripe
+      .retrievePaymentIntent(clientSecret)
+      .then(({ paymentIntent, error }) => {
+        if (cancelled) {
+          return;
+        }
+
+        // retrievePaymentIntent resolves with an `error` and no intent when
+        // the secret is stale or malformed. Reading `paymentIntent.status`
+        // straight through threw a TypeError on that path.
+        if (error || !paymentIntent) {
+          setMessage(
+            'We could not confirm this payment. Check your orders, or contact us before paying again.'
+          );
+          return;
+        }
+
+        setMessage(STATUS_MESSAGES[paymentIntent.status] ?? 'Something went wrong.');
+
+        // Customers whose payment method redirected away never passed
+        // through the in-page success branch, so their cart was still full
+        // when they landed back here. See #315.
+        if (
+          paymentIntent.status === 'succeeded' ||
+          paymentIntent.status === 'processing'
+        ) {
+          clearCart();
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setMessage('We could not reach the payment provider to confirm this order.');
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [stripe, clientSecret, clearCart]);
 
   return (
-    <div style={{ maxWidth: '600px', margin: '4rem auto', padding: '2rem', background: '#fff', borderRadius: '12px', textAlign: 'center', boxShadow: '0 4px 6px rgba(0,0,0,0.1)' }}>
-      <h2 style={{ color: '#221e19', marginBottom: '1rem' }}>Order Confirmation</h2>
-      {orderId && <p style={{ fontSize: '1.1rem', color: '#666', marginBottom: '1rem' }}>Order ID: <strong>{orderId}</strong></p>}
-      <p style={{ fontSize: '1.2rem', marginBottom: '2rem', fontWeight: 'bold' }}>{message || 'Checking payment status...'}</p>
-      
-      <Link to="/" style={{ display: 'inline-block', padding: '10px 20px', background: 'var(--leather)', color: '#fff', textDecoration: 'none', borderRadius: '8px', fontWeight: 'bold' }}>
-        Return to Home
-      </Link>
-    </div>
+    <main className="checkout">
+      <div className="checkout__panel checkout__panel--message">
+        <h1 className="checkout__title">Order confirmation</h1>
+
+        {orderId && (
+          <p>
+            Order ID: <strong>{orderId}</strong>
+          </p>
+        )}
+
+        <p role="status">
+          {message ?? (clientSecret ? 'Checking payment status…' : 'No payment to confirm.')}
+        </p>
+
+        <Link className="checkout__link-btn" to="/">
+          Return to the shop
+        </Link>
+      </div>
+    </main>
   );
 };
 
-const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY || 'pk_test_mock_stripe_key_123');
+const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY;
+const stripePromise = publishableKey ? loadStripe(publishableKey) : null;
 
 export default function OrderConfirmation() {
+  if (!stripePromise) {
+    return (
+      <main className="checkout">
+        <div className="checkout__panel checkout__panel--message">
+          <h1 className="checkout__title">Order confirmation</h1>
+          <p>Payments are not configured for this deployment.</p>
+          <Link className="checkout__link-btn" to="/">
+            Return to the shop
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
   return (
     <Elements stripe={stripePromise}>
       <OrderConfirmationContent />

--- a/bookshelf-frontend/src/utils/checkoutValidation.js
+++ b/bookshelf-frontend/src/utils/checkoutValidation.js
@@ -1,0 +1,285 @@
+/**
+ * Checkout input handling: what the customer typed, and what the cart holds.
+ *
+ * Kept out of the page component on purpose. The page cannot be exercised
+ * without Stripe.js and a live payment intent; these rules can, and they are
+ * the part that decides what gets charged and where it gets shipped.
+ *
+ * The bug this exists to close: `Checkout.jsx` did not read the cart at all.
+ * It posted a literal
+ *
+ *     items: [{ id: 'book-1', title: 'Sample Book', price: 19.99, quantity: 1 }]
+ *
+ * along with a hardcoded "Jane Doe, 123 Main St" address, for every customer,
+ * on every checkout. `book-1` is not a catalogue id — the catalogue uses
+ * `b1`…`b8` — so since #297 the backend has rejected it outright and the page
+ * has hung on "Loading checkout..." with the failure only in the console.
+ * See #315.
+ */
+
+/**
+ * Fields the API's `shippingAddress` accepts, in the order they should be
+ * presented. The backend's Order schema names them `name`, `address`, `city`,
+ * `postalCode`, `country`; the form uses the same names so nothing has to be
+ * translated on the way out.
+ */
+export const ADDRESS_FIELDS = [
+  {
+    name: 'name',
+    label: 'Full name',
+    autoComplete: 'name',
+    placeholder: 'A. Sharma',
+    maxLength: 100,
+  },
+  {
+    name: 'address',
+    label: 'Street address',
+    autoComplete: 'street-address',
+    placeholder: '221B Baker Street',
+    maxLength: 200,
+  },
+  {
+    name: 'city',
+    label: 'City',
+    autoComplete: 'address-level2',
+    placeholder: 'Mumbai',
+    maxLength: 100,
+  },
+  {
+    name: 'postalCode',
+    label: 'Postal code',
+    autoComplete: 'postal-code',
+    placeholder: '400001',
+    maxLength: 16,
+  },
+  {
+    name: 'country',
+    label: 'Country',
+    autoComplete: 'country-name',
+    placeholder: 'India',
+    maxLength: 60,
+  },
+];
+
+export const EMPTY_ADDRESS = ADDRESS_FIELDS.reduce(
+  (blank, field) => ({ ...blank, [field.name]: '' }),
+  {}
+);
+
+/**
+ * Deliberately loose. Postal codes differ by country far more than any single
+ * regex can express, and a checkout that refuses a valid address is a worse
+ * failure than one that accepts a typo — the courier can read "400 001".
+ * These rules only catch the empty and the obviously-not-an-address.
+ */
+const MIN_LENGTHS = {
+  name: 2,
+  address: 5,
+  city: 2,
+  postalCode: 3,
+  country: 2,
+};
+
+const POSTAL_CODE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9\s-]{1,14}$/;
+
+function collapseWhitespace(value) {
+  return String(value ?? '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Trim every field and collapse runs of whitespace.
+ *
+ * Returned separately from validation so the caller can write the normalised
+ * values back into the form. A customer who pasted a trailing space should
+ * see it disappear, not be told their address is wrong.
+ */
+export function normaliseAddress(address = {}) {
+  const normalised = {};
+
+  for (const field of ADDRESS_FIELDS) {
+    normalised[field.name] = collapseWhitespace(address[field.name]);
+  }
+
+  return normalised;
+}
+
+/**
+ * Validate a normalised address.
+ *
+ * Returns `{ field: message }` — an object rather than an array, because the
+ * form renders each message next to its own input and looking them up by
+ * name is what it actually needs.
+ */
+export function validateAddress(address = {}) {
+  const errors = {};
+  const normalised = normaliseAddress(address);
+
+  for (const { name, label, maxLength } of ADDRESS_FIELDS) {
+    const value = normalised[name];
+
+    if (value === '') {
+      errors[name] = `${label} is required.`;
+      continue;
+    }
+
+    if (value.length < MIN_LENGTHS[name]) {
+      errors[name] = `${label} looks too short.`;
+      continue;
+    }
+
+    if (value.length > maxLength) {
+      errors[name] = `${label} must be ${maxLength} characters or fewer.`;
+    }
+  }
+
+  if (!errors.postalCode && !POSTAL_CODE_PATTERN.test(normalised.postalCode)) {
+    errors.postalCode =
+      'Postal code may only contain letters, numbers, spaces and hyphens.';
+  }
+
+  return errors;
+}
+
+export function isAddressValid(address) {
+  return Object.keys(validateAddress(address)).length === 0;
+}
+
+/**
+ * Turn the cart into the `items` array the API expects.
+ *
+ * Only the id and the quantity are sent. The price is deliberately *not* —
+ * `prepareCheckout()` prices every line from `books.json` itself, so a client
+ * that sent a price would either be ignored or, worse, believed. Sending it
+ * invites the second.
+ *
+ * Lines that cannot produce a usable id or a positive integer quantity are
+ * dropped here rather than posted for the server to reject one at a time.
+ * A cart entry with no id got there through a bug on this side; the customer
+ * should not be shown a 400 about it.
+ */
+export function toOrderItems(cart = []) {
+  if (!Array.isArray(cart)) {
+    return [];
+  }
+
+  const merged = new Map();
+
+  for (const item of cart) {
+    if (item === null || typeof item !== 'object') {
+      continue;
+    }
+
+    const rawId = item.bookId ?? item.id;
+
+    if (typeof rawId !== 'string' || rawId.trim() === '') {
+      continue;
+    }
+
+    const quantity = Number(item.quantity);
+
+    if (!Number.isInteger(quantity) || quantity < 1) {
+      continue;
+    }
+
+    const bookId = rawId.trim();
+    // The cart keys on book id so duplicates should be impossible, but a
+    // hand-edited `cart` in localStorage can hold two lines for one book and
+    // the API rejects the whole request if it sees them separately.
+    merged.set(bookId, (merged.get(bookId) ?? 0) + quantity);
+  }
+
+  return [...merged.entries()].map(([bookId, quantity]) => ({
+    bookId,
+    quantity,
+  }));
+}
+
+/** Number of books, not number of lines. */
+export function countItems(cart = []) {
+  if (!Array.isArray(cart)) {
+    return 0;
+  }
+
+  return cart.reduce((total, item) => {
+    const quantity = Number(item?.quantity);
+    return Number.isFinite(quantity) && quantity > 0 ? total + quantity : total;
+  }, 0);
+}
+
+/**
+ * The cart subtotal, for the order summary only.
+ *
+ * The authoritative total comes back from the API in `amount`. This is what
+ * the customer is looking at while they type their address, before any
+ * request has been made.
+ */
+export function cartSubtotal(cart = []) {
+  if (!Array.isArray(cart)) {
+    return 0;
+  }
+
+  return cart.reduce((total, item) => {
+    const price = Number(item?.price);
+    const quantity = Number(item?.quantity);
+
+    if (!Number.isFinite(price) || !Number.isFinite(quantity)) {
+      return total;
+    }
+
+    return total + price * quantity;
+  }, 0);
+}
+
+/**
+ * Pull something a human can act on out of a failed create-intent call.
+ *
+ * The API answers a bad cart with `{ message, errors: [{ field, message }] }`
+ * (see `CheckoutValidationError`), a bad reservation with a plain
+ * `{ message }` and a 409, and `utils/api.js` normalises transport failures
+ * into `{ status, message, code }`. All three land here.
+ */
+export function describeCheckoutError(error) {
+  if (!error) {
+    return 'Checkout could not be started. Please try again.';
+  }
+
+  const details = error.original?.response?.data ?? error.response?.data;
+  const fieldErrors = details?.errors;
+
+  if (Array.isArray(fieldErrors) && fieldErrors.length > 0) {
+    const first = fieldErrors[0];
+
+    if (/Book not found/i.test(first?.message ?? '')) {
+      return 'One of the books in your cart is no longer available. Remove it and try again.';
+    }
+
+    return first?.message ?? 'Your cart could not be processed.';
+  }
+
+  if (error.status === 409) {
+    return (
+      details?.message ??
+      'Some of these books were bought while you were checking out. Please review your cart.'
+    );
+  }
+
+  if (error.code === 'NETWORK_ERROR') {
+    return 'We could not reach the shop. Check your connection and try again.';
+  }
+
+  return details?.message ?? error.message ?? 'Checkout could not be started.';
+}
+
+export default {
+  ADDRESS_FIELDS,
+  EMPTY_ADDRESS,
+  normaliseAddress,
+  validateAddress,
+  isAddressValid,
+  toOrderItems,
+  countItems,
+  cartSubtotal,
+  describeCheckoutError,
+};

--- a/bookshelf-frontend/src/utils/checkoutValidation.test.js
+++ b/bookshelf-frontend/src/utils/checkoutValidation.test.js
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ADDRESS_FIELDS,
+  EMPTY_ADDRESS,
+  cartSubtotal,
+  countItems,
+  describeCheckoutError,
+  isAddressValid,
+  normaliseAddress,
+  toOrderItems,
+  validateAddress,
+} from './checkoutValidation.js';
+
+const goodAddress = {
+  name: 'A. Sharma',
+  address: '221B Baker Street',
+  city: 'Mumbai',
+  postalCode: '400001',
+  country: 'India',
+};
+
+describe('normaliseAddress', () => {
+  it('trims and collapses whitespace in every field', () => {
+    expect(
+      normaliseAddress({
+        name: '  A.   Sharma ',
+        address: '221B\tBaker  Street',
+        city: ' Mumbai',
+        postalCode: '400 001 ',
+        country: 'India ',
+      })
+    ).toEqual({
+      name: 'A. Sharma',
+      address: '221B Baker Street',
+      city: 'Mumbai',
+      postalCode: '400 001',
+      country: 'India',
+    });
+  });
+
+  it('turns missing fields into empty strings rather than undefined', () => {
+    expect(normaliseAddress({})).toEqual(EMPTY_ADDRESS);
+    expect(normaliseAddress()).toEqual(EMPTY_ADDRESS);
+  });
+
+  it('covers every declared field', () => {
+    const normalised = normaliseAddress(goodAddress);
+    for (const field of ADDRESS_FIELDS) {
+      expect(normalised).toHaveProperty(field.name);
+    }
+  });
+});
+
+describe('validateAddress', () => {
+  it('accepts a complete address', () => {
+    expect(validateAddress(goodAddress)).toEqual({});
+    expect(isAddressValid(goodAddress)).toBe(true);
+  });
+
+  it('reports every missing field at once, not one at a time', () => {
+    const errors = validateAddress(EMPTY_ADDRESS);
+    expect(Object.keys(errors).sort()).toEqual(
+      ADDRESS_FIELDS.map((field) => field.name).sort()
+    );
+  });
+
+  it('treats whitespace-only input as missing', () => {
+    expect(validateAddress({ ...goodAddress, city: '   ' })).toHaveProperty('city');
+  });
+
+  it('rejects a field that is far too short to be real', () => {
+    expect(validateAddress({ ...goodAddress, address: '1' })).toHaveProperty(
+      'address'
+    );
+  });
+
+  it('rejects a field longer than the API will store', () => {
+    const errors = validateAddress({ ...goodAddress, name: 'x'.repeat(101) });
+    expect(errors.name).toMatch(/100 characters or fewer/);
+  });
+
+  it('accepts postal codes with spaces and hyphens, as used outside India', () => {
+    for (const postalCode of ['400 001', 'SW1A 1AA', '12345-6789', 'K1A0B1']) {
+      expect(validateAddress({ ...goodAddress, postalCode })).toEqual({});
+    }
+  });
+
+  it('rejects a postal code containing punctuation', () => {
+    expect(validateAddress({ ...goodAddress, postalCode: '400/001' })).toHaveProperty(
+      'postalCode'
+    );
+  });
+});
+
+describe('toOrderItems', () => {
+  it('sends only the id and quantity, never the price', () => {
+    const items = toOrderItems([
+      { id: 'b1', title: 'The Quiet Ones', price: 349, quantity: 2 },
+    ]);
+
+    expect(items).toEqual([{ bookId: 'b1', quantity: 2 }]);
+    expect(items[0]).not.toHaveProperty('price');
+    expect(items[0]).not.toHaveProperty('title');
+  });
+
+  it('accepts either `id` or `bookId` on the cart line', () => {
+    expect(toOrderItems([{ bookId: 'b2', quantity: 1 }])).toEqual([
+      { bookId: 'b2', quantity: 1 },
+    ]);
+  });
+
+  it('merges two lines for the same book, which the API would reject apart', () => {
+    expect(
+      toOrderItems([
+        { id: 'b1', quantity: 2 },
+        { id: 'b1', quantity: 3 },
+      ])
+    ).toEqual([{ bookId: 'b1', quantity: 5 }]);
+  });
+
+  it('drops lines that could never be priced', () => {
+    expect(
+      toOrderItems([
+        { id: 'b1', quantity: 1 },
+        { id: '', quantity: 1 },
+        { id: '   ', quantity: 1 },
+        { quantity: 1 },
+        { id: 'b3', quantity: 0 },
+        { id: 'b4', quantity: -2 },
+        { id: 'b5', quantity: 1.5 },
+        { id: 'b6' },
+        null,
+        'nonsense',
+      ])
+    ).toEqual([{ bookId: 'b1', quantity: 1 }]);
+  });
+
+  it('survives a cart that is not an array', () => {
+    expect(toOrderItems(null)).toEqual([]);
+    expect(toOrderItems({ id: 'b1' })).toEqual([]);
+    expect(toOrderItems()).toEqual([]);
+  });
+});
+
+describe('countItems', () => {
+  it('counts books, not cart lines — the bug the navbar badge also has', () => {
+    expect(countItems([{ id: 'b1', quantity: 5 }])).toBe(5);
+    expect(
+      countItems([
+        { id: 'b1', quantity: 2 },
+        { id: 'b2', quantity: 3 },
+      ])
+    ).toBe(5);
+  });
+
+  it('ignores lines with an unusable quantity', () => {
+    expect(
+      countItems([{ id: 'b1', quantity: 'two' }, { id: 'b2', quantity: 1 }])
+    ).toBe(1);
+  });
+});
+
+describe('cartSubtotal', () => {
+  it('multiplies price by quantity across the cart', () => {
+    expect(
+      cartSubtotal([
+        { price: 349, quantity: 2 },
+        { price: 299, quantity: 1 },
+      ])
+    ).toBe(997);
+  });
+
+  it('skips lines that would poison the total with NaN', () => {
+    expect(cartSubtotal([{ price: 'free', quantity: 1 }, { price: 100, quantity: 2 }])).toBe(
+      200
+    );
+  });
+});
+
+describe('describeCheckoutError', () => {
+  it('turns an unknown book id into something a customer can act on', () => {
+    const message = describeCheckoutError({
+      status: 400,
+      original: {
+        response: {
+          data: {
+            message: 'Invalid checkout request',
+            errors: [
+              { field: 'items[0].bookId', message: 'Book not found: book-1' },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(message).toMatch(/no longer available/i);
+  });
+
+  it('passes through the first field error for other validation failures', () => {
+    expect(
+      describeCheckoutError({
+        status: 400,
+        response: {
+          data: {
+            errors: [
+              { field: 'items[0].quantity', message: 'items[0].quantity must be at least 1' },
+            ],
+          },
+        },
+      })
+    ).toBe('items[0].quantity must be at least 1');
+  });
+
+  it('explains a stock conflict', () => {
+    expect(describeCheckoutError({ status: 409 })).toMatch(/bought while you were/i);
+  });
+
+  it('explains a network failure in the shape utils/api.js produces', () => {
+    expect(
+      describeCheckoutError({ status: 0, code: 'NETWORK_ERROR', message: 'Network error.' })
+    ).toMatch(/could not reach the shop/i);
+  });
+
+  it('never returns an empty string', () => {
+    expect(describeCheckoutError(null)).toBeTruthy();
+    expect(describeCheckoutError({})).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #315.

## The bug

`pages/Checkout.jsx` never imported `CartContext`. Every checkout, for every customer, posted this:

```js
items: [{ id: 'book-1', title: 'Sample Book', price: 19.99, quantity: 1 }],
shippingAddress: { name: 'Jane Doe', address: '123 Main St', … }
```

`book-1` is not a catalogue id — `books.json` uses `b1`…`b8` — so since #297 landed, `prepareCheckout()` rejects it and the API answers `400 Book not found: book-1`. The page's entire error handling was `console.error(...)`, so `clientSecret` stayed `''` and the customer sat on **"Loading checkout..." forever**. Checkout has been failing 100% of the time.

## What this changes

**The cart is what gets charged.** `toOrderItems()` maps the cart to `[{ bookId, quantity }]`. Only ids and quantities travel — `prepareCheckout()` prices every line from `books.json`, so a client-supplied price could only be ignored or believed, and the second is worse than not sending it.

**Two steps instead of a mount effect.** Address first, payment second. Nothing reaches the API until the address validates, and an empty cart never gets there at all — the old effect created a server-side order on mount regardless of what the customer had done.

**Failures are visible.** `describeCheckoutError()` turns the three shapes the API can return (a `CheckoutValidationError` body, a 409 from the stock reservation, and the normalised transport error from `utils/api.js`) into one sentence a customer can act on, with the button re-enabled for a retry.

**`CheckoutForm` no longer crashes on success.** The old code did:

```js
const { error } = await stripe.confirmPayment({ … });
if (error.type === 'card_error' || …)
```

`confirmPayment` resolves *without* an `error` property when the payment did not fail — so the component a customer saw immediately after paying was the one guaranteed to throw `TypeError: Cannot read properties of undefined (reading 'type')`. It now branches on the result it actually got, catches a rejected promise (Stripe.js rejects on a blocked network, which previously left the button disabled forever), and passes `redirect: 'if_required'` so a card that needs no 3-D Secure step resolves in-page.

**The cart is cleared, once, after the payment is confirmed** — in-page for non-redirecting methods, and on the confirmation page for the ones that redirect away. Not before: clearing early loses the cart of everyone whose card is declined.

**`OrderConfirmation`** read `paymentIntent.status` without checking whether `retrievePaymentIntent` had come back with an `error` and no intent, which is what a stale client secret produces.

**Styles.** The page held its layout in inline `style` objects with `background: '#fff'` and `color: '#221e19'` baked in, which made it the one page the theme from #296 could not reach — it stayed cream-on-white in dark mode. Moved into the existing `Checkout.css` using the existing tokens. The older `.checkout-*` rules in that file are untouched.

## Tests

40 new tests across three files, all of which fail against `main`:

- `utils/checkoutValidation.test.js` — address normalisation and validation, cart→items mapping (duplicate lines merged, unusable lines dropped, price never sent), and every branch of the error description.
- `pages/Checkout.test.jsx` — asserts the payload contains the real cart and that `JSON.stringify(payload)` matches neither `Sample Book`, `book-1` nor `Jane Doe`; that nothing is sent on mount; that a rejected cart shows a message rather than hanging.
- `components/CheckoutForm.test.jsx` — covers the `error.type` crash directly, the decline path, the redirect flag, and the rejected-promise path.

## Verification

```
npm run test    # 149 passed (was 109)
npm run lint    # clean
npm run build   # clean
```

`dist/` is intentionally not rebuilt in this PR — it is checked in, and regenerating it would conflict with every other open branch.

## Not in this PR

The `₹`/`usd` mismatch (prices display as rupees, `createPaymentIntent` is called with `'usd'`) is real but predates this and needs a decision about which currency the shop is actually in. Worth its own issue.
