### PR TITLE
fix(catalog): filter on the server instead of on the four books on screen (closes #319)

### DIFF
--- a/bookshelf-frontend/src/App.css
+++ b/bookshelf-frontend/src/App.css
@@ -174,3 +174,12 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Error detail under the catalogue's failure state (#319). The page had no
+   error state worth the name — a failed fetch showed one generic line and no
+   way to retry. */
+.catalog__error-detail {
+  color: var(--ink-soft);
+  font-size: 14px;
+  margin: 8px 0 16px;
+}

--- a/bookshelf-frontend/src/hooks/useBookCatalog.js
+++ b/bookshelf-frontend/src/hooks/useBookCatalog.js
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { API_BASE_URL } from '../config/env.js';
+import { buildCatalogQuery } from '../utils/catalogQuery.js';
+import useDebounce from './useDebounce.js';
+
+/**
+ * A page of the catalogue, with every filter applied by the server.
+ *
+ * Two problems this closes (#319).
+ *
+ * The filters. Home fetched a page of four books and then applied the price,
+ * rating and multi-genre filters to those four in the browser, so "under
+ * ₹300" showed the empty state whenever page 1 happened to contain nothing
+ * that cheap, while the header claimed 16 titles and the pager offered four
+ * pages. Everything goes to the API now, which filters the whole catalogue
+ * before it paginates — so `totalBooks` and `totalPages` describe what the
+ * customer actually asked for.
+ *
+ * The search box. `searchQuery` was a direct dependency of the fetch effect,
+ * so every keystroke fired a request — "mystery" was seven of them — with no
+ * AbortController and no sequence check, meaning a slow response for `myst`
+ * could land after `mystery` and overwrite the results with stale ones.
+ * `hooks/useDebounce.js` had been in the repo, imported by nothing, since it
+ * was added.
+ */
+export const SEARCH_DEBOUNCE_MS = 350;
+
+const EMPTY_RESULT = {
+  books: [],
+  totalBooks: 0,
+  totalPages: 0,
+  hasNextPage: false,
+  hasPrevPage: false,
+};
+
+export function useBookCatalog(filters, { debounceMs = SEARCH_DEBOUNCE_MS } = {}) {
+  const {
+    search = '',
+    genres,
+    minPrice,
+    maxPrice,
+    minRating,
+    inStock,
+    sort,
+    page,
+    limit,
+  } = filters ?? {};
+
+  // Only the free-text box is debounced. A checkbox or a select is one
+  // deliberate action, and delaying it just makes the UI feel broken.
+  const debouncedSearch = useDebounce(search, debounceMs);
+
+  const [result, setResult] = useState(EMPTY_RESULT);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [attempt, setAttempt] = useState(0);
+
+  const requestIdRef = useRef(0);
+
+  // Genres is an array rebuilt on every render, so it cannot be a dependency
+  // directly without refetching forever.
+  const genreKey = useMemo(
+    () => (Array.isArray(genres) ? genres.join('|') : String(genres ?? '')),
+    [genres]
+  );
+
+  const queryString = useMemo(
+    () =>
+      buildCatalogQuery({
+        search: debouncedSearch,
+        genres,
+        minPrice,
+        maxPrice,
+        minRating,
+        inStock,
+        sort,
+        page,
+        limit,
+      }).toString(),
+    // genreKey stands in for `genres` here: the array is rebuilt on every
+    // render of the page, so depending on it directly would refetch forever.
+    // The rest are primitives.
+    [debouncedSearch, genreKey, minPrice, maxPrice, minRating, inStock, sort, page, limit]
+  );
+
+  const reload = useCallback(() => setAttempt((n) => n + 1), []);
+
+  useEffect(() => {
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+
+    const controller = new AbortController();
+
+    // A response for a query the customer has already moved past must not be
+    // painted over the current one.
+    const isStale = () => requestIdRef.current !== requestId;
+
+    setLoading(true);
+    setError(null);
+
+    fetch(`${API_BASE_URL}/books?${queryString}`, { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) {
+          // The API answers a bad query with { message, parameter }; showing
+          // that beats "Failed to load books" when the cause is a filter the
+          // customer can change.
+          const body = await response.json().catch(() => null);
+          const error = new Error(body?.message ?? 'Failed to load books');
+          error.parameter = body?.parameter;
+          error.status = response.status;
+          throw error;
+        }
+
+        return response.json();
+      })
+      .then((data) => {
+        if (isStale()) return;
+
+        setResult({
+          books: Array.isArray(data?.books) ? data.books : [],
+          totalBooks: Number(data?.totalBooks ?? 0),
+          totalPages: Number(data?.totalPages ?? 0),
+          hasNextPage: Boolean(data?.hasNextPage),
+          hasPrevPage: Boolean(data?.hasPrevPage),
+        });
+        setLoading(false);
+      })
+      .catch((caught) => {
+        if (caught?.name === 'AbortError' || isStale()) {
+          return;
+        }
+
+        console.error('[catalog] could not load books:', caught);
+        setResult(EMPTY_RESULT);
+        setError(caught?.message ?? 'Failed to load books');
+        setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [queryString, attempt]);
+
+  return {
+    ...result,
+    loading,
+    error,
+    reload,
+    // Exposed so the page can tell "typing" from "loaded", and so tests can
+    // assert the debounce rather than guess at it.
+    isSearchPending: search !== debouncedSearch,
+    queryString,
+  };
+}
+
+export default useBookCatalog;

--- a/bookshelf-frontend/src/hooks/useBookCatalog.test.jsx
+++ b/bookshelf-frontend/src/hooks/useBookCatalog.test.jsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+
+import { useBookCatalog } from './useBookCatalog.js';
+
+function jsonResponse(body, { ok = true, status = 200 } = {}) {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+const PAGE = {
+  books: [{ id: 'b5', title: 'Low Tide', price: 249, rating: 4.1 }],
+  page: 1,
+  limit: 4,
+  totalBooks: 1,
+  totalPages: 1,
+  hasNextPage: false,
+  hasPrevPage: false,
+};
+
+function Probe({ filters }) {
+  const { books, totalBooks, totalPages, loading, error, queryString } =
+    useBookCatalog(filters, { debounceMs: 20 });
+
+  return (
+    <div>
+      <span data-testid="state">{loading ? 'loading' : error ? 'error' : 'ready'}</span>
+      <span data-testid="titles">{books.map((b) => b.title).join(',')}</span>
+      <span data-testid="total-books">{totalBooks}</span>
+      <span data-testid="total-pages">{totalPages}</span>
+      <span data-testid="query">{queryString}</span>
+      <span data-testid="error">{error ?? ''}</span>
+    </div>
+  );
+}
+
+const lastUrl = () => globalThis.fetch.mock.calls.at(-1)[0];
+
+describe('useBookCatalog', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn(() => Promise.resolve(jsonResponse(PAGE)));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends the price and rating filters to the API', async () => {
+    render(<Probe filters={{ minPrice: 100, maxPrice: 250, minRating: 4, limit: 4 }} />);
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+
+    const url = lastUrl();
+    // The old page never put these in the request at all.
+    expect(url).toContain('minPrice=100');
+    expect(url).toContain('maxPrice=250');
+    expect(url).toContain('minRating=4');
+  });
+
+  it('sends multiple genres rather than collapsing them to All', async () => {
+    render(<Probe filters={{ genres: ['Fiction', 'Poetry'], limit: 4 }} />);
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+
+    expect(lastUrl()).toContain('genre=Fiction&genre=Poetry');
+    expect(lastUrl()).not.toContain('genre=All');
+  });
+
+  it('reports the totals the server calculated for the filtered set', async () => {
+    globalThis.fetch.mockResolvedValue(
+      jsonResponse({ ...PAGE, totalBooks: 1, totalPages: 1 })
+    );
+
+    render(<Probe filters={{ maxPrice: 250, limit: 4 }} />);
+
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('ready'));
+    // The header used to read "16 titles total" above one filtered card.
+    expect(screen.getByTestId('total-books')).toHaveTextContent('1');
+    expect(screen.getByTestId('total-pages')).toHaveTextContent('1');
+  });
+
+  it('debounces the search box instead of firing per keystroke', async () => {
+    vi.useFakeTimers();
+
+    const { rerender } = render(<Probe filters={{ search: '', limit: 4 }} />);
+    for (const term of ['m', 'my', 'mys', 'myst', 'mystery']) {
+      rerender(<Probe filters={{ search: term, limit: 4 }} />);
+    }
+
+    // One request for the initial empty search; none yet for the typing.
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(50);
+    });
+
+    vi.useRealTimers();
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2));
+    expect(lastUrl()).toContain('search=mystery');
+  });
+
+  it('does not debounce a checkbox or a sort — those are single deliberate acts', async () => {
+    const { rerender } = render(<Probe filters={{ limit: 4 }} />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+
+    rerender(<Probe filters={{ limit: 4, sort: 'price_asc' }} />);
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2));
+  });
+
+  it('aborts the in-flight request when the query changes', async () => {
+    const abortSpy = vi.spyOn(AbortController.prototype, 'abort');
+
+    const { rerender } = render(<Probe filters={{ limit: 4, page: 1 }} />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+
+    rerender(<Probe filters={{ limit: 4, page: 2 }} />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2));
+
+    expect(abortSpy).toHaveBeenCalled();
+  });
+
+  it('drops a slow response for a query the reader has moved past', async () => {
+    let resolveFirst;
+    globalThis.fetch
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }))
+      .mockResolvedValueOnce(
+        jsonResponse({ ...PAGE, books: [{ id: 'b2', title: 'Field Notes' }] })
+      );
+
+    const { rerender } = render(<Probe filters={{ limit: 4, page: 1 }} />);
+    rerender(<Probe filters={{ limit: 4, page: 2 }} />);
+
+    await waitFor(() => expect(screen.getByTestId('titles')).toHaveTextContent('Field Notes'));
+
+    resolveFirst(jsonResponse({ ...PAGE, books: [{ id: 'b9', title: 'Stale Result' }] }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(screen.getByTestId('titles')).toHaveTextContent('Field Notes');
+    expect(screen.getByTestId('titles')).not.toHaveTextContent('Stale Result');
+  });
+
+  it('surfaces the parameter the API objected to', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    globalThis.fetch.mockResolvedValue(
+      jsonResponse(
+        { message: 'minRating must be at least 0, received -1', parameter: 'minRating' },
+        { ok: false, status: 400 }
+      )
+    );
+
+    render(<Probe filters={{ minRating: -1, limit: 4 }} />);
+
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('error'));
+    expect(screen.getByTestId('error')).toHaveTextContent('minRating must be at least 0');
+  });
+
+  it('reports a transport failure without leaving stale books on screen', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    globalThis.fetch.mockRejectedValue(new Error('Network down'));
+
+    render(<Probe filters={{ limit: 4 }} />);
+
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('error'));
+    expect(screen.getByTestId('titles')).toHaveTextContent('');
+  });
+
+  it('tolerates a response body that is not the shape it expects', async () => {
+    globalThis.fetch.mockResolvedValue(jsonResponse({ unexpected: true }));
+
+    render(<Probe filters={{ limit: 4 }} />);
+
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('ready'));
+    expect(screen.getByTestId('total-books')).toHaveTextContent('0');
+  });
+});

