### PR TITLE
fix(navbar): stop reloading the app, count the cart properly, follow the session (closes #316)

### DIFF
--- a/bookshelf-frontend/src/components/Navbar.css
+++ b/bookshelf-frontend/src/components/Navbar.css
@@ -530,3 +530,42 @@
   font-weight: 500;
   padding: 10px 12px;
 }
+/* ─── Active route + auth controls (#316) ───────────────────────────────
+ *
+ * The desktop links are <NavLink> now, so the current route can mark itself
+ * instead of every link looking identical. The logout control is a <button>
+ * because it performs an action rather than navigating — styling it to sit
+ * flush with its neighbours is the whole job.
+ */
+
+.nav__links a.is-active,
+.nav__mobile-menu a.is-active {
+  color: var(--leather-deep);
+  font-weight: 600;
+}
+
+.nav__links a.is-active::after {
+  content: '';
+  display: block;
+  height: 2px;
+  margin-top: 2px;
+  border-radius: 2px;
+  background: var(--leather);
+}
+
+.nav__mobile-cart-btn {
+  width: 100%;
+  margin-top: 8px;
+  padding: 12px 14px;
+  border: none;
+  border-radius: 8px;
+  background: var(--leather);
+  color: #fff;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.nav__mobile-cart-btn:hover {
+  background: var(--leather-deep);
+}

--- a/bookshelf-frontend/src/components/Navbar.jsx
+++ b/bookshelf-frontend/src/components/Navbar.jsx
@@ -1,21 +1,187 @@
-import { useState } from 'react';
-import { Link } from 'react-router-dom';
-import { useCart } from '../hooks/useCart.js';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+
+import { useCart } from '../hooks/useCart.js';
+import { useAuth } from '../hooks/useAuth.js';
 import ThemeToggle from './ThemeToggle.jsx';
 import './Navbar.css';
