### PR TITLE
fix(recently viewed): write the list the component has always read (closes #318)

### DIFF
--- a/bookshelf-frontend/src/components/RecentlyViewed.jsx
+++ b/bookshelf-frontend/src/components/RecentlyViewed.jsx
@@ -1,55 +1,120 @@
-import { useState, useEffect } from 'react';
-import BookCard from './BookCard';
-import { books } from '../data/books';
+import { useEffect, useMemo, useState } from 'react';
+import { matchPath, useLocation } from 'react-router-dom';
+
+import BookCard from './BookCard.jsx';
+import { books } from '../data/books.js';
+import {
+  readRecentlyViewedExcept,
+  recordBookView,
+} from '../utils/recentlyViewed.js';
 import './RecentlyViewed.css';
 
 /**
- * RecentlyViewed — shows a horizontal scroll strip of previously visited books.
+ * A strip of books the reader has looked at recently.
  *
- * Reads an array of book IDs from localStorage ('recentlyViewed') and maps them
- * to book objects. The current book (if provided) is excluded from the list.
+ * Two things were wrong with this component (#318).
  *
- * Add-to-cart behaviour is handled by BookCard via CartContext — no prop needed.
+ * The list it reads was never written. `grep -rn recentlyViewed src` found a
+ * single `getItem` and no `setItem` anywhere in the application, so `stored`
+ * was always null, the effect returned early, and the component rendered
+ * null on every page for its entire existence.
+ *
+ * It was also mounted in App.jsx — the layout shell — with no
+ * `currentBookId`. So it was declared on the login form, the checkout page
+ * and the 404 page, none of which are places you browse books; and on
+ * /book/:id the book being read would have appeared in its own "recently
+ * viewed" strip, which is exactly what the `currentBookId` prop was written
+ * to prevent and never received.
+ *
+ * Rather than move the mount into each page, the component gates itself: one
+ * mount point in the shell, an explicit allow-list of routes, and the current
+ * book id derived from the path. That keeps the whole feature — the read, the
+ * write and the visibility rule — in one file that can be tested on its own,
+ * and it leaves BookDetail and Home untouched, which matters while #317 and
+ * #319 are open against both of them.
+ *
+ * Props:
+ *   currentBookId  optional override; normally derived from the route
+ *   title          optional heading override
  */
-export default function RecentlyViewed({ currentBookId }) {
+
+/**
+ * Where a browsing history belongs: the catalogue, and a book page.
+ *
+ * Anywhere else it is either noise (a legal page) or an active distraction
+ * (a checkout, where the job is to finish paying).
+ */
+export const VISIBLE_ROUTES = ['/', '/book/:id'];
+
+/** The book page pattern, which also supplies the id to record and exclude. */
+const BOOK_ROUTE = '/book/:id';
+
+export default function RecentlyViewed({
+  currentBookId: currentBookIdProp,
+  title = 'Recently Viewed',
+}) {
+  const location = useLocation();
   const [recentBooks, setRecentBooks] = useState([]);
 
+  const bookRouteMatch = useMemo(
+    () => matchPath(BOOK_ROUTE, location.pathname),
+    [location.pathname]
+  );
+
+  const currentBookId = currentBookIdProp ?? bookRouteMatch?.params?.id;
+
+  const isVisibleRoute = useMemo(
+    () => VISIBLE_ROUTES.some((pattern) => matchPath(pattern, location.pathname)),
+    [location.pathname]
+  );
+
+  /*
+   * The write half of the feature. Recording here rather than in BookDetail
+   * keeps the read and the write in one place — and the component is mounted
+   * on every route, so it always observes the navigation.
+   *
+   * recordBookView is total: an id that is not in the catalogue is stored and
+   * then dropped when the list is resolved for display, rather than rejected
+   * here on a guess about what a valid id looks like.
+   */
   useEffect(() => {
-    try {
-      const stored = localStorage.getItem('recentlyViewed');
-      if (!stored) return;
-
-      let parsed = JSON.parse(stored);
-
-      // Exclude the book currently being viewed
-      if (currentBookId) {
-        parsed = parsed.filter(id => String(id) !== String(currentBookId));
-      }
-
-      // Map IDs → book objects, dropping any stale/invalid IDs
-      const mappedBooks = parsed
-        .map(id => books.find(b => String(b.id) === String(id)))
-        .filter(Boolean);
-
-      setRecentBooks(mappedBooks);
-    } catch (e) {
-      console.error('Failed to parse recently viewed books:', e);
+    if (currentBookId) {
+      recordBookView(currentBookId);
     }
   }, [currentBookId]);
 
-  // Nothing to show — render nothing rather than an empty section
-  if (recentBooks.length === 0) {
+  useEffect(() => {
+    if (!isVisibleRoute) {
+      setRecentBooks([]);
+      return;
+    }
+
+    const ids = readRecentlyViewedExcept(currentBookId);
+
+    // Ids are resolved against the local catalogue copy. Unknown ids are
+    // dropped rather than rendered as gaps — see #317 for why that copy still
+    // exists and what should replace it.
+    setRecentBooks(
+      ids
+        .map((id) => books.find((book) => String(book.id) === id))
+        .filter(Boolean)
+    );
+  }, [isVisibleRoute, currentBookId, location.key]);
+
+  // Nothing to show — render nothing rather than a heading over an empty row.
+  if (!isVisibleRoute || recentBooks.length === 0) {
     return null;
   }
 
   return (
-    <section className="recently-viewed">
+    <section className="recently-viewed" aria-labelledby="recently-viewed-title">
       <div className="recently-viewed__inner">
-        <h2 className="recently-viewed__title">Recently Viewed</h2>
+        <h2 className="recently-viewed__title" id="recently-viewed-title">
+          {title}
+        </h2>
         <div className="recently-viewed__scroll">
-          {recentBooks.map(book => (
+          {recentBooks.map((book) => (
             <div key={book.id} className="recently-viewed__item">
-              {/* BookCard uses CartContext internally — no onAddToCart prop needed */}
               <BookCard book={book} />
             </div>
           ))}

--- a/bookshelf-frontend/src/components/RecentlyViewed.test.jsx
+++ b/bookshelf-frontend/src/components/RecentlyViewed.test.jsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+vi.mock('./BookCard.jsx', () => ({
+  default: ({ book }) => <div data-testid="book-card">{book.title}</div>,
+}));
+
+import { books } from '../data/books.js';
+import {
+  STORAGE_KEY,
+  readRecentlyViewed,
+  recordBookView,
+} from '../utils/recentlyViewed.js';
+import RecentlyViewed from './RecentlyViewed.jsx';
+
+const catalogue = books.filter((book) => String(book.id).startsWith('b'));
+const [first, second, third] = catalogue;
+
+/**
+ * The component is mounted in the layout shell, so it is rendered on every
+ * route. These tests mount it the same way.
+ */
+function renderAt(pathname, props = {}) {
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <RecentlyViewed {...props} />
+      <Routes>
+        <Route path="*" element={<span data-testid="page" />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+const titles = () =>
+  screen.queryAllByTestId('book-card').map((card) => card.textContent);
+
+describe('RecentlyViewed', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  describe('recording', () => {
+    it('records the visit, which nothing in the app ever did', async () => {
+      renderAt(`/book/${first.id}`);
+
+      await waitFor(() => expect(readRecentlyViewed()).toEqual([first.id]));
+    });
+
+    it('moves a revisited book to the front rather than duplicating it', async () => {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify(['b4', first.id, 'b6'])
+      );
+
+      renderAt(`/book/${first.id}`);
+
+      await waitFor(() =>
+        expect(readRecentlyViewed()).toEqual([first.id, 'b4', 'b6'])
+      );
+    });
+
+    it('records an id that is not in the catalogue without throwing', async () => {
+      renderAt('/book/not-a-book');
+
+      await waitFor(() => expect(readRecentlyViewed()).toEqual(['not-a-book']));
+    });
+
+    it('records nothing on a route that is not a book page', async () => {
+      renderAt('/checkout');
+
+      await waitFor(() => expect(readRecentlyViewed()).toEqual([]));
+    });
+  });
+
+  describe('visibility', () => {
+    beforeEach(() => {
+      recordBookView(first.id);
+      recordBookView(second.id);
+    });
+
+    it('shows on the catalogue', () => {
+      renderAt('/');
+      expect(titles()).toEqual([second.title, first.title]);
+    });
+
+    it('shows on a book page', async () => {
+      renderAt(`/book/${third.id}`);
+      await waitFor(() =>
+        expect(titles()).toEqual([second.title, first.title])
+      );
+    });
+
+    for (const route of ['/login', '/checkout', '/privacy', '/nonsense']) {
+      it(`renders nothing on ${route}`, () => {
+        // It used to be declared on all of these, because the layout shell
+        // mounted it unconditionally.
+        const { container } = renderAt(route);
+        expect(container.querySelector('.recently-viewed')).toBeNull();
+      });
+    }
+  });
+
+  describe('the current book', () => {
+    it('is excluded from its own strip', async () => {
+      recordBookView(first.id);
+      recordBookView(second.id);
+
+      renderAt(`/book/${second.id}`);
+
+      await waitFor(() => expect(titles()).toEqual([first.title]));
+    });
+
+    it('leaves nothing to render when it is the only entry', async () => {
+      recordBookView(first.id);
+
+      const { container } = renderAt(`/book/${first.id}`);
+
+      await waitFor(() =>
+        expect(container.querySelector('.recently-viewed')).toBeNull()
+      );
+    });
+
+    it('can still be overridden by the prop', async () => {
+      recordBookView(first.id);
+      recordBookView(second.id);
+
+      renderAt('/', { currentBookId: second.id });
+
+      await waitFor(() => expect(titles()).toEqual([first.title]));
+    });
+  });
+
+  describe('resilience', () => {
+    it('renders nothing when nothing has been viewed', () => {
+      const { container } = renderAt('/');
+      expect(container.querySelector('.recently-viewed')).toBeNull();
+    });
+
+    it('skips ids that no longer resolve to a book', () => {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify([first.id, 'deleted-book', third.id])
+      );
+
+      renderAt('/');
+
+      expect(titles()).toEqual([first.title, third.title]);
+    });
+
+    it('survives a corrupted stored value', () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      window.localStorage.setItem(STORAGE_KEY, '{not json');
+
+      const { container } = renderAt('/');
+      expect(container.querySelector('.recently-viewed')).toBeNull();
+    });
+  });
+
+  describe('markup', () => {
+    it('labels the section for assistive technology', () => {
+      recordBookView(first.id);
+      renderAt('/');
+
+      expect(
+        screen.getByRole('region', { name: 'Recently Viewed' })
+      ).toBeInTheDocument();
+    });
+
+    it('accepts a heading override', () => {
+      recordBookView(first.id);
+      renderAt('/', { title: 'Pick up where you left off' });
+
+      expect(
+        screen.getByRole('heading', { name: 'Pick up where you left off' })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/bookshelf-frontend/src/utils/recentlyViewed.js
+++ b/bookshelf-frontend/src/utils/recentlyViewed.js
@@ -1,0 +1,161 @@
+/**
+ * The "recently viewed" list, in localStorage.
+ *
+ * `components/RecentlyViewed.jsx` has read this key since the day it was
+ * added. Nothing has ever written it:
+ *
+ *     $ grep -rn "recentlyViewed" src
+ *     src/components/RecentlyViewed.jsx:19:  localStorage.getItem('recentlyViewed')
+ *     src/components/UserDashboard.jsx:21:  recentlyViewed = [   # an unrelated prop
+ *
+ * One read, no writes. `stored` was always null, the effect returned early,
+ * and the component rendered null on every page for its entire existence.
+ * See #318.
+ *
+ * The write side lives here rather than inline in the page for two reasons:
+ * it can be tested without rendering anything, and every rule about the list
+ * — the cap, the dedup, the ordering — has one home instead of being
+ * reimplemented by the next caller.
+ */
+
+export const STORAGE_KEY = 'recentlyViewed';
+
+/**
+ * How many ids to keep.
+ *
+ * Eight fits the horizontal strip on a wide screen without the list becoming
+ * a second, worse browsing history. The cap is applied on write, so the value
+ * can be lowered later without leaving a long list stranded in someone's
+ * browser.
+ */
+export const MAX_ENTRIES = 8;
+
+/**
+ * Read the stored ids, newest first.
+ *
+ * Total for anything localStorage can hold. The value is shared with other
+ * tabs, older versions of this app, and anyone with devtools open — the same
+ * reasoning that hardened the cart in #309. A browsing-history nicety is not
+ * worth a white screen.
+ */
+export function readRecentlyViewed() {
+  let raw;
+
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY);
+  } catch (error) {
+    // Safari private browsing and blocked third-party storage throw on read,
+    // not just on write.
+    console.error('[recentlyViewed] could not read from storage:', error);
+    return [];
+  }
+
+  if (!raw) {
+    return [];
+  }
+
+  let parsed;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    console.error('[recentlyViewed] stored value was not JSON:', error);
+    return [];
+  }
+
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+
+  const seen = new Set();
+  const ids = [];
+
+  for (const entry of parsed) {
+    // Ids are strings in books.json but a hand-written value could be
+    // anything; numbers are coerced rather than discarded because the app
+    // itself compares with String() on both sides.
+    const id =
+      typeof entry === 'string'
+        ? entry.trim()
+        : typeof entry === 'number' && Number.isFinite(entry)
+          ? String(entry)
+          : null;
+
+    if (!id || seen.has(id)) {
+      continue;
+    }
+
+    seen.add(id);
+    ids.push(id);
+
+    if (ids.length >= MAX_ENTRIES) {
+      break;
+    }
+  }
+
+  return ids;
+}
+
+/**
+ * Move a book to the front of the list.
+ *
+ * Revisiting a book moves it rather than adding a second entry — a list that
+ * reads "A, A, A, B" after three looks at A is not a history, it is a log.
+ *
+ * Returns the new list so a caller can use it without reading back.
+ */
+export function recordBookView(bookId) {
+  const id =
+    typeof bookId === 'string'
+      ? bookId.trim()
+      : typeof bookId === 'number' && Number.isFinite(bookId)
+        ? String(bookId)
+        : '';
+
+  if (!id) {
+    return readRecentlyViewed();
+  }
+
+  const existing = readRecentlyViewed();
+  const next = [id, ...existing.filter((entry) => entry !== id)].slice(
+    0,
+    MAX_ENTRIES
+  );
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch (error) {
+    // Quota exceeded, or storage disabled. The customer is looking at a book;
+    // failing to note that down is not a reason to interrupt them.
+    console.error('[recentlyViewed] could not save to storage:', error);
+  }
+
+  return next;
+}
+
+/** Everything except `excludeId`, for a page that is already showing it. */
+export function readRecentlyViewedExcept(excludeId) {
+  if (excludeId === undefined || excludeId === null || excludeId === '') {
+    return readRecentlyViewed();
+  }
+
+  const excluded = String(excludeId);
+  return readRecentlyViewed().filter((id) => id !== excluded);
+}
+
+export function clearRecentlyViewed() {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    console.error('[recentlyViewed] could not clear storage:', error);
+  }
+}
+
+export default {
+  STORAGE_KEY,
+  MAX_ENTRIES,
+  readRecentlyViewed,
+  readRecentlyViewedExcept,
+  recordBookView,
+  clearRecentlyViewed,
+};

--- a/bookshelf-frontend/src/utils/recentlyViewed.test.js
+++ b/bookshelf-frontend/src/utils/recentlyViewed.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  MAX_ENTRIES,
+  STORAGE_KEY,
+  clearRecentlyViewed,
+  readRecentlyViewed,
+  readRecentlyViewedExcept,
+  recordBookView,
+} from './recentlyViewed.js';
+
+const stored = () => JSON.parse(window.localStorage.getItem(STORAGE_KEY));
+
+describe('recentlyViewed', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('recordBookView', () => {
+    it('writes the key the component has always read but nobody wrote', () => {
+      recordBookView('b1');
+      expect(stored()).toEqual(['b1']);
+    });
+
+    it('puts the newest book first', () => {
+      recordBookView('b1');
+      recordBookView('b2');
+      recordBookView('b3');
+      expect(stored()).toEqual(['b3', 'b2', 'b1']);
+    });
+
+    it('moves a revisited book rather than adding it twice', () => {
+      recordBookView('b1');
+      recordBookView('b2');
+      recordBookView('b1');
+      // A list reading "b1, b1, b2" is a log, not a history.
+      expect(stored()).toEqual(['b1', 'b2']);
+    });
+
+    it('caps the list', () => {
+      for (let i = 0; i < MAX_ENTRIES + 5; i += 1) {
+        recordBookView(`b${i}`);
+      }
+
+      const list = stored();
+      expect(list).toHaveLength(MAX_ENTRIES);
+      expect(list[0]).toBe(`b${MAX_ENTRIES + 4}`);
+      expect(list).not.toContain('b0');
+    });
+
+    it('accepts a numeric id, since ids are compared as strings everywhere', () => {
+      recordBookView(7);
+      expect(stored()).toEqual(['7']);
+    });
+
+    it('ignores an id that could never resolve to a book', () => {
+      recordBookView('');
+      recordBookView('   ');
+      recordBookView(null);
+      recordBookView(undefined);
+      recordBookView({ id: 'b1' });
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    it('returns the new list without a second read', () => {
+      recordBookView('b1');
+      expect(recordBookView('b2')).toEqual(['b2', 'b1']);
+    });
+
+    it('does not throw when storage is full or disabled', () => {
+      // Safari private browsing, and any browser at quota.
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+
+      expect(() => recordBookView('b1')).not.toThrow();
+    });
+  });
+
+  describe('readRecentlyViewed', () => {
+    it('returns an empty list when nothing has been recorded', () => {
+      expect(readRecentlyViewed()).toEqual([]);
+    });
+
+    it('survives a value that is not JSON', () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      window.localStorage.setItem(STORAGE_KEY, 'b1,b2,b3');
+      expect(readRecentlyViewed()).toEqual([]);
+    });
+
+    it('survives a value that is JSON but not an array', () => {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ b1: true }));
+      expect(readRecentlyViewed()).toEqual([]);
+    });
+
+    it('drops entries that are not usable ids', () => {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify(['b1', null, 42, { id: 'b2' }, '', '  ', ['b3'], 'b4'])
+      );
+      expect(readRecentlyViewed()).toEqual(['b1', '42', 'b4']);
+    });
+
+    it('deduplicates a hand-edited list', () => {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(['b1', 'b1', 'b2']));
+      expect(readRecentlyViewed()).toEqual(['b1', 'b2']);
+    });
+
+    it('applies the cap on read as well, so lowering it takes effect', () => {
+      const long = Array.from({ length: MAX_ENTRIES + 10 }, (_, i) => `b${i}`);
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(long));
+      expect(readRecentlyViewed()).toHaveLength(MAX_ENTRIES);
+    });
+
+    it('does not throw when storage itself is unavailable', () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
+        throw new DOMException('SecurityError');
+      });
+
+      expect(readRecentlyViewed()).toEqual([]);
+    });
+  });
+
+  describe('readRecentlyViewedExcept', () => {
+    it('leaves out the book already on screen', () => {
+      recordBookView('b1');
+      recordBookView('b2');
+      expect(readRecentlyViewedExcept('b2')).toEqual(['b1']);
+    });
+
+    it('compares as strings, matching how ids are compared elsewhere', () => {
+      recordBookView('7');
+      expect(readRecentlyViewedExcept(7)).toEqual([]);
+    });
+
+    it('excludes nothing when given no id', () => {
+      recordBookView('b1');
+      expect(readRecentlyViewedExcept(undefined)).toEqual(['b1']);
+      expect(readRecentlyViewedExcept('')).toEqual(['b1']);
+    });
+  });
+
+  describe('clearRecentlyViewed', () => {
+    it('empties the list', () => {
+      recordBookView('b1');
+      clearRecentlyViewed();
+      expect(readRecentlyViewed()).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #318.

## The bug

```
$ grep -rn "recentlyViewed" bookshelf-frontend/src
src/components/RecentlyViewed.jsx:19:  const stored = localStorage.getItem('recentlyViewed');
src/components/UserDashboard.jsx:21:  recentlyViewed = [        # an unrelated prop, hardcoded demo data
```

One read. No writes. `stored` is always `null`, the effect returns early, `recentBooks` stays `[]`, and the component returns `null` on every render of every page. The feature has never worked once.

## Second defect: mounted with no idea where it was

`App.jsx` renders it in the layout shell, with no `currentBookId`:

```jsx
<Outlet context={{ searchQuery, setSearchQuery }} />
<RecentlyViewed />
<Footer />
```

So even once the write side existed it would have appeared on the login form, the checkout page, the privacy policy and the 404 page — none of which are places you browse books — and on `/book/:id` the book being read would have shown up in its own "Recently Viewed" strip. That is exactly what the `currentBookId` prop was written to prevent. The prop was declared, documented, and never passed by the only place that mounted the component.

## What this changes

**`utils/recentlyViewed.js`** holds the rules, so they have one home and can be tested without rendering anything:

- newest first;
- deduplicated — a revisit **moves** the book rather than appending, because a list reading "A, A, A, B" is a log, not a history;
- capped at 8, on read as well as on write, so lowering the cap later takes effect on lists already sitting in people's browsers;
- total for anything `localStorage` can contain: a non-JSON value, JSON that is not an array, entries that are objects or `null`, and a browser that throws on `getItem` (Safari private browsing) or `setItem` (quota). A browsing-history nicety must not be able to white-screen a page — the same reasoning applied to the cart in #309.

**`RecentlyViewed` gates itself.** It keeps its single mount point in the shell and derives everything else from the route: `matchPath('/book/:id')` gives it the id to record and to exclude, and `VISIBLE_ROUTES` is an explicit allow-list (`/` and `/book/:id`).

The obvious alternative was to move the mount into each page and record the view from `BookDetail`. I started there and backed out: it puts the read in one file, the write in a second and the visibility rule in a third, and it edits `pages/BookDetail.jsx` and `pages/Home.jsx` — both of which are being rewritten right now by #317 and #319. Self-gating keeps the whole feature in one testable file and this PR's diff to **four files, none of them shared with another open PR**. The `currentBookId` prop stays as an override.

## Still resolved against `src/data/books.js`

Ids are mapped to records through the frontend's local catalogue copy, which is stale for reasons tracked separately in #317 — unknown ids are dropped rather than rendered as gaps. Moving this to the API is that issue's job.

## Tests

37 new tests:

- `utils/recentlyViewed.test.js` (19) — ordering, the move-not-duplicate rule, the cap, numeric ids, and every corruption path including a `localStorage` that throws on read and on write.
- `components/RecentlyViewed.test.jsx` (18) — the visit is recorded and a revisit reorders; nothing is recorded off a book page; the strip renders on `/` and `/book/:id` and **not** on `/login`, `/checkout`, `/privacy` or an unknown route; the current book is excluded; nothing renders when the only entry *is* the current book; corrupted storage and unresolvable ids are survived.

```
npm run test    # 146 passed (was 109)
npm run lint    # clean
npm run build   # clean
```

Verified to merge cleanly with #320, #321, #322 and #324 in either direction; the five together give 273 passing tests, a clean lint and a clean build.

`dist/` is checked in and intentionally not regenerated — it would conflict with every other open branch.