--- a/bookshelf-frontend/src/pages/Home.jsx
+++ b/bookshelf-frontend/src/pages/Home.jsx
@@ -1,16 +1,20 @@
-import { useMemo, useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+
 import Hero from '../components/Hero.jsx';
 import FilterSidebar from '../components/FilterSidebar.jsx';
 import BookCard from '../components/BookCard.jsx';
 import Pagination from '../components/Pagination.jsx';
 import SkeletonLoader from '../components/SkeletonLoader.jsx';
-import { API_BASE_URL } from '../config/env.js';
+import { useBookCatalog } from '../hooks/useBookCatalog.js';
+import { hasActiveFilters } from '../utils/catalogQuery.js';
 
-// Genre list is static since the backend catalogue is fixed.
-// If the backend adds a GET /api/genres endpoint in the future, replace this.
+// Genre list is static because the catalogue is. GET /api/books/genres
+// exists and returns these with counts; wiring it up is a separate change.
 const ALL_GENRES = ['All', 'Fiction', 'Sci-Fi', 'Mystery', 'Self-Help', 'Poetry'];
+
+const PAGE_SIZE = 4;
 
 export default function Home({ searchQuery: searchQueryProp }) {
   const { t } = useTranslation();
@@ -21,39 +25,64 @@ export default function Home({ searchQuery: searchQueryProp }) {
   const outletContext = useOutletContext();
   const searchQuery = searchQueryProp ?? outletContext?.searchQuery ?? '';
 
-  // ── Server-side data ──────────────────────────────────────────────────
-  const [books, setBooks] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
-  // ── Pagination ────────────────────────────────────────────────────────
   const [currentPage, setCurrentPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
-  const [totalBooks, setTotalBooks] = useState(0);
-  const limit = 4; // books per page
-
-  // ── Sort (server-side) ────────────────────────────────────────────────
   const [activeSort, setActiveSort] = useState('');
 
-  // ── FilterSidebar state ───────────────────────────────────────────────
-  const [selectedGenres, setSelectedGenres] = useState([]);  // multi-select checkboxes
-  const [minPrice, setMinPrice] = useState('');              // client-side price filter
-  const [maxPrice, setMaxPrice] = useState('');              // client-side price filter
-  const [minRating, setMinRating] = useState(null);          // client-side rating filter
-  const [sidebarOpen, setSidebarOpen] = useState(false);     // mobile toggle
+  const [selectedGenres, setSelectedGenres] = useState([]);
+  const [minPrice, setMinPrice] = useState('');
+  const [maxPrice, setMaxPrice] = useState('');
+  const [minRating, setMinRating] = useState(null);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
-  // ── Derived: single genre for API (backend takes one string) ──────────
-  // If exactly one genre is selected, pass it. Otherwise fetch everything
-  // and rely on client-side filtering for multi-select or "show all" cases.
-  const apiGenre = selectedGenres.length === 1 ? selectedGenres[0] : 'All';
+  const filters = useMemo(
+    () => ({
+      search: searchQuery,
+      genres: selectedGenres,
+      minPrice,
+      maxPrice,
+      minRating,
+      sort: activeSort,
+      page: currentPage,
+      limit: PAGE_SIZE,
+    }),
+    [searchQuery, selectedGenres, minPrice, maxPrice, minRating, activeSort, currentPage]
+  );
 
-  // ── Helpers ───────────────────────────────────────────────────────────
+  /*
+   * Every filter now goes to the API, which filters the whole catalogue and
+   * then paginates it. Previously the price, rating and multi-genre filters
+   * ran in a useMemo over the four books the server had already paged down
+   * to — so "Max ₹250" showed "No books found." while a ₹249 book sat on
+   * page 2, and the header still read "16 titles total" above it. See #319.
+   */
+  const { books, totalBooks, totalPages, loading, error, reload } =
+    useBookCatalog(filters);
+
+  const filtersActive = hasActiveFilters({
+    genres: selectedGenres,
+    minPrice,
+    maxPrice,
+    minRating,
+  });
+
+  /*
+   * Any change to what is being asked for returns to page 1.
+   *
+   * The old effect listed only search, genre and sort, so changing a price
+   * filter left the reader on page 3 of a result set that no longer had
+   * three pages — and the API answers a page past the end with an empty
+   * slice, not an error, so the symptom was a blank grid.
+   */
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, selectedGenres, minPrice, maxPrice, minRating, activeSort]);
 
   const handleGenreChange = useCallback((genre, checked) => {
-    setSelectedGenres(prev =>
-      checked ? [...prev, genre] : prev.filter(g => g !== genre)
+    setSelectedGenres((previous) =>
+      checked
+        ? [...previous, genre]
+        : previous.filter((entry) => entry !== genre)
     );
-    setCurrentPage(1);
   }, []);
 
   const handleClearFilters = useCallback(() => {
@@ -61,98 +90,29 @@ export default function Home({ searchQuery: searchQueryProp }) {
     setMinPrice('');
     setMaxPrice('');
     setMinRating(null);
-    setCurrentPage(1);
   }, []);
 
-  const hasActiveFilters =
-    selectedGenres.length > 0 ||
-    minPrice !== '' ||
-    maxPrice !== '' ||
-    minRating !== null;
+  const handlePageChange = useCallback((page) => {
+    setCurrentPage(page);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, []);
 
-  // ── Reset page when any upstream filter changes ───────────────────────
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchQuery, apiGenre, activeSort]);
-
-  // ── Fetch books from backend ──────────────────────────────────────────
-  useEffect(() => {
-    const loadBooks = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const params = new URLSearchParams({
-          page: currentPage,
-          limit: limit,
-          genre: apiGenre,
-          search: searchQuery,
-          ...(activeSort && { sort: activeSort }),
-        });
-        const response = await fetch(
-          `${API_BASE_URL}/books?${params.toString()}`
-        );
-
-        if (!response.ok) {
-          throw new Error('Failed to load books');
-        }
-
-        const data = await response.json();
-        setBooks(data.books || data);
-        setTotalPages(data.totalPages || 1);
-        setTotalBooks(data.totalBooks || (data.books || data).length);
-      } catch (err) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadBooks();
-  }, [currentPage, apiGenre, activeSort, searchQuery]);
-
-  // ── Client-side filter on fetched page ───────────────────────────────
-  // Applied after the fetch so server pagination stays accurate for genre/search/sort.
-  // Price and rating filters narrow the displayed results within the current page.
-  const displayedBooks = useMemo(() => {
-    let result = books;
-
-    // Multi-genre: if more than one genre is checked, filter the fetched batch
-    if (selectedGenres.length > 1) {
-      result = result.filter(b => selectedGenres.includes(b.genre));
-    }
-
-    if (minPrice !== '') {
-      result = result.filter(b => b.price >= Number(minPrice));
-    }
-
-    if (maxPrice !== '') {
-      result = result.filter(b => b.price <= Number(maxPrice));
-    }
-
-    if (minRating !== null) {
-      result = result.filter(b => b.rating >= minRating);
-    }
-
-    return result;
-  }, [books, selectedGenres, minPrice, maxPrice, minRating]);
-
-  // ── Render ────────────────────────────────────────────────────────────
   return (
     <>
       <Hero />
       <main className="catalog" id="catalog">
         <div className="catalog__inner">
 
-          {/* Page title + book count */}
           <div className="catalog__header">
             <h2 className="catalog__title">{t('home.featuredTitle')}</h2>
-            <p className="catalog__count">{t('home.titlesTotal', { count: totalBooks })}</p>
+            {/* Counts the filtered set, because the server counted it. */}
+            <p className="catalog__count">
+              {t('home.titlesTotal', { count: totalBooks })}
+            </p>
           </div>
 
-          {/* Two-column layout: sidebar | grid */}
           <div className="catalog__layout">
 
-            {/* ── Left: filter sidebar ─────────────────────── */}
             <FilterSidebar
               genres={ALL_GENRES}
               selectedGenres={selectedGenres}
@@ -165,19 +125,17 @@ export default function Home({ searchQuery: searchQueryProp }) {
               onMinRatingChange={setMinRating}
               onClearFilters={handleClearFilters}
               isOpen={sidebarOpen}
-              onToggle={() => setSidebarOpen(o => !o)}
+              onToggle={() => setSidebarOpen((open) => !open)}
             />
 
-            {/* ── Right: sort bar + grid + pagination ─────── */}
             <div className="catalog__grid-container">
 
-              {/* Sort dropdown */}
               <div className="catalog__controls">
                 <select
                   id="sort-select"
                   className="catalog__sort-select"
                   value={activeSort}
-                  onChange={(e) => { setActiveSort(e.target.value); setCurrentPage(1); }}
+                  onChange={(event) => setActiveSort(event.target.value)}
                   aria-label={t('home.sortAriaLabel')}
                 >
                   <option value="">{t('home.sortDefault')}</option>
@@ -188,16 +146,15 @@ export default function Home({ searchQuery: searchQueryProp }) {
                 </select>
               </div>
 
-              {/* Active filter tags */}
-              {hasActiveFilters && (
+              {filtersActive && (
                 <div className="catalog__filter-summary">
                   <span>Active filters:</span>
-                  {selectedGenres.map(g => (
-                    <span key={g} className="catalog__filter-tag">
-                      {g}
+                  {selectedGenres.map((genre) => (
+                    <span key={genre} className="catalog__filter-tag">
+                      {genre}
                       <button
-                        onClick={() => handleGenreChange(g, false)}
-                        aria-label={`Remove ${g} filter`}
+                        onClick={() => handleGenreChange(genre, false)}
+                        aria-label={`Remove ${genre} filter`}
                       >✕</button>
                     </span>
                   ))}
@@ -225,19 +182,22 @@ export default function Home({ searchQuery: searchQueryProp }) {
                 </div>
               )}
 
-              {/* Books grid */}
               {loading ? (
                 <div className="catalog__grid">
-                  <SkeletonLoader variant="card" count={4} />
+                  <SkeletonLoader variant="card" count={PAGE_SIZE} />
                 </div>
               ) : error ? (
-                <p style={{ textAlign: 'center', padding: '2rem 0', color: 'var(--leather)' }}>
-                  {t('home.errorLoading')}
-                </p>
-              ) : displayedBooks.length === 0 ? (
+                <div className="catalog__empty">
+                  <h3>{t('home.errorLoading')}</h3>
+                  <p className="catalog__error-detail">{error}</p>
+                  <button className="catalog__empty-btn" onClick={reload}>
+                    Try again
+                  </button>
+                </div>
+              ) : books.length === 0 ? (
                 <div className="catalog__empty">
                   <h3>{t('home.noBooksFound')}</h3>
-                  {hasActiveFilters && (
+                  {filtersActive && (
                     <button className="catalog__empty-btn" onClick={handleClearFilters}>
                       Clear filters
                     </button>
@@ -246,14 +206,16 @@ export default function Home({ searchQuery: searchQueryProp }) {
               ) : (
                 <>
                   <div className="catalog__grid">
-                    {displayedBooks.map((book) => (
+                    {books.map((book) => (
                       <BookCard key={book.id} book={book} />
                     ))}
                   </div>
+                  {/* totalPages describes the filtered set now, so the pager
+                      no longer offers pages that render empty. */}
                   <Pagination
                     currentPage={currentPage}
                     totalPages={totalPages}
-                    onPageChange={setCurrentPage}
+                    onPageChange={handlePageChange}
                   />
                 </>
               )}

--- a/bookshelf-frontend/src/pages/Home.test.jsx
+++ b/bookshelf-frontend/src/pages/Home.test.jsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, options) =>
+      key === 'home.titlesTotal' ? `${options?.count ?? 0} titles total` : key,
+  }),
+}));
+
+vi.mock('../components/Hero.jsx', () => ({ default: () => <div /> }));
+vi.mock('../components/SkeletonLoader.jsx', () => ({
+  default: () => <div data-testid="skeleton" />,
+}));
+vi.mock('../components/BookCard.jsx', () => ({
+  default: ({ book }) => <div data-testid="book-card">{book.title}</div>,
+}));
+
+import { CartProvider } from '../context/CartContext.jsx';
+import { WishlistContext } from '../context/WishlistContext.jsx';
+import Home from './Home.jsx';
+
+const wishlist = {
+  wishlist: [],
+  loading: false,
+  count: 0,
+  isWishlisted: () => false,
+  toggleWishlist: vi.fn(),
+};
+
+const CATALOGUE = [
+  { id: 'b1', title: 'The Quiet Ones', genre: 'Fiction', price: 349, rating: 4.5, inventory: 8 },
+  { id: 'b2', title: 'Field Notes', genre: 'Self-Help', price: 299, rating: 4.2, inventory: 10 },
+  { id: 'b5', title: 'Low Tide', genre: 'Poetry', price: 249, rating: 4.1, inventory: 6 },
+  { id: 'b7', title: 'Paper Trail', genre: 'Mystery', price: 199, rating: 3.9, inventory: 4 },
+];
+
+/**
+ * A stand-in for the backend's queryBooks(): filter the whole catalogue,
+ * then paginate. The point of these tests is that the page asks the server
+ * for the right thing and trusts what comes back, so the stand-in has to
+ * behave like the real one.
+ */
+function fakeApi(url) {
+  const params = new URL(url, 'http://localhost').searchParams;
+
+  const minPrice = params.get('minPrice');
+  const maxPrice = params.get('maxPrice');
+  const minRating = params.get('minRating');
+  const genres = params.getAll('genre');
+  const search = params.get('search');
+
+  let filtered = CATALOGUE.filter((book) => {
+    if (minPrice !== null && book.price < Number(minPrice)) return false;
+    if (maxPrice !== null && book.price > Number(maxPrice)) return false;
+    if (minRating !== null && book.rating < Number(minRating)) return false;
+    if (genres.length > 0 && !genres.includes(book.genre)) return false;
+    if (search && !book.title.toLowerCase().includes(search.toLowerCase())) return false;
+    return true;
+  });
+
+  const limit = Number(params.get('limit')) || 4;
+  const page = Number(params.get('page')) || 1;
+  const totalPages = filtered.length === 0 ? 0 : Math.ceil(filtered.length / limit);
+
+  return {
+    ok: true,
+    status: 200,
+    json: () =>
+      Promise.resolve({
+        books: filtered.slice((page - 1) * limit, page * limit),
+        page,
+        limit,
+        totalBooks: filtered.length,
+        totalPages,
+        hasNextPage: page < totalPages,
+        hasPrevPage: page > 1,
+      }),
+  };
+}
+
+function renderHome() {
+  return render(
+    <MemoryRouter>
+      <WishlistContext.Provider value={wishlist}>
+        <CartProvider>
+          <Home searchQuery="" />
+        </CartProvider>
+      </WishlistContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+const titles = () =>
+  screen.queryAllByTestId('book-card').map((card) => card.textContent);
+
+describe('Home catalogue', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    globalThis.fetch = vi.fn((url) => Promise.resolve(fakeApi(url)));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lists the catalogue', async () => {
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+  });
+
+  it('finds a cheap book that is not on the first page', async () => {
+    // The reported symptom: with 4-per-page and client-side filtering, "Max
+    // ₹250" showed "No books found." while a ₹249 book sat on page 2.
+    const user = userEvent.setup();
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    await user.type(screen.getByLabelText('Maximum price in rupees'), '250');
+
+    await waitFor(() => expect(titles()).toEqual(['Low Tide', 'Paper Trail']));
+    expect(screen.queryByText('home.noBooksFound')).not.toBeInTheDocument();
+  });
+
+  it('counts the filtered set, not the whole catalogue', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    await user.type(screen.getByLabelText('Maximum price in rupees'), '250');
+
+    // The header used to read "16 titles total" above a single card.
+    await waitFor(() =>
+      expect(screen.getByText('2 titles total')).toBeInTheDocument()
+    );
+  });
+
+  it('asks the API for every checked genre', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    await user.click(screen.getByLabelText('Fiction'));
+    await user.click(screen.getByLabelText('Mystery'));
+
+    await waitFor(() => {
+      const url = globalThis.fetch.mock.calls.at(-1)[0];
+      expect(url).toContain('genre=Fiction&genre=Mystery');
+    });
+    await waitFor(() => expect(titles()).toEqual(['The Quiet Ones', 'Paper Trail']));
+  });
+
+  it('returns to page 1 when a filter changes', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    // A price filter used to leave the reader stranded on a page number that
+    // no longer existed, and the API answers a page past the end with an
+    // empty slice rather than an error — so the symptom was a blank grid.
+    await user.type(screen.getByLabelText('Minimum price in rupees'), '100');
+
+    await waitFor(() => {
+      const url = globalThis.fetch.mock.calls.at(-1)[0];
+      expect(url).toContain('page=1');
+    });
+  });
+
+  it('offers a retry when the catalogue fails to load', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    globalThis.fetch
+      .mockRejectedValueOnce(new Error('Network down'))
+      .mockImplementation((url) => Promise.resolve(fakeApi(url)));
+
+    const user = userEvent.setup();
+    renderHome();
+
+    expect(await screen.findByText('home.errorLoading')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+    await waitFor(() => expect(titles()).toHaveLength(4));
+  });
+
+  it('clears every filter at once', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    await user.click(screen.getByLabelText('Fiction'));
+    await waitFor(() => expect(titles()).toEqual(['The Quiet Ones']));
+
+    await user.click(screen.getByRole('button', { name: /clear all ✕/i }));
+    await waitFor(() => expect(titles()).toHaveLength(4));
+  });
+});

--- a/bookshelf-frontend/src/utils/catalogQuery.js
+++ b/bookshelf-frontend/src/utils/catalogQuery.js
@@ -1,0 +1,170 @@
+/**
+ * Build the query string for GET /api/books.
+ *
+ * A pure function, deliberately: this is the exact mapping that was missing,
+ * and it is far easier to be sure about as twenty assertions than as a page
+ * that has to be rendered and a fetch that has to be intercepted.
+ *
+ * The bug (#319): Home sent only `page`, `limit`, `genre` and `search`, then
+ * applied price, rating and multi-genre filters to the four books the server
+ * had already paged down to. Filtering after pagination is filtering the
+ * wrong set — the customer asked "books under ₹300" and got "of the four
+ * books on page 1, the ones under ₹300", with the header still claiming
+ * 16 titles and the pager still offering four pages.
+ *
+ * The backend has supported all of this since #274. `utils/bookQuery.js`
+ * parses minPrice, maxPrice, minRating and inStock, `toList()` accepts both
+ * repeated and comma-separated genres, and `queryBooks()` filters, then
+ * sorts, then paginates — so totalBooks and totalPages already describe the
+ * filtered set. The parameters were simply never sent.
+ */
+
+/** Matches DEFAULT_LIMIT in the backend's utils/bookQuery.js. */
+export const DEFAULT_LIMIT = 12;
+
+/** Matches MAX_LIMIT there too. The API rejects anything larger with a 400. */
+export const MAX_LIMIT = 100;
+
+/**
+ * The sentinel the catalogue page uses for "no genre filter". The backend
+ * strips it as well; not sending it at all is one less thing to agree about.
+ */
+const ALL_GENRES = 'all';
+
+function appendIfPresent(params, key, value) {
+  if (value === undefined || value === null || value === '') {
+    return;
+  }
+
+  params.append(key, String(value));
+}
+
+/**
+ * A number, or undefined if the input cannot be one.
+ *
+ * The price inputs are `<input type="number">`, which yields a *string* —
+ * and an empty one when cleared. `Number('')` is 0, so a cleared "Min ₹"
+ * box would otherwise send `minPrice=0` and read as a deliberate filter.
+ */
+function toNumber(value) {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function toPositiveInteger(value, fallback) {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+/**
+ * Normalise the filter state into what the API accepts.
+ *
+ * Returns a plain object as well as the URLSearchParams, so a caller can key
+ * a cache or a dependency array on the normalised shape rather than on five
+ * separate pieces of component state.
+ */
+export function normaliseCatalogFilters(filters = {}) {
+  const {
+    search = '',
+    genres = [],
+    minPrice,
+    maxPrice,
+    minRating,
+    inStock,
+    sort = '',
+    page = 1,
+    limit = DEFAULT_LIMIT,
+  } = filters;
+
+  const cleanGenres = (Array.isArray(genres) ? genres : [genres])
+    .map((genre) => String(genre ?? '').trim())
+    .filter((genre) => genre !== '' && genre.toLowerCase() !== ALL_GENRES);
+
+  let min = toNumber(minPrice);
+  let max = toNumber(maxPrice);
+
+  // The API answers minPrice > maxPrice with a 400. A customer who typed
+  // them the wrong way round meant a range, so read it as one rather than
+  // showing them a validation error about their own typing.
+  if (min !== undefined && max !== undefined && min > max) {
+    [min, max] = [max, min];
+  }
+
+  return {
+    search: String(search ?? '').trim(),
+    genres: cleanGenres,
+    minPrice: min !== undefined && min >= 0 ? min : undefined,
+    maxPrice: max !== undefined && max >= 0 ? max : undefined,
+    minRating: toNumber(minRating),
+    inStock: typeof inStock === 'boolean' ? inStock : undefined,
+    sort: String(sort ?? '').trim(),
+    page: toPositiveInteger(page, 1),
+    limit: Math.min(toPositiveInteger(limit, DEFAULT_LIMIT), MAX_LIMIT),
+  };
+}
+
+/**
+ * The URLSearchParams for a set of filters.
+ *
+ * Genres are appended one at a time rather than joined, because
+ * `?genre=Fiction&genre=Poetry` is what Express hands the backend as an
+ * array. The old page collapsed a multi-select to `genre=All` and filtered
+ * the fetched page in the browser instead.
+ */
+export function buildCatalogQuery(filters = {}) {
+  const normalised = normaliseCatalogFilters(filters);
+  const params = new URLSearchParams();
+
+  params.set('page', String(normalised.page));
+  params.set('limit', String(normalised.limit));
+
+  appendIfPresent(params, 'search', normalised.search);
+
+  for (const genre of normalised.genres) {
+    params.append('genre', genre);
+  }
+
+  appendIfPresent(params, 'minPrice', normalised.minPrice);
+  appendIfPresent(params, 'maxPrice', normalised.maxPrice);
+  appendIfPresent(params, 'minRating', normalised.minRating);
+
+  if (normalised.inStock !== undefined) {
+    params.set('inStock', String(normalised.inStock));
+  }
+
+  appendIfPresent(params, 'sort', normalised.sort);
+
+  return params;
+}
+
+/** Whether anything is narrowing the catalogue right now. */
+export function hasActiveFilters(filters = {}) {
+  const { search, genres, minPrice, maxPrice, minRating, inStock } =
+    normaliseCatalogFilters(filters);
+
+  return (
+    search !== '' ||
+    genres.length > 0 ||
+    minPrice !== undefined ||
+    maxPrice !== undefined ||
+    minRating !== undefined ||
+    inStock !== undefined
+  );
+}
+
+export default {
+  DEFAULT_LIMIT,
+  MAX_LIMIT,
+  normaliseCatalogFilters,
+  buildCatalogQuery,
+  hasActiveFilters,
+};

--- a/bookshelf-frontend/src/utils/catalogQuery.test.js
+++ b/bookshelf-frontend/src/utils/catalogQuery.test.js
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_LIMIT,
+  MAX_LIMIT,
+  buildCatalogQuery,
+  hasActiveFilters,
+  normaliseCatalogFilters,
+} from './catalogQuery.js';
+
+const query = (filters) => buildCatalogQuery(filters).toString();
+
+describe('buildCatalogQuery', () => {
+  it('always sends page and limit', () => {
+    expect(query({})).toBe(`page=1&limit=${DEFAULT_LIMIT}`);
+  });
+
+  it('sends the price filters the old page applied in the browser', () => {
+    // This is the whole bug: minPrice and maxPrice were never in the request.
+    const params = buildCatalogQuery({ minPrice: 100, maxPrice: 250 });
+    expect(params.get('minPrice')).toBe('100');
+    expect(params.get('maxPrice')).toBe('250');
+  });
+
+  it('sends minRating', () => {
+    expect(buildCatalogQuery({ minRating: 4 }).get('minRating')).toBe('4');
+  });
+
+  it('sends each genre as a repeated parameter, which Express reads as an array', () => {
+    const params = buildCatalogQuery({ genres: ['Fiction', 'Poetry'] });
+    expect(params.getAll('genre')).toEqual(['Fiction', 'Poetry']);
+    // The old page collapsed a multi-select to genre=All and filtered locally.
+    expect(params.get('genre')).not.toBe('All');
+  });
+
+  it('omits the All sentinel entirely', () => {
+    expect(buildCatalogQuery({ genres: ['All'] }).getAll('genre')).toEqual([]);
+    expect(buildCatalogQuery({ genres: ['all'] }).getAll('genre')).toEqual([]);
+  });
+
+  it('drops blank genres rather than sending genre=', () => {
+    expect(buildCatalogQuery({ genres: ['', '  ', 'Fiction'] }).getAll('genre')).toEqual([
+      'Fiction',
+    ]);
+  });
+
+  it('does not send a cleared price box as zero', () => {
+    // <input type="number"> yields '' when cleared, and Number('') is 0 —
+    // which the API would read as a deliberate "at least ₹0" filter.
+    const params = buildCatalogQuery({ minPrice: '', maxPrice: '' });
+    expect(params.has('minPrice')).toBe(false);
+    expect(params.has('maxPrice')).toBe(false);
+  });
+
+  it('accepts the string values the number inputs actually produce', () => {
+    expect(buildCatalogQuery({ minPrice: '100' }).get('minPrice')).toBe('100');
+  });
+
+  it('ignores a price that is not a number', () => {
+    expect(buildCatalogQuery({ minPrice: 'cheap' }).has('minPrice')).toBe(false);
+  });
+
+  it('swaps a reversed range instead of letting the API 400 it', () => {
+    const params = buildCatalogQuery({ minPrice: 500, maxPrice: 100 });
+    expect(params.get('minPrice')).toBe('100');
+    expect(params.get('maxPrice')).toBe('500');
+  });
+
+  it('trims the search term and omits an empty one', () => {
+    expect(buildCatalogQuery({ search: '  quiet ' }).get('search')).toBe('quiet');
+    expect(buildCatalogQuery({ search: '   ' }).has('search')).toBe(false);
+  });
+
+  it('sends inStock only when it is a real boolean', () => {
+    expect(buildCatalogQuery({ inStock: true }).get('inStock')).toBe('true');
+    expect(buildCatalogQuery({ inStock: false }).get('inStock')).toBe('false');
+    expect(buildCatalogQuery({ inStock: null }).has('inStock')).toBe(false);
+    expect(buildCatalogQuery({}).has('inStock')).toBe(false);
+  });
+
+  it('omits an empty sort rather than sending sort=', () => {
+    expect(buildCatalogQuery({ sort: '' }).has('sort')).toBe(false);
+    expect(buildCatalogQuery({ sort: 'price_asc' }).get('sort')).toBe('price_asc');
+  });
+
+  it('clamps the limit to what the API accepts', () => {
+    expect(buildCatalogQuery({ limit: 500 }).get('limit')).toBe(String(MAX_LIMIT));
+    expect(buildCatalogQuery({ limit: 0 }).get('limit')).toBe(String(DEFAULT_LIMIT));
+    expect(buildCatalogQuery({ limit: 2.5 }).get('limit')).toBe(String(DEFAULT_LIMIT));
+  });
+
+  it('falls back to page 1 for a nonsensical page', () => {
+    expect(buildCatalogQuery({ page: 0 }).get('page')).toBe('1');
+    expect(buildCatalogQuery({ page: -3 }).get('page')).toBe('1');
+    expect(buildCatalogQuery({ page: 'two' }).get('page')).toBe('1');
+  });
+
+  it('builds a complete query with everything set at once', () => {
+    const params = buildCatalogQuery({
+      search: 'quiet',
+      genres: ['Fiction', 'Mystery'],
+      minPrice: 100,
+      maxPrice: 400,
+      minRating: 4,
+      inStock: true,
+      sort: 'price_asc',
+      page: 2,
+      limit: 4,
+    });
+
+    expect(Object.fromEntries(params)).toMatchObject({
+      page: '2',
+      limit: '4',
+      search: 'quiet',
+      minPrice: '100',
+      maxPrice: '400',
+      minRating: '4',
+      inStock: 'true',
+      sort: 'price_asc',
+    });
+    expect(params.getAll('genre')).toEqual(['Fiction', 'Mystery']);
+  });
+});
+
+describe('normaliseCatalogFilters', () => {
+  it('accepts a single genre string as well as an array', () => {
+    expect(normaliseCatalogFilters({ genres: 'Fiction' }).genres).toEqual(['Fiction']);
+  });
+
+  it('is stable, so it can key a dependency array', () => {
+    const a = normaliseCatalogFilters({ search: ' x ', page: '3' });
+    const b = normaliseCatalogFilters({ search: 'x', page: 3 });
+    expect(a).toEqual(b);
+  });
+});
+
+describe('hasActiveFilters', () => {
+  it('is false for an untouched catalogue', () => {
+    expect(hasActiveFilters({})).toBe(false);
+    expect(hasActiveFilters({ genres: ['All'], minPrice: '', minRating: null })).toBe(false);
+  });
+
+  it('is true for each filter on its own', () => {
+    expect(hasActiveFilters({ search: 'quiet' })).toBe(true);
+    expect(hasActiveFilters({ genres: ['Fiction'] })).toBe(true);
+    expect(hasActiveFilters({ minPrice: 100 })).toBe(true);
+    expect(hasActiveFilters({ maxPrice: 100 })).toBe(true);
+    expect(hasActiveFilters({ minRating: 4 })).toBe(true);
+    expect(hasActiveFilters({ inStock: true })).toBe(true);
+  });
+
+  it('does not count sort or pagination as a filter', () => {
+    expect(hasActiveFilters({ sort: 'price_asc', page: 3, limit: 4 })).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #319.

## The bug

`Home.jsx` fetched a page of four books, then filtered *those four* in the browser:

```js
const params = new URLSearchParams({ page, limit, genre: apiGenre, search: searchQuery, … });
// …
const displayedBooks = useMemo(() => {
  let result = books;                                     // the 4 on this page
  if (minPrice !== '') result = result.filter(b => b.price >= Number(minPrice));
  // …
}, [books, selectedGenres, minPrice, maxPrice, minRating]);
```

Filtering after pagination is filtering the wrong set. The customer asked for "books under ₹300"; what they got was "of the four books that happen to be on page 1, the ones under ₹300".

| Symptom | Cause |
|---|---|
| "Max ₹250" → **No books found.** while a ₹249 book sits on page 2 | filter applied to the current page only |
| Header reads "16 titles total" above one card | `totalBooks` from the *unfiltered* response |
| Pager offers 4 pages, most render empty | `totalPages` unfiltered too |
| Changing a price filter shows a blank grid | price/rating missing from the page-reset effect; the API answers a page past the end with an empty slice, not an error |
| Ticking two genres widens the results | `selectedGenres.length === 1 ? selectedGenres[0] : 'All'` |

## The backend already did all of this

`utils/bookQuery.js` has parsed `minPrice`, `maxPrice`, `minRating` and `inStock` since #274; `toList()` accepts both `?genre=A&genre=B` and `?genre=A,B`; and `queryBooks()` filters → sorts → paginates, so `totalBooks` and `totalPages` already describe the filtered set. **The parameters were simply never sent.**

## What this changes

**`utils/catalogQuery.js`** — the parameter mapping, as a pure function. The details that live there and are easy to get wrong:

- a cleared `<input type="number">` yields `''`, and `Number('') === 0` — so an untouched "Min ₹" box would have sent `minPrice=0` and read to the server as a deliberate filter;
- genres are `append`ed one at a time, because that is what Express reads back as an array;
- a reversed range (`min 500, max 100`) is swapped rather than sent for the API to reject with a 400 — someone who typed them backwards still meant a range;
- `limit` is clamped to the backend's `MAX_LIMIT`.

**`hooks/useBookCatalog.js`** — the fetch. Also fixes the search box, which was a direct dependency of the effect: every keystroke fired a request ("mystery" was seven), with no `AbortController` and no sequence check, so a slow response for `myst` could land after `mystery` and overwrite the results with stale ones. `hooks/useDebounce.js` has been in the repo, imported by nothing, since it was added — it is used now, on the free-text box **only**. A checkbox or a select is one deliberate act; delaying those just makes the UI feel broken.

**`Home.jsx`** — no client-side filtering left. Any change to what is being asked for returns to page 1. The failure state is a message plus a **Try again** button, and shows the parameter the API objected to when it names one, instead of a single generic line.

## Tests

38 new tests:

- `utils/catalogQuery.test.js` (21) — every parameter, the `Number('') === 0` trap, the `All` sentinel, reversed ranges, limit clamping.
- `hooks/useBookCatalog.test.jsx` (10) — the filters reach the URL, genres repeat rather than collapse, the debounce fires one request for five keystrokes, a sort is *not* debounced, the in-flight request is aborted, a stale response is dropped, and a 400 surfaces its `parameter`.
- `pages/Home.test.jsx` (7) — end to end against a stand-in that behaves like `queryBooks()` (filter the whole catalogue, *then* paginate). The headline test is the reported symptom: **"Max ₹250" now finds the ₹249 book that was on page 2**, and the header says "2 titles total" rather than "16".

```
npm run test    # 147 passed (was 109)
npm run lint    # clean
npm run build   # clean
```

## Follow-ups, not done here

- The genre list is still the hardcoded `ALL_GENRES` array. `GET /api/books/genres` exists and returns them with counts.
- `inStock` is plumbed through `catalogQuery` and the hook but has no control in `FilterSidebar` yet.
- Filters are not in the URL, so a filtered view still cannot be shared or bookmarked.

## Merges cleanly with the other open PRs

Verified against #320, #321, #322 and #323 in both merge orders. #323 originally added two lines to `pages/Home.jsx`; it has since been restructured so that it touches neither this file nor `BookDetail.jsx`, and no conflict remains. The five branches merged together give 273 passing tests, a clean lint and a clean build.