### PR TITLE
fix(book detail): read the catalogue from the API instead of a stale copy (closes #317)

### DIFF
--- a/bookshelf-frontend/src/components/BookCard.jsx
+++ b/bookshelf-frontend/src/components/BookCard.jsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import WishlistButton from './WishlistButton.jsx';
 import { useWishlist } from '../hooks/useWishlist.js';
 import { useCart } from '../hooks/useCart.js';
+import { formatPrice, formatRating, isInStock } from '../utils/bookFormat.js';
 import './BookCard.css';
 
 /**
@@ -18,6 +19,13 @@ export default function BookCard({ book, onAddToCart }) {
   const { isWishlisted, toggleWishlist } = useWishlist();
   const { addToCart } = useCart();
   const wishlisted = isWishlisted(book.id);
+
+  // `book.rating.toFixed(1)` ran unguarded here. Nothing requires a book to
+  // carry a rating, and one record without it threw a TypeError that took the
+  // whole grid down rather than leaving one line blank. See #317.
+  const ratingLabel = formatRating(book.rating);
+  const priceLabel = formatPrice(book.price);
+  const available = isInStock(book);
 
   const handleAddToCart = () => {
     if (onAddToCart) {
@@ -48,13 +56,19 @@ export default function BookCard({ book, onAddToCart }) {
         <p className="book-card__author">{book.author}</p>
 
         <div className="book-card__meta">
-          <span className="book-card__rating">★ {book.rating.toFixed(1)}</span>
-          <span className="book-card__price">₹{book.price}</span>
+          {ratingLabel && (
+            <span className="book-card__rating">★ {ratingLabel}</span>
+          )}
+          {priceLabel && <span className="book-card__price">{priceLabel}</span>}
         </div>
 
         <div className="book-card__actions">
-          <button className="book-card__add" onClick={handleAddToCart}>
-            Add to cart
+          <button
+            className="book-card__add"
+            onClick={handleAddToCart}
+            disabled={!available}
+          >
+            {available ? 'Add to cart' : 'Out of stock'}
           </button>
         </div>
       </div>

--- a/bookshelf-frontend/src/data/books.js
+++ b/bookshelf-frontend/src/data/books.js
@@ -1,5 +1,18 @@
 // Sample catalog — in the real app this is served by the Node backend
 // from data/books.json. Kept local here for the frontend-only draft.
+//
+// DEPRECATED for anything with an API behind it. `books` below is a snapshot
+// of bookshelf-backend/data/books.json that nothing keeps in sync: it has no
+// `inventory`, its prices go stale the moment the catalogue is edited, and a
+// book added to the backend does not exist here at all. Home (#274) and the
+// book detail page (#317) read the API instead.
+//
+// Still imported by pages/Wishlist.jsx, pages/WishlistPage.jsx and
+// components/RecentlyViewed.jsx, which resolve stored book ids to records.
+// Those should move to the API too; until they do, this file stays.
+//
+// `spines` has no API behind it — it drives the decorative shelf strip in
+// Hero.jsx and is genuinely local data.
 
 export const spines = [
   {

--- a/bookshelf-frontend/src/hooks/useBook.js
+++ b/bookshelf-frontend/src/hooks/useBook.js
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { getBookById, BookNotFoundError } from '../services/bookService.js';
+
+/**
+ * One book, from the API.
+ *
+ * Returns:
+ *   book      the record, or null while loading / on failure
+ *   loading   true while a request is in flight
+ *   notFound  the id is genuinely not in the catalogue (a 404), as distinct
+ *             from "we could not ask" — the page renders different things
+ *             for those two and conflating them is how a network blip starts
+ *             telling customers a book has been withdrawn
+ *   error     a message for anything else
+ *   reload    retry, for the error state's button
+ *
+ * The page this replaces did a synchronous `books.find(...)` against a
+ * hardcoded array and then faked a request with
+ * `setTimeout(() => setLoading(false), 700)` — a fixed delay wrapped around
+ * nothing. See #317.
+ */
+export function useBook(bookId) {
+  const [book, setBook] = useState(null);
+  const [loading, setLoading] = useState(Boolean(bookId));
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Bumped to force a refetch without changing the id.
+  const [attempt, setAttempt] = useState(0);
+
+  // Guards against a slow response for the previous id landing after a fast
+  // one for the current id — navigating between two book pages quickly is
+  // enough to hit it.
+  const requestIdRef = useRef(0);
+
+  const reload = useCallback(() => setAttempt((n) => n + 1), []);
+
+  useEffect(() => {
+    if (!bookId) {
+      setBook(null);
+      setLoading(false);
+      setNotFound(true);
+      setError(null);
+      return undefined;
+    }
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+
+    const controller = new AbortController();
+    let cancelled = false;
+
+    const isStale = () => cancelled || requestIdRef.current !== requestId;
+
+    setLoading(true);
+    setNotFound(false);
+    setError(null);
+
+    getBookById(bookId, { signal: controller.signal })
+      .then((data) => {
+        if (isStale()) return;
+        setBook(data);
+        setLoading(false);
+      })
+      .catch((caught) => {
+        if (isStale()) return;
+
+        if (caught instanceof BookNotFoundError || caught?.status === 404) {
+          setBook(null);
+          setNotFound(true);
+          setLoading(false);
+          return;
+        }
+
+        // An aborted request is not a failure the customer needs told about;
+        // something else is already replacing this state.
+        if (caught?.code === 'ERR_CANCELED' || caught?.name === 'CanceledError') {
+          return;
+        }
+
+        console.error(`[book] could not load ${bookId}:`, caught);
+        setBook(null);
+        setError(
+          caught?.message ?? 'This book could not be loaded. Please try again.'
+        );
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [bookId, attempt]);
+
+  return { book, loading, notFound, error, reload };
+}
+
+export default useBook;

--- a/bookshelf-frontend/src/hooks/useBook.test.jsx
+++ b/bookshelf-frontend/src/hooks/useBook.test.jsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const getBookById = vi.fn();
+
+vi.mock('../services/bookService.js', async () => {
+  const actual = await vi.importActual('../services/bookService.js');
+  return {
+    ...actual,
+    getBookById: (...args) => getBookById(...args),
+  };
+});
+
+import { BookNotFoundError } from '../services/bookService.js';
+import { useBook } from './useBook.js';
+
+function Probe({ bookId }) {
+  const { book, loading, notFound, error, reload } = useBook(bookId);
+
+  return (
+    <div>
+      <span data-testid="state">
+        {loading ? 'loading' : notFound ? 'not-found' : error ? 'error' : 'ready'}
+      </span>
+      <span data-testid="title">{book?.title ?? ''}</span>
+      <span data-testid="error">{error ?? ''}</span>
+      <button onClick={reload}>reload</button>
+    </div>
+  );
+}
+
+const BOOK = { id: 'b1', title: 'The Quiet Ones', price: 349, rating: 4.5, inventory: 8 };
+
+describe('useBook', () => {
+  beforeEach(() => {
+    getBookById.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('loads the book from the API', async () => {
+    getBookById.mockResolvedValue(BOOK);
+
+    render(<Probe bookId="b1" />);
+
+    expect(screen.getByTestId('state')).toHaveTextContent('loading');
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('ready'));
+    expect(screen.getByTestId('title')).toHaveTextContent('The Quiet Ones');
+    expect(getBookById).toHaveBeenCalledWith('b1', expect.objectContaining({ signal: expect.anything() }));
+  });
+
+  it('distinguishes a missing book from a failed request', async () => {
+    getBookById.mockRejectedValue(new BookNotFoundError('b9'));
+
+    render(<Probe bookId="b9" />);
+
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('not-found'));
+  });
+
+  it('does not claim a book is missing when the network failed', async () => {
+    // A blip must not tell a customer the book has been withdrawn.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    getBookById.mockRejectedValue({ status: 0, code: 'NETWORK_ERROR', message: 'Network error.' });
+
+    render(<Probe bookId="b1" />);
+
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('error'));
+    expect(screen.getByTestId('error')).toHaveTextContent('Network error.');
+  });
+
+  it('stays quiet when the request was aborted', async () => {
+    getBookById.mockRejectedValue({ name: 'CanceledError', code: 'ERR_CANCELED' });
+
+    render(<Probe bookId="b1" />);
+
+    // Nothing replaces the state; the component that triggered the abort does.
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('loading'));
+  });
+
+  it('refetches on reload', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    getBookById
+      .mockRejectedValueOnce({ status: 500, message: 'Server error' })
+      .mockResolvedValueOnce(BOOK);
+
+    const user = userEvent.setup();
+    render(<Probe bookId="b1" />);
+
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('error'));
+    await user.click(screen.getByRole('button', { name: 'reload' }));
+
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('ready'));
+    expect(getBookById).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores a slow response for a book the reader has already navigated away from', async () => {
+    let resolveFirst;
+    getBookById
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }))
+      .mockResolvedValueOnce({ ...BOOK, id: 'b2', title: 'Field Notes' });
+
+    const { rerender } = render(<Probe bookId="b1" />);
+    rerender(<Probe bookId="b2" />);
+
+    await waitFor(() => expect(screen.getByTestId('title')).toHaveTextContent('Field Notes'));
+
+    // The stale response lands late and must be dropped.
+    resolveFirst(BOOK);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(screen.getByTestId('title')).toHaveTextContent('Field Notes');
+  });
+
+  it('treats a missing id as not found rather than requesting it', async () => {
+    render(<Probe bookId={undefined} />);
+
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('not-found'));
+    expect(getBookById).not.toHaveBeenCalled();
+  });
+});