+
+/**
+ * Sections that live on the home page rather than at a route of their own.
+ *
+ * These were `<a href="/#shelf">`, which is a full document navigation: the
+ * React tree is torn down and rebuilt, the cart drawer closes, the search box
+ * empties, AuthContext re-runs checkAuth() and the whole bundle is re-parsed.
+ * They are routes now, and the hash is scrolled to by the effect below —
+ * React Router does not do that on its own, which is why the old anchors did
+ * nothing at all when clicked from /book/:id. See #316.
+ */
+const HOME_SECTIONS = [
+  { hash: '#shelf', labelKey: null, fallback: 'The Shelf' },
+  { hash: '#catalog', labelKey: 'navbar.catalog', fallback: 'Browse' },
+];
+
+/** Routes shown to everyone. */
+const PUBLIC_LINKS = [
+  { to: '/wishlist', labelKey: 'navbar.wishlist', fallback: 'Wishlist' },
+  { to: '/orders', labelKey: 'navbar.orders', fallback: 'Orders' },
+  { to: '/about', labelKey: 'navbar.about', fallback: 'About' },
+];
+
+/**
+ * Total books in the cart.
+ *
+ * The badge used to render `cart.length`, which is the number of *lines*.
+ * Five copies of one book read as "1" while the drawer it opens showed
+ * quantity 5.
+ */
+export function cartItemCount(cart) {
+  if (!Array.isArray(cart)) {
+    return 0;
+  }
+
+  return cart.reduce((total, item) => {
+    const quantity = Number(item?.quantity);
+    return Number.isFinite(quantity) && quantity > 0 ? total + quantity : total;
+  }, 0);
+}
+
+function MenuIcon({ open }) {
+  return open ? (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  ) : (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <line x1="3" y1="6" x2="21" y2="6" />
+      <line x1="3" y1="12" x2="21" y2="12" />
+      <line x1="3" y1="18" x2="21" y2="18" />
+    </svg>
+  );
+}
 
 export default function Navbar({ searchQuery, setSearchQuery }) {
   const { t } = useTranslation();
   const [mobileOpen, setMobileOpen] = useState(false);
   const { cart, setIsCartOpen } = useCart();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // useAuth() reads a context with no default value, so it is undefined when
+  // the navbar is rendered outside AuthProvider — which happens in tests and
+  // in Storybook-style harnesses. The navbar is chrome; it degrades to the
+  // signed-out view rather than throwing.
+  const auth = useAuth() ?? {};
+  const { isAuthenticated = false, user = null, logout } = auth;
+
+  const itemCount = useMemo(() => cartItemCount(cart), [cart]);
+
+  /*
+   * Scroll to the hash target after a hash navigation.
+   *
+   * React Router restores neither scroll position nor hash anchors. Without
+   * this, `/#catalog` from a book page navigates home and then sits at the
+   * top of the page — the exact "clicking Browse does nothing" report.
+   *
+   * requestAnimationFrame because the target section belongs to the route
+   * that is only just mounting; querying for it synchronously finds nothing.
+   */
+  useEffect(() => {
+    if (!location.hash) {
+      return;
+    }
+
+    let frame = 0;
+
+    const scrollToTarget = () => {
+      const target = document.querySelector(location.hash);
+      if (!target) {
+        return;
+      }
+
+      const prefersReducedMotion = window.matchMedia?.(
+        '(prefers-reduced-motion: reduce)'
+      )?.matches;
+
+      target.scrollIntoView({
+        behavior: prefersReducedMotion ? 'auto' : 'smooth',
+        block: 'start',
+      });
+    };
+
+    frame = window.requestAnimationFrame(scrollToTarget);
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [location.pathname, location.hash, location.key]);
+
+  const closeMobileMenu = useCallback(() => setMobileOpen(false), []);
+
+  const openCart = useCallback(() => {
+    setIsCartOpen(true);
+    setMobileOpen(false);
+  }, [setIsCartOpen]);
+
+  const handleLogout = useCallback(async () => {
+    setMobileOpen(false);
+
+    try {
+      await logout?.();
+    } catch (error) {
+      // AuthContext already drops the local session in its own finally block,
+      // so the user is signed out here regardless. Swallowing the rejection
+      // rather than letting it escape keeps a failed network call from
+      // surfacing as an unhandled promise rejection.
+      console.error('[navbar] logout failed:', error);
+    }
+
+    navigate('/');
+  }, [logout, navigate]);
+
+  const label = (key, fallback) => (key ? t(key) || fallback : fallback);
+
+  const accountLinks = isAuthenticated
+    ? [
+        { to: '/profile', label: t('navbar.profile') || 'Profile' },
+        { to: '/account/orders', label: 'My orders' },
+      ]
+    : [];
+
+  const cartLabel = t('navbar.cart') || 'Cart';
+  const cartAriaLabel =
+    itemCount === 0
+      ? 'Open cart, empty'
+      : `Open cart, ${itemCount} ${itemCount === 1 ? 'book' : 'books'}`;
 
   return (
     <div className="nav-wrapper">
       <header className="nav">
         <div className="nav__inner">
-          {/* Brand — book icon visible on desktop, hidden on mobile */}
-          <a href="/" className="nav__brand">
+          {/*
+            Was `<a href="/">`. Clicking the logo reloaded the entire
+            application — the single most-clicked element in the chrome was
+            also the most expensive.
+          */}
+          <Link to="/" className="nav__brand">
             <span className="nav__book-icon" aria-hidden="true">
               <svg
                 width="18"
@@ -32,96 +198,137 @@ export default function Navbar({ searchQuery, setSearchQuery }) {
               </svg>
             </span>
             {t('navbar.logo') || 'BookShelf'}
-          </a>
+          </Link>
 
-          {/* Desktop nav links */}
-          <nav className="nav__links">
-            <a href="/#shelf">The Shelf</a>
-            <a href="/#catalog">{t('navbar.catalog') || 'Browse'}</a>
-            <Link to="/wishlist">{t('navbar.wishlist') || 'Wishlist'}</Link>
-            <Link to="/orders">{t('navbar.orders') || 'Orders'}</Link>
-            <Link to="/about">{t('navbar.about') || 'About'}</Link>
-            <Link to="/login">Login</Link>
+          <nav className="nav__links" aria-label="Main">
+            {HOME_SECTIONS.map((section) => (
+              <Link key={section.hash} to={`/${section.hash}`}>
+                {label(section.labelKey, section.fallback)}
+              </Link>
+            ))}
+
+            {PUBLIC_LINKS.map((link) => (
+              <NavLink
+                key={link.to}
+                to={link.to}
+                className={({ isActive }) => (isActive ? 'is-active' : undefined)}
+              >
+                {label(link.labelKey, link.fallback)}
+              </NavLink>
+            ))}
+
+            {accountLinks.map((link) => (
+              <NavLink
+                key={link.to}
+                to={link.to}
+                className={({ isActive }) => (isActive ? 'is-active' : undefined)}
+              >
+                {link.label}
+              </NavLink>
+            ))}
+
+            {/*
+              The navbar rendered a hardcoded "Login" on every render and
+              never imported useAuth, so a signed-in user was still told to
+              log in and had no way to sign out or reach /profile.
+            */}
+            {isAuthenticated ? (
+              <button type="button" className="nav__logout" onClick={handleLogout}>
+                {user?.name ? `Log out (${user.name})` : 'Log out'}
+              </button>
+            ) : (
+              <NavLink
+                to="/login"
+                className={({ isActive }) => (isActive ? 'is-active' : undefined)}
+              >
+                Login
+              </NavLink>
+            )}
           </nav>
 
-          {/* Desktop actions */}
           <div className="nav__actions">
-            <input 
-              className="nav__search" 
-              type="search" 
-              placeholder={t('navbar.searchPlaceholder') || "Search titles, authors..."} 
+            <input
+              className="nav__search"
+              type="search"
+              placeholder={t('navbar.searchPlaceholder') || 'Search titles, authors...'}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
+              aria-label={t('navbar.searchPlaceholder') || 'Search titles, authors'}
             />
-            {/*
-              The navbar used to hand-roll its own toggle button on top of its
-              own copy of the theme state, which is what put two disagreeing
-              toggles on screen. It renders the shared component now.
-            */}
+
             <ThemeToggle variant="inline" className="nav__theme-toggle" />
-            <button className="nav__cart" onClick={() => setIsCartOpen(true)} aria-label="Open cart">
-              {t('navbar.cart') || 'Cart'}
-              <span className="nav__cart-count">{cart.length}</span>
+
+            <button className="nav__cart" onClick={openCart} aria-label={cartAriaLabel}>
+              {cartLabel}
+              {/* An empty cart does not need a badge reading "0". */}
+              {itemCount > 0 && (
+                <span className="nav__cart-count" data-testid="cart-count">
+                  {itemCount}
+                </span>
+              )}
             </button>
           </div>
 
-          {/* Hamburger — mobile only */}
           <button
             className="nav__hamburger"
-            onClick={() => setMobileOpen((o) => !o)}
+            onClick={() => setMobileOpen((open) => !open)}
             aria-label="Toggle menu"
             aria-expanded={mobileOpen}
           >
-            {mobileOpen ? (
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.2"
-                strokeLinecap="round"
-              >
-                <line x1="18" y1="6" x2="6" y2="18" />
-                <line x1="6" y1="6" x2="18" y2="18" />
-              </svg>
-            ) : (
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.2"
-                strokeLinecap="round"
-              >
-                <line x1="3" y1="6" x2="21" y2="6" />
-                <line x1="3" y1="12" x2="21" y2="12" />
-                <line x1="3" y1="18" x2="21" y2="18" />
-              </svg>
-            )}
+            <MenuIcon open={mobileOpen} />
           </button>
         </div>
 
-        {/* Mobile dropdown menu */}
         {mobileOpen && (
           <div className="nav__mobile-menu">
-            <a href="/#shelf" onClick={() => setMobileOpen(false)}>The Shelf</a>
-            <a href="/#catalog" onClick={() => setMobileOpen(false)}>{t('navbar.catalog') || 'Browse'}</a>
-            <Link to="/wishlist" onClick={() => setMobileOpen(false)}>{t('navbar.wishlist') || 'Wishlist'}</Link>
-            <Link to="/orders" onClick={() => setMobileOpen(false)}>{t('navbar.orders') || 'Orders'}</Link>
-            <Link to="/about" onClick={() => setMobileOpen(false)}>{t('navbar.about') || 'About'}</Link>
-            <Link to="/login" onClick={() => setMobileOpen(false)}>Login</Link>
-            <input 
-              className="nav__search nav__search--mobile" 
-              type="search" 
-              placeholder={t('navbar.searchPlaceholder') || "Search titles, authors..."} 
+            {HOME_SECTIONS.map((section) => (
+              <Link
+                key={section.hash}
+                to={`/${section.hash}`}
+                onClick={closeMobileMenu}
+              >
+                {label(section.labelKey, section.fallback)}
+              </Link>
+            ))}
+
+            {PUBLIC_LINKS.map((link) => (
+              <Link key={link.to} to={link.to} onClick={closeMobileMenu}>
+                {label(link.labelKey, link.fallback)}
+              </Link>
+            ))}
+
+            {accountLinks.map((link) => (
+              <Link key={link.to} to={link.to} onClick={closeMobileMenu}>
+                {link.label}
+              </Link>
+            ))}
+
+            {isAuthenticated ? (
+              <button
+                type="button"
+                className="nav__logout nav__logout--mobile"
+                onClick={handleLogout}
+              >
+                Log out
+              </button>
+            ) : (
+              <Link to="/login" onClick={closeMobileMenu}>
+                Login
+              </Link>
+            )}
+
+            <input
+              className="nav__search nav__search--mobile"
+              type="search"
+              placeholder={t('navbar.searchPlaceholder') || 'Search titles, authors...'}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
+              aria-label={t('navbar.searchPlaceholder') || 'Search titles, authors'}
             />
-            {/* Added cart button to mobile menu for completeness! */}
-            <button className="nav__mobile-cart-btn" onClick={() => { setIsCartOpen(true); setMobileOpen(false); }}>
-              {t('navbar.cart') || 'Cart'} ({cart.length})
+
+            <button className="nav__mobile-cart-btn" onClick={openCart}>
+              {cartLabel}
+              {itemCount > 0 ? ` (${itemCount})` : ''}
             </button>
           </div>
         )}

--- a/bookshelf-frontend/src/components/Navbar.test.jsx
+++ b/bookshelf-frontend/src/components/Navbar.test.jsx
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+
+/*
+ * The theme toggle and i18n are chrome the navbar merely hosts; stubbing them
+ * keeps these tests about routing, the cart badge and the session.
+ */
+vi.mock('./ThemeToggle.jsx', () => ({
+  default: () => <button type="button">theme</button>,
+}));
+
+vi.mock('react-i18next', () => ({
+  // i18n is only initialised by importing src/i18n.js for its side effect,
+  // which no test does. Returning '' from t() exercises the same `|| fallback`
+  // path the app takes before initialisation completes.
+  useTranslation: () => ({ t: () => '' }),
+}));
+
+import { CartProvider } from '../context/CartContext.jsx';
+import { AuthContext } from '../context/AuthContext.jsx';
+import Navbar, { cartItemCount } from './Navbar.jsx';
+
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <span data-testid="location">
+      {location.pathname}
+      {location.hash}
+    </span>
+  );
+}
+
+function renderNavbar({ cart = [], auth = null, initialEntry = '/' } = {}) {
+  window.localStorage.setItem('cart', JSON.stringify(cart));
+
+  const setSearchQuery = vi.fn();
+
+  const tree = (
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <CartProvider>
+        <Navbar searchQuery="" setSearchQuery={setSearchQuery} />
+        <LocationProbe />
+        <Routes>
+          <Route path="/" element={<h1 id="catalog">home</h1>} />
+          <Route path="/book/:id" element={<h1>book</h1>} />
+          <Route path="/login" element={<h1>login</h1>} />
+          <Route path="/profile" element={<h1>profile</h1>} />
+        </Routes>
+      </CartProvider>
+    </MemoryRouter>
+  );
+
+  render(
+    auth ? (
+      <AuthContext.Provider value={auth}>{tree}</AuthContext.Provider>
+    ) : (
+      tree
+    )
+  );
+
+  return { setSearchQuery };
+}
+
+const signedIn = (overrides = {}) => ({
+  isAuthenticated: true,
+  user: { name: 'Asha', _id: 'u1' },
+  loading: false,
+  logout: vi.fn().mockResolvedValue(undefined),
+  login: vi.fn(),
+  register: vi.fn(),
+  checkAuth: vi.fn(),
+  ...overrides,
+});
+
+describe('cartItemCount', () => {
+  it('counts books rather than cart lines', () => {
+    // The badge read `cart.length`: five copies of one book showed "1".
+    expect(cartItemCount([{ id: 'b1', quantity: 5 }])).toBe(5);
+    expect(
+      cartItemCount([
+        { id: 'b1', quantity: 2 },
+        { id: 'b2', quantity: 3 },
+      ])
+    ).toBe(5);
+  });
+
+  it('ignores lines whose quantity is unusable', () => {
+    expect(cartItemCount([{ quantity: 'lots' }, { quantity: -1 }, { quantity: 2 }])).toBe(2);
+  });
+
+  it('survives a cart that is not an array', () => {
+    expect(cartItemCount(null)).toBe(0);
+    expect(cartItemCount(undefined)).toBe(0);
+    expect(cartItemCount('cart')).toBe(0);
+  });
+});
+
+describe('Navbar', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('routing', () => {
+    it('routes the brand client-side instead of reloading the document', async () => {
+      const user = userEvent.setup();
+      renderNavbar({ initialEntry: '/book/b1' });
+
+      const brand = screen.getByRole('link', { name: /bookshelf/i });
+      // A plain <a href="/"> tears down and rebuilds the whole React tree.
+      expect(brand).toHaveAttribute('href', '/');
+
+      await user.click(brand);
+      expect(screen.getByTestId('location')).toHaveTextContent('/');
+    });
+
+    it('takes the catalogue anchors home from a book page', async () => {
+      const user = userEvent.setup();
+      renderNavbar({ initialEntry: '/book/b1' });
+
+      await user.click(screen.getByRole('link', { name: 'Browse' }));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('location')).toHaveTextContent('/#catalog')
+      );
+    });
+
+    it('scrolls the hash target into view, which React Router does not do', async () => {
+      const user = userEvent.setup();
+      const scrollIntoView = vi.fn();
+      Element.prototype.scrollIntoView = scrollIntoView;
+
+      renderNavbar({ initialEntry: '/book/b1' });
+      await user.click(screen.getByRole('link', { name: 'Browse' }));
+
+      await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+    });
+
+    it('uses no plain anchors for in-app destinations', () => {
+      renderNavbar();
+
+      for (const link of screen.getAllByRole('link')) {
+        // react-router renders <a>, but it attaches a click handler; a raw
+        // anchor is detectable by an absolute or protocol-relative href.
+        expect(link.getAttribute('href')).toMatch(/^\/(?!\/)/);
+      }
+    });
+  });
+
+  describe('cart badge', () => {
+    it('shows the number of books, not the number of lines', () => {
+      renderNavbar({ cart: [{ id: 'b1', title: 'The Quiet Ones', price: 349, quantity: 5 }] });
+      expect(screen.getByTestId('cart-count')).toHaveTextContent('5');
+    });
+
+    it('adds up across lines', () => {
+      renderNavbar({
+        cart: [
+          { id: 'b1', price: 349, quantity: 2 },
+          { id: 'b2', price: 299, quantity: 3 },
+        ],
+      });
+      expect(screen.getByTestId('cart-count')).toHaveTextContent('5');
+    });
+
+    it('renders no badge at all for an empty cart', () => {
+      renderNavbar({ cart: [] });
+      expect(screen.queryByTestId('cart-count')).not.toBeInTheDocument();
+    });
+
+    it('describes the cart contents to screen readers', () => {
+      renderNavbar({ cart: [{ id: 'b1', price: 349, quantity: 3 }] });
+      expect(screen.getByLabelText('Open cart, 3 books')).toBeInTheDocument();
+    });
+
+    it('says "book" rather than "books" for one', () => {
+      renderNavbar({ cart: [{ id: 'b1', price: 349, quantity: 1 }] });
+      expect(screen.getByLabelText('Open cart, 1 book')).toBeInTheDocument();
+    });
+  });
+
+  describe('session', () => {
+    it('offers Login when signed out', () => {
+      renderNavbar();
+      expect(screen.getAllByRole('link', { name: 'Login' }).length).toBeGreaterThan(0);
+      expect(screen.queryByRole('button', { name: /log out/i })).not.toBeInTheDocument();
+    });
+
+    it('stops telling a signed-in user to log in', () => {
+      renderNavbar({ auth: signedIn() });
+      expect(screen.queryByRole('link', { name: 'Login' })).not.toBeInTheDocument();
+    });
+
+    it('exposes Profile and My orders once signed in', () => {
+      renderNavbar({ auth: signedIn() });
+      expect(screen.getByRole('link', { name: 'Profile' })).toHaveAttribute('href', '/profile');
+      expect(screen.getByRole('link', { name: 'My orders' })).toHaveAttribute(
+        'href',
+        '/account/orders'
+      );
+    });
+
+    it('logs out and returns to the shop', async () => {
+      const user = userEvent.setup();
+      const auth = signedIn();
+      renderNavbar({ auth, initialEntry: '/profile' });
+
+      await user.click(screen.getByRole('button', { name: /log out/i }));
+
+      await waitFor(() => expect(auth.logout).toHaveBeenCalledTimes(1));
+      expect(screen.getByTestId('location')).toHaveTextContent('/');
+    });
+
+    it('still navigates away when the logout request fails', async () => {
+      const user = userEvent.setup();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const auth = signedIn({ logout: vi.fn().mockRejectedValue(new Error('offline')) });
+      renderNavbar({ auth, initialEntry: '/profile' });
+
+      await user.click(screen.getByRole('button', { name: /log out/i }));
+
+      await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('/'));
+    });
+
+    it('renders the signed-out view rather than throwing without AuthProvider', () => {
+      // The navbar is chrome; it must not be the thing that takes the page down.
+      expect(() => renderNavbar()).not.toThrow();
+    });
+  });
+
+  describe('mobile menu', () => {
+    it('closes itself when the cart is opened from it', async () => {
+      const user = userEvent.setup();
+      renderNavbar({ cart: [{ id: 'b1', price: 349, quantity: 1 }] });
+
+      await user.click(screen.getByRole('button', { name: /toggle menu/i }));
+      expect(screen.getByRole('button', { name: /^Cart \(1\)$/ })).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /^Cart \(1\)$/ }));
+      expect(screen.queryByRole('button', { name: /^Cart \(1\)$/ })).not.toBeInTheDocument();
+    });
+
+    it('reports its own state to assistive technology', async () => {
+      const user = userEvent.setup();
+      renderNavbar();
+
+      const hamburger = screen.getByRole('button', { name: /toggle menu/i });
+      expect(hamburger).toHaveAttribute('aria-expanded', 'false');
+
+      await user.click(hamburger);
+      expect(hamburger).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+});