--- a/bookshelf-frontend/src/pages/BookDetail.css
+++ b/bookshelf-frontend/src/pages/BookDetail.css
@@ -143,3 +143,51 @@
   to   { opacity: 1; transform: translateY(0); }
 }
  main
+
+/* ─── Stock and load-failure states (#317) ──────────────────────────────
+ *
+ * The page had neither. It read a hardcoded array, so there was no request
+ * that could fail and no `inventory` field to report.
+ */
+
+.book-detail-stock {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(31, 75, 67, 0.12);
+  color: var(--pine);
+}
+
+.book-detail-stock--out {
+  background: rgba(192, 57, 43, 0.12);
+  color: #c0392b;
+}
+
+.book-detail-add-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.book-detail-error-message {
+  color: var(--ink-soft);
+  margin: 12px 0 20px;
+}
+
+.book-detail-retry {
+  display: inline-block;
+  margin-bottom: 16px;
+  padding: 10px 18px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--leather);
+  color: #fff;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.book-detail-retry:hover {
+  background: var(--leather-deep);
+}

--- a/bookshelf-frontend/src/pages/BookDetail.jsx
+++ b/bookshelf-frontend/src/pages/BookDetail.jsx
@@ -1,50 +1,102 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { books } from '../data/books.js';
+import { useTranslation } from 'react-i18next';
+
 import Rating from '../components/Rating.jsx';
 import WishlistButton from '../components/WishlistButton.jsx';
 import SkeletonLoader from '../components/SkeletonLoader.jsx';
+import BookCard from '../components/BookCard.jsx';
+import { useBook } from '../hooks/useBook.js';
 import { useCart } from '../hooks/useCart.js';
 import { useWishlist } from '../hooks/useWishlist.js';
-import { useTranslation } from 'react-i18next';
-import BookCard from '../components/BookCard.jsx';
+import { getBooks } from '../services/bookService.js';
+import {
+  describeStock,
+  formatPrice,
+  formatRating,
+  isInStock,
+} from '../utils/bookFormat.js';
 import './BookDetail.css';
 
+/**
+ * The book detail page.
+ *
+ * It used to read `src/data/books.js` — a hardcoded copy of the backend's
+ * `books.json`, kept in the repo for a frontend-only draft and never removed.
+ * The grid on Home has fetched `/api/books` since #274, so the two views of
+ * the same book disagreed about its price and rating, the detail page had no
+ * idea whether anything was in stock (`inventory` does not exist in the local
+ * copy), and a book added to the catalogue rendered "Book Not Found" on its
+ * own page. See #317.
+ */
 export default function BookDetail() {
   const { t } = useTranslation();
   const { id } = useParams();
-  const [rating, setRating] = useState(0);
-  const [reviewText, setReviewText] = useState('');
-  const [error, setError] = useState('');
-  const [successMsg, setSuccessMsg] = useState('');
-  const [loading, setLoading] = useState(true);
+
+  const { book, loading, notFound, error, reload } = useBook(id);
   const { addToCart } = useCart();
   const { isWishlisted, toggleWishlist } = useWishlist();
 
-  const book = books.find((item) => String(item.id) === String(id));
+  const [rating, setRating] = useState(0);
+  const [reviewText, setReviewText] = useState('');
+  const [reviewError, setReviewError] = useState('');
+  const [successMsg, setSuccessMsg] = useState('');
+  const [related, setRelated] = useState([]);
 
+  // The review form belongs to whichever book is on screen.
   useEffect(() => {
-    const timer = setTimeout(() => setLoading(false), 700);
-    return () => clearTimeout(timer);
+    setRating(0);
+    setReviewText('');
+    setReviewError('');
+    setSuccessMsg('');
   }, [id]);
 
-  const handleReviewSubmit = (e) => {
-    e.preventDefault();
+  /*
+   * Related books come from the same API, filtered by genre. The old page
+   * scanned the local array; now that the catalogue is paged and filtered
+   * server-side, asking the server is both cheaper and correct.
+   *
+   * A failure here is silent on purpose. "You might also like" is a garnish;
+   * it must not turn a working book page into an error page.
+   */
+  useEffect(() => {
+    if (!book?.genre) {
+      setRelated([]);
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    let cancelled = false;
+
+    getBooks({ genre: book.genre, limit: 5 }, { signal: controller.signal })
+      .then((data) => {
+        if (cancelled) return;
+        const others = (data?.books ?? [])
+          .filter((candidate) => String(candidate.id) !== String(book.id))
+          .slice(0, 4);
+        setRelated(others);
+      })
+      .catch(() => {
+        if (!cancelled) setRelated([]);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [book?.id, book?.genre]);
+
+  const handleReviewSubmit = (event) => {
+    event.preventDefault();
+
     if (rating === 0) {
-      setError('Please select a rating before submitting.');
+      setReviewError('Please select a rating before submitting.');
       return;
     }
-    setError('');
 
-    const payload = {
-      bookId: book.id,
-      rating,
-      review: reviewText,
-    };
+    setReviewError('');
 
-    // TODO: Send to POST /api/reviews
-
-    // Reset form
+    // TODO: POST /api/reviews once the endpoint exists.
     setRating(0);
     setReviewText('');
     setSuccessMsg('Thank you! Your review has been submitted.');
@@ -59,23 +111,46 @@ export default function BookDetail() {
     );
   }
 
-  if (!book) {
+  if (notFound) {
     return (
       <div className="book-detail-not-found">
         <h2>{t('bookDetail.notFound') || 'Book Not Found'}</h2>
-        <Link to="/" className="book-detail-back-link">{t('bookDetail.returnToCatalog') || 'Return to Catalog'}</Link>
+        <Link to="/" className="book-detail-back-link">
+          {t('bookDetail.returnToCatalog') || 'Return to Catalog'}
+        </Link>
       </div>
     );
   }
 
-  const relatedBooks = books
-    .filter((b) => b.genre === book.genre && String(b.id) !== String(book.id))
-    .slice(0, 4);
+  // A book that could not be fetched is not a book that does not exist, and
+  // the page must not say it is.
+  if (error || !book) {
+    return (
+      <div className="book-detail-not-found">
+        <h2>We could not load this book</h2>
+        <p className="book-detail-error-message">{error}</p>
+        <button type="button" className="book-detail-retry" onClick={reload}>
+          Try again
+        </button>
+        <Link to="/" className="book-detail-back-link">
+          {t('bookDetail.returnToCatalog') || 'Return to Catalog'}
+        </Link>
+      </div>
+    );
+  }
+
+  const ratingLabel = formatRating(book.rating);
+  const priceLabel = formatPrice(book.price);
+  const stockLabel = describeStock(book);
+  const available = isInStock(book);
 
   return (
     <main className="book-detail-page">
       <div className="book-detail-container">
-        <div className="book-detail-image-wrapper" style={{ '--cover-color': book.cover }}>
+        <div
+          className="book-detail-image-wrapper"
+          style={{ '--cover-color': book.cover }}
+        >
           <div className="book-detail-cover">
             <span className="book-detail-cover-genre">{book.genre}</span>
             <span className="book-detail-cover-title">{book.title}</span>
@@ -84,12 +159,27 @@ export default function BookDetail() {
 
         <div className="book-detail-content">
           <h1 className="book-detail-title">{book.title}</h1>
-          <p className="book-detail-author">{t('bookDetail.by') || 'by'} {book.author}</p>
+          <p className="book-detail-author">
+            {t('bookDetail.by') || 'by'} {book.author}
+          </p>
 
           <div className="book-detail-metadata">
-            <span className="book-detail-badge">{book.genre}</span>
-            <span className="book-detail-rating">★ {book.rating.toFixed(1)}</span>
-            <span className="book-detail-price">₹{book.price}</span>
+            {book.genre && <span className="book-detail-badge">{book.genre}</span>}
+            {/* Rendered only when there is one — `.toFixed` on undefined used
+                to take the page down. */}
+            {ratingLabel && (
+              <span className="book-detail-rating">★ {ratingLabel}</span>
+            )}
+            {priceLabel && <span className="book-detail-price">{priceLabel}</span>}
+            {stockLabel && (
+              <span
+                className={`book-detail-stock ${
+                  available ? '' : 'book-detail-stock--out'
+                }`}
+              >
+                {stockLabel}
+              </span>
+            )}
           </div>
 
           <div className="book-detail-description">
@@ -97,44 +187,76 @@ export default function BookDetail() {
           </div>
 
           <div className="book-detail-extra-info">
-            {book.isbn && <p><strong>{t('bookDetail.isbn') || 'ISBN:'}</strong> {book.isbn}</p>}
-            {book.year && <p><strong>{t('bookDetail.publicationYear') || 'Year:'}</strong> {book.year}</p>}
+            {book.isbn && (
+              <p>
+                <strong>{t('bookDetail.isbn') || 'ISBN:'}</strong> {book.isbn}
+              </p>
+            )}
+            {book.year && (
+              <p>
+                <strong>{t('bookDetail.publicationYear') || 'Year:'}</strong>{' '}
+                {book.year}
+              </p>
+            )}
           </div>
 
           <div className="book-detail-actions">
-            <button className="book-detail-add-btn" onClick={() => addToCart(book)}>
-              {t('bookDetail.addToCart') || 'Add to Cart'}
+            {/*
+              The primary add-to-cart button in the app, on the page that had
+              no idea whether the book existed in the warehouse. A sold-out
+              book could be added here and only failed at the reservation
+              step during checkout.
+            */}
+            <button
+              className="book-detail-add-btn"
+              onClick={() => addToCart(book)}
+              disabled={!available}
+            >
+              {available
+                ? t('bookDetail.addToCart') || 'Add to Cart'
+                : 'Out of stock'}
             </button>
-            <WishlistButton active={isWishlisted(book.id)} onToggle={() => toggleWishlist(book.id)} />
+            <WishlistButton
+              active={isWishlisted(book.id)}
+              onToggle={() => toggleWishlist(book.id)}
+            />
           </div>
         </div>
       </div>
-      
+
       <div className="book-review-section">
-        <h2 className="book-review-title">{t('bookDetail.writeReview') || 'Write a Review'}</h2>
+        <h2 className="book-review-title">
+          {t('bookDetail.writeReview') || 'Write a Review'}
+        </h2>
         <form className="book-review-form" onSubmit={handleReviewSubmit}>
           <div className="book-review-rating">
             <Rating value={rating} onChange={setRating} />
           </div>
-          {error && <p className="book-review-error">{error}</p>}
+          {reviewError && <p className="book-review-error">{reviewError}</p>}
           {successMsg && <p className="book-review-success">{successMsg}</p>}
           <textarea
             className="book-review-textarea"
-            placeholder={t('bookDetail.reviewPlaceholder') || 'Share your thoughts...'}
+            placeholder={
+              t('bookDetail.reviewPlaceholder') || 'Share your thoughts...'
+            }
             value={reviewText}
-            onChange={(e) => setReviewText(e.target.value)}
+            onChange={(event) => setReviewText(event.target.value)}
             rows={4}
             maxLength={1000}
           />
-          <button type="submit" className="book-review-submit-btn">{t('bookDetail.submitReview') || 'Submit'}</button>
+          <button type="submit" className="book-review-submit-btn">
+            {t('bookDetail.submitReview') || 'Submit'}
+          </button>
         </form>
       </div>
 
-      {relatedBooks.length > 0 && (
+      {related.length > 0 && (
         <div className="book-related-section">
-          <h2 className="book-related-title">{t('bookDetail.relatedBooks') || 'Related Books'}</h2>
+          <h2 className="book-related-title">
+            {t('bookDetail.relatedBooks') || 'Related Books'}
+          </h2>
           <div className="book-related-grid">
-            {relatedBooks.map(relatedBook => (
+            {related.map((relatedBook) => (
               <BookCard key={relatedBook.id} book={relatedBook} />
             ))}
           </div>

--- a/bookshelf-frontend/src/pages/BookDetail.test.jsx
+++ b/bookshelf-frontend/src/pages/BookDetail.test.jsx
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+const getBookById = vi.fn();
+const getBooks = vi.fn();
+
+vi.mock('../services/bookService.js', async () => {
+  const actual = await vi.importActual('../services/bookService.js');
+  return {
+    ...actual,
+    getBookById: (...args) => getBookById(...args),
+    getBooks: (...args) => getBooks(...args),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: () => '' }),
+}));
+
+vi.mock('../components/SkeletonLoader.jsx', () => ({
+  default: () => <div data-testid="skeleton" />,
+}));
+
+import { BookNotFoundError } from '../services/bookService.js';
+import { CartProvider } from '../context/CartContext.jsx';
+import { WishlistContext } from '../context/WishlistContext.jsx';
+import BookDetail from './BookDetail.jsx';
+
+const wishlist = {
+  wishlist: [],
+  loading: false,
+  count: 0,
+  isWishlisted: () => false,
+  toggleWishlist: vi.fn(),
+};
+
+const BOOK = {
+  id: 'b1',
+  title: 'The Quiet Ones',
+  author: 'M. Arora',
+  genre: 'Fiction',
+  price: 349,
+  rating: 4.5,
+  cover: '#7A2E2E',
+  inventory: 8,
+};
+
+function renderDetail(bookId = 'b1') {
+  window.localStorage.clear();
+
+  return render(
+    <MemoryRouter initialEntries={[`/book/${bookId}`]}>
+      <WishlistContext.Provider value={wishlist}>
+        <CartProvider>
+          <Routes>
+            <Route path="/book/:id" element={<BookDetail />} />
+            <Route path="/" element={<h1>home</h1>} />
+          </Routes>
+        </CartProvider>
+      </WishlistContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+describe('BookDetail', () => {
+  beforeEach(() => {
+    getBookById.mockReset();
+    getBooks.mockReset();
+    getBooks.mockResolvedValue({ books: [] });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reads the book from the API, not the hardcoded frontend copy', async () => {
+    // A price that differs from src/data/books.js proves which source won.
+    getBookById.mockResolvedValue({ ...BOOK, price: 999 });
+
+    renderDetail('b1');
+
+    expect(await screen.findByRole('heading', { name: 'The Quiet Ones' })).toBeInTheDocument();
+    expect(getBookById).toHaveBeenCalledWith('b1', expect.anything());
+    expect(screen.getByText('₹999')).toBeInTheDocument();
+    expect(screen.queryByText('₹349')).not.toBeInTheDocument();
+  });
+
+  it('shows a real skeleton while the request is in flight, not a 700ms timer', () => {
+    getBookById.mockReturnValue(new Promise(() => {}));
+
+    renderDetail('b1');
+
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+  });
+
+  it('renders a book the local copy has never heard of', async () => {
+    getBookById.mockResolvedValue({
+      ...BOOK,
+      id: 'b9',
+      title: 'A Ninth Book',
+    });
+
+    renderDetail('b9');
+
+    expect(await screen.findByRole('heading', { name: 'A Ninth Book' })).toBeInTheDocument();
+  });
+
+  it('says "not found" only for a genuine 404', async () => {
+    getBookById.mockRejectedValue(new BookNotFoundError('b99'));
+
+    renderDetail('b99');
+
+    expect(await screen.findByRole('heading', { name: /book not found/i })).toBeInTheDocument();
+  });
+
+  it('offers a retry rather than "not found" when the request failed', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    getBookById.mockRejectedValueOnce({ status: 500, message: 'Server error' });
+    getBookById.mockResolvedValueOnce(BOOK);
+
+    const user = userEvent.setup();
+    renderDetail('b1');
+
+    expect(await screen.findByRole('heading', { name: /could not load/i })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /book not found/i })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+
+    expect(await screen.findByRole('heading', { name: 'The Quiet Ones' })).toBeInTheDocument();
+  });
+
+  it('shows stock, which the local copy does not carry at all', async () => {
+    getBookById.mockResolvedValue({ ...BOOK, inventory: 2 });
+
+    renderDetail('b1');
+
+    expect(await screen.findByText('Only 2 left')).toBeInTheDocument();
+  });
+
+  it('refuses to add a sold-out book to the cart', async () => {
+    getBookById.mockResolvedValue({ ...BOOK, inventory: 0 });
+
+    renderDetail('b1');
+
+    const button = await screen.findByRole('button', { name: /out of stock/i });
+    expect(button).toBeDisabled();
+    expect(screen.getByText('Out of stock', { selector: 'span' })).toBeInTheDocument();
+  });
+
+  it('renders a book with no rating instead of throwing on toFixed', async () => {
+    const { rating, ...withoutRating } = BOOK;
+    getBookById.mockResolvedValue(withoutRating);
+
+    renderDetail('b1');
+
+    expect(await screen.findByRole('heading', { name: 'The Quiet Ones' })).toBeInTheDocument();
+    expect(screen.queryByText(/★/)).not.toBeInTheDocument();
+  });
+
+  it('asks the API for related books in the same genre', async () => {
+    getBookById.mockResolvedValue(BOOK);
+    getBooks.mockResolvedValue({
+      books: [BOOK, { ...BOOK, id: 'b7', title: 'Another Fiction' }],
+    });
+
+    renderDetail('b1');
+
+    await waitFor(() =>
+      expect(getBooks).toHaveBeenCalledWith(
+        { genre: 'Fiction', limit: 5 },
+        expect.anything()
+      )
+    );
+
+    // BookCard prints the title on the cover and again in the body, so this
+    // is a findAll rather than a findBy.
+    expect((await screen.findAllByText('Another Fiction')).length).toBeGreaterThan(0);
+
+    // The book being viewed is excluded from its own related list.
+    const relatedGrid = document.querySelector('.book-related-grid');
+    expect(within(relatedGrid).queryByText('The Quiet Ones')).not.toBeInTheDocument();
+  });
+
+  it('still renders the book when related books fail to load', async () => {
+    getBookById.mockResolvedValue(BOOK);
+    getBooks.mockRejectedValue({ status: 500, message: 'nope' });
+
+    renderDetail('b1');
+
+    expect(await screen.findByRole('heading', { name: 'The Quiet Ones' })).toBeInTheDocument();
+  });
+
+  it('requires a star rating before a review can be submitted', async () => {
+    getBookById.mockResolvedValue(BOOK);
+    const user = userEvent.setup();
+
+    renderDetail('b1');
+    await screen.findByRole('heading', { name: 'The Quiet Ones' });
+
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    expect(await screen.findByText(/select a rating/i)).toBeInTheDocument();
+  });
+});

--- a/bookshelf-frontend/src/services/bookService.js
+++ b/bookshelf-frontend/src/services/bookService.js
@@ -1,0 +1,72 @@
+import api from '../utils/api.js';
+
+/**
+ * The catalogue, from the API.
+ *
+ * `src/data/books.js` is a hardcoded copy of `bookshelf-backend/data/books.json`
+ * that says so in its own header comment — "Kept local here for the
+ * frontend-only draft". Home was moved onto the API in #274; the book detail
+ * page was not, so the grid and the page it links to have been reading
+ * different data ever since. Nothing keeps the two files in sync and nothing
+ * would fail if they diverged. See #317.
+ *
+ * Every function here goes through `utils/api.js`, so it inherits the retry
+ * policy (GETs only), the 10s timeout and the normalised error shape
+ * `{ status, message, code }`.
+ */
+
+/** Raised for a book id the catalogue does not have. */
+export class BookNotFoundError extends Error {
+  constructor(bookId) {
+    super(`Book not found: ${bookId}`);
+    this.name = 'BookNotFoundError';
+    this.status = 404;
+    this.bookId = bookId;
+  }
+}
+
+/**
+ * Fetch one book.
+ *
+ * `signal` is passed through to axios so a component that unmounts, or that
+ * asks for a different id, can drop the request it no longer wants.
+ */
+export async function getBookById(bookId, { signal } = {}) {
+  if (typeof bookId !== 'string' || bookId.trim() === '') {
+    throw new BookNotFoundError(String(bookId));
+  }
+
+  try {
+    const response = await api.get(`/books/${encodeURIComponent(bookId.trim())}`, {
+      signal,
+    });
+    return response.data;
+  } catch (error) {
+    // utils/api.js normalises to { status, code, message }; a bare axios
+    // cancellation is not normalised and keeps its own shape.
+    if (error?.status === 404) {
+      throw new BookNotFoundError(bookId);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Fetch a page of the catalogue.
+ *
+ * `params` maps straight onto what `utils/bookQuery.js` parses — `search`,
+ * `genre` (repeatable), `minPrice`, `maxPrice`, `minRating`, `inStock`,
+ * `sort`, `page`, `limit`.
+ */
+export async function getBooks(params = {}, { signal } = {}) {
+  const response = await api.get('/books', { params, signal });
+  return response.data;
+}
+
+/** Distinct genres with counts, from GET /api/books/genres. */
+export async function getGenres({ signal } = {}) {
+  const response = await api.get('/books/genres', { signal });
+  return response.data?.genres ?? [];
+}
+
+export default { getBookById, getBooks, getGenres, BookNotFoundError };

--- a/bookshelf-frontend/src/utils/bookFormat.js
+++ b/bookshelf-frontend/src/utils/bookFormat.js
@@ -1,0 +1,106 @@
+/**
+ * Display helpers for a book record.
+ *
+ * These exist because the pages did this:
+ *
+ *     <span>★ {book.rating.toFixed(1)}</span>
+ *
+ * `rating` is not required by anything — not by the Order schema, not by
+ * `books.json`, not by the query layer, which reads it as `book.rating` and
+ * compares it against a filter. One record without it threw
+ * `TypeError: Cannot read properties of undefined (reading 'toFixed')` and
+ * took down the whole page rather than leaving one line blank. See #317.
+ */
+
+/** Books whose stock is at or below this are worth warning about. */
+export const LOW_STOCK_THRESHOLD = 3;
+
+/**
+ * `null` rather than a fabricated 0.0 when there is no rating — a book nobody
+ * has rated is not a book everybody rated badly. Callers decide what to draw
+ * for `null`.
+ */
+export function formatRating(rating) {
+  // `Number(null)` is 0 and `Number('')` is 0, so neither can be left to the
+  // isFinite check — an unrated book would render as ★ 0.0.
+  if (rating === null || rating === undefined || rating === '') {
+    return null;
+  }
+
+  const value = Number(rating);
+
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  return value.toFixed(1);
+}
+
+/** Rupees, grouped the Indian way, matching the rest of the shop. */
+export function formatPrice(price) {
+  if (price === null || price === undefined || price === '') {
+    return null;
+  }
+
+  const value = Number(price);
+
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  return `₹${value.toLocaleString('en-IN', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+/**
+ * Whether a book can be added to a cart.
+ *
+ * A record with no `inventory` field at all is treated as available. That is
+ * the frontend's local copy of the catalogue, which has never had the field —
+ * refusing to sell everything the moment this helper is introduced would be a
+ * worse bug than the one it fixes.
+ */
+export function isInStock(book) {
+  if (!book || book.inventory === undefined || book.inventory === null) {
+    return true;
+  }
+
+  const inventory = Number(book.inventory);
+  return Number.isFinite(inventory) && inventory > 0;
+}
+
+/**
+ * A short sentence about availability, or null when there is nothing worth
+ * saying — a well-stocked book does not need a badge.
+ */
+export function describeStock(book) {
+  if (!book || book.inventory === undefined || book.inventory === null) {
+    return null;
+  }
+
+  const inventory = Number(book.inventory);
+
+  if (!Number.isFinite(inventory)) {
+    return null;
+  }
+
+  if (inventory <= 0) {
+    return 'Out of stock';
+  }
+
+  if (inventory <= LOW_STOCK_THRESHOLD) {
+    return `Only ${inventory} left`;
+  }
+
+  return 'In stock';
+}
+
+export default {
+  LOW_STOCK_THRESHOLD,
+  formatRating,
+  formatPrice,
+  isInStock,
+  describeStock,
+};

--- a/bookshelf-frontend/src/utils/bookFormat.test.js
+++ b/bookshelf-frontend/src/utils/bookFormat.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LOW_STOCK_THRESHOLD,
+  describeStock,
+  formatPrice,
+  formatRating,
+  isInStock,
+} from './bookFormat.js';
+
+describe('formatRating', () => {
+  it('renders one decimal place', () => {
+    expect(formatRating(4.5)).toBe('4.5');
+    expect(formatRating(4)).toBe('4.0');
+    expect(formatRating('4.25')).toBe('4.3');
+  });
+
+  it('returns null rather than throwing when a book has no rating', () => {
+    // The crash this replaces: `book.rating.toFixed(1)` on a record without
+    // one took down the whole page.
+    expect(formatRating(undefined)).toBeNull();
+    expect(formatRating(null)).toBeNull();
+    expect(formatRating('')).toBeNull();
+    expect(formatRating('unrated')).toBeNull();
+    expect(formatRating(NaN)).toBeNull();
+  });
+
+  it('does not invent a 0.0 for an unrated book', () => {
+    expect(formatRating(undefined)).not.toBe('0.0');
+  });
+});
+
+describe('formatPrice', () => {
+  it('formats rupees with Indian grouping', () => {
+    expect(formatPrice(349)).toBe('₹349');
+    expect(formatPrice(123456)).toBe('₹1,23,456');
+  });
+
+  it('returns null for an unusable price', () => {
+    expect(formatPrice(undefined)).toBeNull();
+    expect(formatPrice(null)).toBeNull();
+    expect(formatPrice('')).toBeNull();
+    expect(formatPrice('free')).toBeNull();
+  });
+});
+
+describe('isInStock', () => {
+  it('reads the inventory field the API returns', () => {
+    expect(isInStock({ inventory: 8 })).toBe(true);
+    expect(isInStock({ inventory: 1 })).toBe(true);
+    expect(isInStock({ inventory: 0 })).toBe(false);
+    expect(isInStock({ inventory: -2 })).toBe(false);
+  });
+
+  it('treats a record with no inventory field as available', () => {
+    // src/data/books.js has never carried the field. Refusing to sell
+    // everything the moment this helper lands would be a worse bug.
+    expect(isInStock({ id: 'b1' })).toBe(true);
+    expect(isInStock(null)).toBe(true);
+  });
+});
+
+describe('describeStock', () => {
+  it('says nothing about a well-stocked book', () => {
+    expect(describeStock({ inventory: 10 })).toBe('In stock');
+  });
+
+  it('warns when only a few are left', () => {
+    expect(describeStock({ inventory: LOW_STOCK_THRESHOLD })).toBe(
+      `Only ${LOW_STOCK_THRESHOLD} left`
+    );
+    expect(describeStock({ inventory: 1 })).toBe('Only 1 left');
+  });
+
+  it('reports a sold-out book', () => {
+    expect(describeStock({ inventory: 0 })).toBe('Out of stock');
+  });
+
+  it('stays quiet when there is no inventory data to report', () => {
+    expect(describeStock({ id: 'b1' })).toBeNull();
+    expect(describeStock({ inventory: 'many' })).toBeNull();
+    expect(describeStock(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #317.

## The bug

Two catalogues, drifting apart.

| | `bookshelf-backend/data/books.json` | `bookshelf-frontend/src/data/books.js` |
|---|---|---|
| Served by | `GET /api/books` | nothing |
| Written by | `updateInventoryWithOCC()` on every checkout | nobody |
| Has `inventory` | yes | **no** |
| Read by | `pages/Home.jsx` (since #274) | `pages/BookDetail.jsx` |

The card and the page it links to have been showing different data. Nothing keeps the two files in sync, and nothing would fail if they diverged — I checked by changing a price in `books.json`: the grid updated, the detail page did not.

## What that broke

- **Stale prices and ratings**, silently.
- **Inventory was invisible.** The page carrying the app's primary add-to-cart button had no way to know whether the book was in stock, because the field does not exist in the frontend copy. A sold-out book could be added and only failed at the reservation step during checkout, several screens later.
- **A new book 404s on its own page.** Add a ninth book to `books.json`; it appears in the grid and renders "Book Not Found" when clicked.
- **`book.rating.toFixed(1)`**, unguarded, in both `BookDetail.jsx` and `BookCard.jsx`. Nothing requires a book to have a rating. One record without it throws `TypeError: Cannot read properties of undefined (reading 'toFixed')` and takes down the page — or, in `BookCard`, the whole grid.
- **The loading state was theatre**: `setTimeout(() => setLoading(false), 700)` wrapped around a synchronous `books.find()`.

## What this changes

**`services/bookService.js`** — `getBookById`, `getBooks`, `getGenres`, going through `utils/api.js` so they inherit the retry policy, timeout and normalised error shape. `BookNotFoundError` gives a 404 a type rather than a status code to sniff for.

**`hooks/useBook.js`** — the fetch, with the states the page actually needs. The one that matters:

> `notFound` and `error` are separate. A network blip must not tell a customer that a book has been withdrawn.

A 404 gets the not-found page; everything else gets an error with a **Try again** button. Requests carry an `AbortController` and a sequence number, so a slow response for a book the reader has already navigated away from is dropped rather than painted over the current one.

**`utils/bookFormat.js`** — `formatRating`, `formatPrice`, `isInStock`, `describeStock`. `formatRating` returns `null`, not `'0.0'` — a book nobody has rated is not a book everybody rated badly. `isInStock` treats a record with *no* `inventory` field as available, because the frontend copy has never carried one and refusing to sell everything would be a worse bug than the one being fixed.

**`BookCard`** gets the same formatting, so the crash cannot come back through the grid, and its add-to-cart button now disables for a sold-out book.

**Related books** come from the API filtered by genre, and fail silently — "You might also like" is a garnish and must not turn a working book page into an error page.

## `src/data/books.js` stays

`pages/Wishlist.jsx`, `pages/WishlistPage.jsx` and `components/RecentlyViewed.jsx` still resolve stored book ids against it, and `spines` (the decorative shelf in `Hero.jsx`) has no API behind it at all. Deleting it here would be a much larger change touching three more pages. It is marked deprecated with a note naming the remaining consumers.

## Tests

29 new tests:

- `utils/bookFormat.test.js` — including the `Number(null) === 0` trap, which my own test caught: the first version of `formatRating` rendered `★ 0.0` for an unrated book.
- `hooks/useBook.test.jsx` — 404 vs network failure, reload, and the stale-response race.
- `pages/BookDetail.test.jsx` — asserts the page shows a price the local copy does *not* contain; renders a book the local copy has never heard of; distinguishes 404 from failure; shows stock; disables add-to-cart when sold out; renders a book with no rating without throwing.

```
npm run test    # 138 passed (was 109)
npm run lint    # clean
npm run build   # clean
```

`dist/` is checked in and intentionally not regenerated — it would conflict with every other open branch.

## Merges cleanly with the other open PRs

Verified against #320, #321, #323 and #324 in both merge orders. #323 originally edited `pages/BookDetail.jsx` as well and conflicted here; it has since been restructured to leave this file alone. The five branches merged together give 273 passing tests, a clean lint and a clean build.