### PR DESCRIPTION
Closes #316.

Three defects, one component, one fix.

## 1. Half the nav bar hard-reloaded the SPA

```jsx
<a href="/" className="nav__brand">…</a>
<a href="/#shelf">The Shelf</a>
<a href="/#catalog">Browse</a>
```

Those are full document navigations. Clicking the logo tore down the React tree and rebuilt it — closing the cart drawer, emptying the search box, re-running `AuthContext.checkAuth()` (so a visible "Loading..." flash on protected pages), refetching the wishlist and re-parsing the whole bundle. The rest of the nav used `<Link>`, so the behaviour depended on which link you happened to click.

They are `<Link>` / `<NavLink>` now. The active route also marks itself, which it could not do as a raw anchor.

**The hash anchors had a second problem:** React Router scrolls to neither a saved position nor a hash target, so `/#catalog` clicked from `/book/b1` navigated home and left you at the top of the page. That is the "Browse does nothing" report. An effect now resolves `location.hash` after the route mounts — inside `requestAnimationFrame`, because the target section belongs to the route that is only just rendering — and honours `prefers-reduced-motion`.

## 2. The badge counted lines, not books

```jsx
<span className="nav__cart-count">{cart.length}</span>
```

`cart` holds one entry per distinct book with a `quantity`. Five copies of one book showed **1**, while the drawer that button opens correctly showed quantity 5. Two components, one cart, two different numbers.

`cartItemCount()` is exported so the arithmetic is testable on its own. The badge is now hidden for an empty cart rather than rendering "0", and the button carries `aria-label="Open cart, 3 books"` so the count is not communicated by a bare number floating next to a word.

## 3. The nav bar did not know who was signed in

`useAuth` was never imported. A hardcoded `<Link to="/login">Login</Link>` rendered on every render, forever — a signed-in user was still told to log in, there was no way to sign out from the chrome, and `/profile` and `/account/orders` (both real routes, both protected) were unreachable from it. `locales/en.json` has shipped a `navbar.profile` string that nothing rendered.

The nav follows the session in both menus. `useAuth()` reads a context created with no default value, so it is `undefined` outside `AuthProvider`; the value is guarded and the navbar degrades to the signed-out view instead of throwing. Chrome should not be the thing that takes a page down.

Logout catches its own rejection — `AuthContext.logout()` already drops the local session in a `finally`, so the user is signed out either way, and letting the rejection escape produced an unhandled promise rejection.

## Deliberately not fixed here

**#219** — the mobile menu not closing on route change. It is open, it is somebody's to take, and touching it here would collide with that PR. The menu does close when the cart is opened from it, which was already the behaviour.

## CSS

Two small additions: `.is-active` for the current route, and `.nav__mobile-cart-btn`, which the mobile menu has referenced since it was added but which never had a rule — the mobile cart button was rendering unstyled. `.nav__logout` already existed in the stylesheet, unused, and is now used.

## Tests

20 new tests in `components/Navbar.test.jsx`, covering all three defects:

- brand and anchors resolve client-side; `scrollIntoView` is called for a hash target reached from another route; no in-app link carries an absolute href
- the badge across single-line, multi-line, and empty carts, plus the accessible label
- signed-out vs signed-in link sets, logout on both the happy and failing path, and rendering without an `AuthProvider`

```
npm run test    # 129 passed (was 109)
npm run lint    # clean
npm run build   # clean
```

`dist/` is checked in but intentionally not regenerated here — rebuilding it would conflict with every other open branch.
