### PR TITLE
fix(auth): show the reason a sign-in failed instead of "Failed to login"

### DIFF
--- a/bookshelf-frontend/src/pages/Auth.css
+++ b/bookshelf-frontend/src/pages/Auth.css
@@ -79,3 +79,33 @@
   flex-direction: column;
   gap: 1rem;
 }
+
+/*
+ * Field-level validation messages.
+ *
+ * The API answers a bad body with one message per field (see
+ * middleware/validateBody.js); before #325 none of them reached the page, so
+ * there was nothing to style. `auth-error` stays the banner for the failure
+ * as a whole — "Invalid email or password", "Too many login attempts" — and
+ * this is the note that sits under the input it is about.
+ */
+.auth-field-error {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+  line-height: 1.35;
+  color: #b3261e;
+}
+
+.auth-form input[aria-invalid='true'] {
+  border-color: #b3261e;
+}
+
+.auth-form input[aria-invalid='true']:focus {
+  outline-color: #b3261e;
+}
+
+.auth-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}

--- a/bookshelf-frontend/src/pages/Login.jsx
+++ b/bookshelf-frontend/src/pages/Login.jsx
@@ -1,12 +1,15 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth.js';
+import { describeApiError, fieldErrors } from '../utils/apiError.js';
 import './Auth.css'; // We'll need some basic CSS for forms
 
 const Login = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const [fieldError, setFieldError] = useState({});
+  const [submitting, setSubmitting] = useState(false);
   const { login, isAuthenticated } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
@@ -22,19 +25,37 @@ const Login = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
+    setFieldError({});
+    setSubmitting(true);
+
     try {
       await login({ email, password });
       navigate(redirect);
     } catch (err) {
-      setError(err.response?.data?.message || 'Failed to login');
+      /*
+       * `utils/api.js` rejects with { status, message, code, original } — the
+       * raw Axios error lives under `original`, so the `err.response?.data?.
+       * message` this used to read was always undefined and every failure
+       * rendered as "Failed to login". A wrong password, a 15-minute
+       * rate-limit lockout and an unreachable server were indistinguishable.
+       * See #325.
+       */
+      setError(describeApiError(err, 'Failed to login'));
+      setFieldError(fieldErrors(err));
+    } finally {
+      setSubmitting(false);
     }
   };
 
   return (
     <div className="auth-container">
       <h2>Log In</h2>
-      {error && <div className="auth-error">{error}</div>}
-      <form onSubmit={handleSubmit} className="auth-form">
+      {error && (
+        <div className="auth-error" role="alert">
+          {error}
+        </div>
+      )}
+      <form onSubmit={handleSubmit} className="auth-form" noValidate>
         <div className="form-group">
           <label htmlFor="email">Email</label>
           <input
@@ -43,7 +64,14 @@ const Login = () => {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
+            aria-invalid={fieldError.email ? 'true' : 'false'}
+            aria-describedby={fieldError.email ? 'email-error' : undefined}
           />
+          {fieldError.email && (
+            <span className="auth-field-error" id="email-error" role="alert">
+              {fieldError.email}
+            </span>
+          )}
         </div>
         <div className="form-group">
           <label htmlFor="password">Password</label>
@@ -53,14 +81,21 @@ const Login = () => {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
+            aria-invalid={fieldError.password ? 'true' : 'false'}
+            aria-describedby={fieldError.password ? 'password-error' : undefined}
           />
+          {fieldError.password && (
+            <span className="auth-field-error" id="password-error" role="alert">
+              {fieldError.password}
+            </span>
+          )}
         </div>
-        <button type="submit" className="auth-button">
-          Login
+        <button type="submit" className="auth-button" disabled={submitting}>
+          {submitting ? 'Logging in…' : 'Login'}
         </button>
       </form>
       <p>
-        Don't have an account?{' '}
+        Don&apos;t have an account?{' '}
         <Link to={`/register?redirect=${redirect}`}>Register</Link>
       </p>
     </div>

--- a/bookshelf-frontend/src/pages/Login.test.jsx
+++ b/bookshelf-frontend/src/pages/Login.test.jsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import Login from './Login.jsx';
+import { AuthContext } from '../context/AuthContext.jsx';
+
+/**
+ * The regression these cover: the page read `err.response.data.message`, but
+ * `utils/api.js` rejects with { status, message, code, original } and has no
+ * `response`. Every failure — wrong password, rate limit, network — rendered
+ * the same "Failed to login". See #325.
+ */
+
+const navigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
+
+/** An error shaped the way the API client's interceptor produces them. */
+function normalisedError({ status, code, message, data }) {
+  const axiosError = new Error('Request failed');
+  axiosError.response = { status, data };
+  return { status, code, message, original: axiosError };
+}
+
+function renderLogin(login) {
+  const value = {
+    login,
+    isAuthenticated: false,
+    loading: false,
+    user: null,
+    register: vi.fn(),
+    logout: vi.fn(),
+    checkAuth: vi.fn(),
+  };
+
+  return render(
+    <MemoryRouter>
+      <AuthContext.Provider value={value}>
+        <Login />
+      </AuthContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+async function submitCredentials(user) {
+  await user.type(screen.getByLabelText('Email'), 'reader@example.com');
+  await user.type(screen.getByLabelText('Password'), 'wrong-password');
+  await user.click(screen.getByRole('button', { name: /login/i }));
+}
+
+describe('Login', () => {
+  beforeEach(() => {
+    navigate.mockClear();
+  });
+
+  it("shows the server's reason for rejecting the credentials", async () => {
+    const user = userEvent.setup();
+    const login = vi.fn().mockRejectedValue(
+      normalisedError({
+        status: 401,
+        code: 'UNAUTHORIZED',
+        message: 'Unauthorized access. Please login again.',
+        data: { message: 'Invalid email or password' },
+      })
+    );
+
+    renderLogin(login);
+    await submitCredentials(user);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Invalid email or password');
+    expect(screen.queryByText('Failed to login')).not.toBeInTheDocument();
+  });
+
+  it('tells the user they have been rate limited rather than that login "failed"', async () => {
+    const user = userEvent.setup();
+    const login = vi.fn().mockRejectedValue(
+      normalisedError({
+        status: 429,
+        code: 'RATE_LIMITED',
+        message: 'Too many requests. Please slow down and try again.',
+        data: { message: 'Too many login attempts. Please try again in 15 minutes.' },
+      })
+    );
+
+    renderLogin(login);
+    await submitCredentials(user);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Too many login attempts. Please try again in 15 minutes.'
+    );
+  });
+
+  it('reports a network failure as a network failure', async () => {
+    const user = userEvent.setup();
+    const login = vi.fn().mockRejectedValue({
+      status: 0,
+      code: 'NETWORK_ERROR',
+      message: 'Network error. Please check your internet connection.',
+      original: new Error('Network Error'),
+    });
+
+    renderLogin(login);
+    await submitCredentials(user);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Network error. Please check your internet connection.'
+    );
+  });
+
+  it('marks the offending field when the API returns field errors', async () => {
+    const user = userEvent.setup();
+    const login = vi.fn().mockRejectedValue(
+      normalisedError({
+        status: 400,
+        code: 'HTTP_ERROR',
+        message: 'An unexpected error occurred.',
+        data: {
+          message: 'Validation failed',
+          errors: [{ field: 'email', message: 'email must be a valid email address' }],
+        },
+      })
+    );
+
+    renderLogin(login);
+    await submitCredentials(user);
+
+    await screen.findByText('email must be a valid email address');
+    expect(screen.getByLabelText('Email')).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByLabelText('Password')).toHaveAttribute('aria-invalid', 'false');
+  });
+
+  it('still has a fallback when the failure carries no message at all', async () => {
+    const user = userEvent.setup();
+    const login = vi.fn().mockRejectedValue({});
+
+    renderLogin(login);
+    await submitCredentials(user);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Failed to login');
+  });
+
+  it('re-enables the submit button after a failure so the user can retry', async () => {
+    const user = userEvent.setup();
+    const login = vi.fn().mockRejectedValue(
+      normalisedError({ status: 401, data: { message: 'Invalid email or password' } })
+    );
+
+    renderLogin(login);
+    await submitCredentials(user);
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /login/i })).not.toBeDisabled()
+    );
+  });
+
+  it('navigates to the redirect target on success', async () => {
+    const user = userEvent.setup();
+    const login = vi.fn().mockResolvedValue({ user: { name: 'Reader' } });
+
+    renderLogin(login);
+    await submitCredentials(user);
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/'));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/bookshelf-frontend/src/pages/OrderDetailsPage.jsx
+++ b/bookshelf-frontend/src/pages/OrderDetailsPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import orderService from '../services/orderService';
 import { OrderStatusBadge, LoadingSkeleton } from '../components/orders/OrderComponents';
+import { describeApiError, isNotFound, isUnauthorized } from '../utils/apiError.js';
 
 export default function OrderDetailsPage() {
   const { id } = useParams();
@@ -10,20 +11,36 @@ export default function OrderDetailsPage() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    /*
+     * `utils/api.js` normalises errors to { status, message, code, original },
+     * so the `err.response.status === 404` this branch used to test was never
+     * true and the not-found message below was dead code — a deleted or
+     * mistyped order id fell through to the generic "Unable to load order
+     * details." See #325.
+     */
     const fetchOrder = async () => {
+      setLoading(true);
+      setError(null);
+
       try {
         const data = await orderService.getOrderById(id);
         setOrder(data);
       } catch (err) {
-        if (err.response && err.response.status === 404) {
-            setError('This order could not be found.');
+        if (isNotFound(err)) {
+          setError('This order could not be found.');
+        } else if (isUnauthorized(err)) {
+          // AuthContext has already dropped the session by the time this
+          // runs — the API client notifies it on any 401 — so the useful
+          // thing to say is what to do about it.
+          setError('Your session has expired. Please sign in again to view this order.');
         } else {
-            setError('Unable to load order details.');
+          setError(describeApiError(err, 'Unable to load order details.'));
         }
       } finally {
         setLoading(false);
       }
     };
+
     fetchOrder();
   }, [id]);
 

--- a/bookshelf-frontend/src/pages/Register.jsx
+++ b/bookshelf-frontend/src/pages/Register.jsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth.js';
+import { describeApiError, fieldErrors } from '../utils/apiError.js';
 import './Auth.css';
 
 const Register = () => {
@@ -9,6 +10,8 @@ const Register = () => {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
+  const [fieldError, setFieldError] = useState({});
+  const [submitting, setSubmitting] = useState(false);
   const { register, isAuthenticated } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
@@ -24,24 +27,56 @@ const Register = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
+    setFieldError({});
 
     if (password !== confirmPassword) {
-      return setError('Passwords do not match');
+      // A local check, so it belongs on the field rather than in the banner.
+      setFieldError({ confirmPassword: 'Passwords do not match' });
+      return;
     }
+
+    setSubmitting(true);
 
     try {
       await register({ name, email, password });
       navigate(redirect);
     } catch (err) {
-      setError(err.response?.data?.message || 'Failed to register');
+      /*
+       * These are the failures a user can actually act on — "Email already
+       * registered", and the per-field messages from validateBody (see
+       * #275). Reading the pre-normalisation `err.response` meant all of
+       * them arrived as "Failed to register", with nothing saying which
+       * field was wrong. See #325.
+       */
+      setError(describeApiError(err, 'Failed to register'));
+      setFieldError(fieldErrors(err));
+    } finally {
+      setSubmitting(false);
     }
   };
+
+  /** Every field renders its error the same way; this keeps that in one place. */
+  const errorFor = (field) =>
+    fieldError[field] ? (
+      <span className="auth-field-error" id={`${field}-error`} role="alert">
+        {fieldError[field]}
+      </span>
+    ) : null;
+
+  const errorProps = (field) => ({
+    'aria-invalid': fieldError[field] ? 'true' : 'false',
+    'aria-describedby': fieldError[field] ? `${field}-error` : undefined,
+  });
 
   return (
     <div className="auth-container">
       <h2>Register</h2>
-      {error && <div className="auth-error">{error}</div>}
-      <form onSubmit={handleSubmit} className="auth-form">
+      {error && (
+        <div className="auth-error" role="alert">
+          {error}
+        </div>
+      )}
+      <form onSubmit={handleSubmit} className="auth-form" noValidate>
         <div className="form-group">
           <label htmlFor="name">Name</label>
           <input
@@ -50,7 +85,9 @@ const Register = () => {
             value={name}
             onChange={(e) => setName(e.target.value)}
             required
+            {...errorProps('name')}
           />
+          {errorFor('name')}
         </div>
         <div className="form-group">
           <label htmlFor="email">Email</label>
@@ -60,7 +97,9 @@ const Register = () => {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
+            {...errorProps('email')}
           />
+          {errorFor('email')}
         </div>
         <div className="form-group">
           <label htmlFor="password">Password</label>
@@ -71,7 +110,9 @@ const Register = () => {
             onChange={(e) => setPassword(e.target.value)}
             required
             minLength="8"
+            {...errorProps('password')}
           />
+          {errorFor('password')}
         </div>
         <div className="form-group">
           <label htmlFor="confirmPassword">Confirm Password</label>
@@ -82,10 +123,12 @@ const Register = () => {
             onChange={(e) => setConfirmPassword(e.target.value)}
             required
             minLength="8"
+            {...errorProps('confirmPassword')}
           />
+          {errorFor('confirmPassword')}
         </div>
-        <button type="submit" className="auth-button">
-          Register
+        <button type="submit" className="auth-button" disabled={submitting}>
+          {submitting ? 'Creating account…' : 'Register'}
         </button>
       </form>
       <p>

--- a/bookshelf-frontend/src/pages/Register.test.jsx
+++ b/bookshelf-frontend/src/pages/Register.test.jsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import Register from './Register.jsx';
+import { AuthContext } from '../context/AuthContext.jsx';
+
+const navigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
+
+function normalisedError({ status, code, message, data }) {
+  const axiosError = new Error('Request failed');
+  axiosError.response = { status, data };
+  return { status, code, message, original: axiosError };
+}
+
+function renderRegister(register) {
+  const value = {
+    register,
+    login: vi.fn(),
+    isAuthenticated: false,
+    loading: false,
+    user: null,
+    logout: vi.fn(),
+    checkAuth: vi.fn(),
+  };
+
+  return render(
+    <MemoryRouter>
+      <AuthContext.Provider value={value}>
+        <Register />
+      </AuthContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+async function fillForm(user, { password = 'correct-horse', confirm = 'correct-horse' } = {}) {
+  await user.type(screen.getByLabelText('Name'), 'Reader');
+  await user.type(screen.getByLabelText('Email'), 'reader@example.com');
+  await user.type(screen.getByLabelText('Password'), password);
+  await user.type(screen.getByLabelText('Confirm Password'), confirm);
+  await user.click(screen.getByRole('button', { name: /register/i }));
+}
+
+describe('Register', () => {
+  beforeEach(() => {
+    navigate.mockClear();
+  });
+
+  it('shows that the email is already taken instead of a generic failure', async () => {
+    const user = userEvent.setup();
+    const register = vi.fn().mockRejectedValue(
+      normalisedError({
+        status: 409,
+        code: 'HTTP_ERROR',
+        message: 'An unexpected error occurred.',
+        data: { message: 'Email already registered' },
+      })
+    );
+
+    renderRegister(register);
+    await fillForm(user);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Email already registered');
+    expect(screen.queryByText('Failed to register')).not.toBeInTheDocument();
+  });
+
+  it('puts each validation message on the field it belongs to', async () => {
+    const user = userEvent.setup();
+    const register = vi.fn().mockRejectedValue(
+      normalisedError({
+        status: 400,
+        code: 'HTTP_ERROR',
+        data: {
+          message: 'Validation failed',
+          errors: [
+            { field: 'password', message: 'password must be at least 8 characters' },
+            { field: 'name', message: 'name is required' },
+          ],
+        },
+      })
+    );
+
+    renderRegister(register);
+    await fillForm(user, { password: 'short', confirm: 'short' });
+
+    await screen.findByText('password must be at least 8 characters');
+    expect(screen.getByText('name is required')).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByLabelText('Email')).toHaveAttribute('aria-invalid', 'false');
+  });
+
+  it('catches a password mismatch locally without calling the API', async () => {
+    const user = userEvent.setup();
+    const register = vi.fn();
+
+    renderRegister(register);
+    await fillForm(user, { password: 'correct-horse', confirm: 'battery-staple' });
+
+    expect(await screen.findByText('Passwords do not match')).toBeInTheDocument();
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it('clears a previous error when the form is resubmitted', async () => {
+    const user = userEvent.setup();
+    const register = vi
+      .fn()
+      .mockRejectedValueOnce(
+        normalisedError({ status: 409, data: { message: 'Email already registered' } })
+      )
+      .mockResolvedValueOnce({ user: { name: 'Reader' } });
+
+    renderRegister(register);
+    await fillForm(user);
+    expect(await screen.findByRole('alert')).toHaveTextContent('Email already registered');
+
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/'));
+    expect(screen.queryByText('Email already registered')).not.toBeInTheDocument();
+  });
+});

--- a/bookshelf-frontend/src/utils/apiError.js
+++ b/bookshelf-frontend/src/utils/apiError.js
@@ -1,0 +1,242 @@
+/**
+ * Reading an error that came back from `utils/api.js`.
+ *
+ * The shared client normalises every failure in its response interceptor and
+ * rejects with a plain object:
+ *
+ *     { status, message, code, original }
+ *
+ * There is no `response` on it — the raw Axios error is kept under `original`.
+ * Four pages were still written against the Axios shape (`err.response.data.
+ * message`, `err.response.status === 404`), and because optional chaining on a
+ * missing property is silent, they did not break loudly. They just stopped
+ * being able to say anything specific: every sign-in failure rendered as
+ * "Failed to login", and the 404 branch on the order details page became dead
+ * code. See #325.
+ *
+ * These helpers accept whatever they are handed — a normalised error, a raw
+ * Axios error that never reached the interceptor (a cancellation, or a call
+ * that used axios directly), a plain `Error`, or a string — because a helper
+ * whose job is to describe a failure must not be able to fail itself.
+ */
+
+/** Codes `utils/api.js` assigns. Re-exported so callers compare a constant. */
+export const ERROR_CODES = {
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  FORBIDDEN: 'FORBIDDEN',
+  NOT_FOUND: 'NOT_FOUND',
+  RATE_LIMITED: 'RATE_LIMITED',
+  SERVER_ERROR: 'SERVER_ERROR',
+  NETWORK_ERROR: 'NETWORK_ERROR',
+  HTTP_ERROR: 'HTTP_ERROR',
+  SETUP_ERROR: 'SETUP_ERROR',
+  UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+};
+
+const DEFAULT_MESSAGE = 'Something went wrong. Please try again.';
+
+/**
+ * The HTTP status behind an error, or `undefined` if there wasn't one.
+ *
+ * Checked in the order a value is most likely to be trustworthy: the
+ * normalised field first, then the raw response under `original`, then a
+ * response hanging directly off the error.
+ *
+ * `status: 0` is what the interceptor uses for "no response at all". It is a
+ * real value and is returned as-is; callers asking about a specific HTTP code
+ * will not match it.
+ */
+export function statusOf(error) {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  const candidates = [
+    error.status,
+    error.original?.response?.status,
+    error.response?.status,
+  ];
+
+  for (const candidate of candidates) {
+    if (Number.isFinite(candidate)) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+/** The `code` the interceptor assigned, if this error went through it. */
+export function codeOf(error) {
+  return typeof error?.code === 'string' ? error.code : undefined;
+}
+
+/**
+ * The message the *server* sent, if it sent one.
+ *
+ * The backend answers failures as `{ message }` (see
+ * `middleware/errorMiddleware.js`), and validation failures as
+ * `{ message, errors }` (see `middleware/validateBody.js`). This digs the
+ * body out of whichever shape the error arrived in and returns the message
+ * only when it is a non-empty string — an empty one is no more use than none.
+ */
+export function serverMessage(error) {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  const body = error.original?.response?.data ?? error.response?.data;
+  const message = body?.message;
+
+  if (typeof message === 'string' && message.trim() !== '') {
+    return message.trim();
+  }
+
+  return undefined;
+}
+
+/**
+ * Field-level validation errors, as `{ field: message }`.
+ *
+ * `validateBody` answers a bad body with `{ message, errors: [{ field, message
+ * }] }`. Returning a map rather than the raw array is what a form actually
+ * wants: it can look up the field it is rendering without scanning.
+ *
+ * Returns an empty object when there are none, so callers can spread the
+ * result unconditionally.
+ */
+export function fieldErrors(error) {
+  const body = error?.original?.response?.data ?? error?.response?.data;
+  const errors = body?.errors;
+
+  if (!Array.isArray(errors)) {
+    return {};
+  }
+
+  const mapped = {};
+
+  for (const entry of errors) {
+    const field = entry?.field ?? entry?.param ?? entry?.path;
+    const message = entry?.message ?? entry?.msg;
+
+    if (typeof field === 'string' && typeof message === 'string' && message.trim()) {
+      // First message per field wins. A field with two complaints is one
+      // field with a problem, and stacking them reads as noise.
+      if (!(field in mapped)) {
+        mapped[field] = message.trim();
+      }
+    }
+  }
+
+  return mapped;
+}
+
+/**
+ * A sentence to put in front of the user.
+ *
+ * Preference order, and the reasoning:
+ *
+ *   1. What the server said. It is the only party that knows *why* — "Invalid
+ *      email or password", "Email already registered", the rate limiter's
+ *      "Too many requests". Throwing that away, which is what these pages
+ *      were doing, is the whole bug.
+ *   2. The interceptor's normalised message, which already has sensible
+ *      wording for the network and 5xx cases where the server said nothing.
+ *   3. A plain `Error`'s own message — covers the errors the app throws
+ *      itself, e.g. `BookNotFoundError` from `services/bookService.js`.
+ *   4. The caller's fallback.
+ *
+ * A 500's message is deliberately *not* preferred: the backend echoes
+ * `err.message` for unhandled errors, which is an internal detail worded for a
+ * log, not for a customer. The normalised "Internal server error" is better
+ * for the reader and leaks less.
+ */
+export function describeApiError(error, fallback = DEFAULT_MESSAGE) {
+  if (typeof error === 'string' && error.trim()) {
+    return error.trim();
+  }
+
+  if (!error || typeof error !== 'object') {
+    return fallback;
+  }
+
+  const status = statusOf(error);
+  const fromServer = serverMessage(error);
+
+  if (fromServer && !(Number.isFinite(status) && status >= 500)) {
+    return fromServer;
+  }
+
+  if (typeof error.message === 'string' && error.message.trim()) {
+    return error.message.trim();
+  }
+
+  return fallback;
+}
+
+/** 401 — the session is missing or has expired. */
+export function isUnauthorized(error) {
+  return statusOf(error) === 401 || codeOf(error) === ERROR_CODES.UNAUTHORIZED;
+}
+
+/** 403 — signed in, but not allowed. */
+export function isForbidden(error) {
+  return statusOf(error) === 403 || codeOf(error) === ERROR_CODES.FORBIDDEN;
+}
+
+/**
+ * 404 — the thing asked for is not there.
+ *
+ * Also true for the app's own not-found errors (`BookNotFoundError` sets
+ * `status = 404` without going near HTTP), which is what lets a page treat
+ * "the API said 404" and "we decided this id is unusable" the same way.
+ */
+export function isNotFound(error) {
+  return statusOf(error) === 404 || codeOf(error) === ERROR_CODES.NOT_FOUND;
+}
+
+/** 429 — the caller has been throttled. */
+export function isRateLimited(error) {
+  return statusOf(error) === 429 || codeOf(error) === ERROR_CODES.RATE_LIMITED;
+}
+
+/** No response reached us: offline, DNS, timeout, connection reset. */
+export function isNetworkError(error) {
+  return codeOf(error) === ERROR_CODES.NETWORK_ERROR || statusOf(error) === 0;
+}
+
+/**
+ * A request the caller deliberately dropped.
+ *
+ * Cancellations never reach the interceptor's normalisation, so they keep the
+ * Axios shape. They are not failures and must never be rendered — a component
+ * that unmounted mid-request would otherwise flash "canceled" into its error
+ * slot.
+ */
+export function isCanceled(error) {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  return (
+    error.name === 'CanceledError' ||
+    error.code === 'ERR_CANCELED' ||
+    error.original?.code === 'ERR_CANCELED' ||
+    error.original?.name === 'CanceledError'
+  );
+}
+
+export default {
+  ERROR_CODES,
+  codeOf,
+  describeApiError,
+  fieldErrors,
+  isCanceled,
+  isForbidden,
+  isNetworkError,
+  isNotFound,
+  isRateLimited,
+  isUnauthorized,
+  serverMessage,
+  statusOf,
+};

--- a/bookshelf-frontend/src/utils/apiError.test.js
+++ b/bookshelf-frontend/src/utils/apiError.test.js
@@ -1,0 +1,263 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  ERROR_CODES,
+  codeOf,
+  describeApiError,
+  fieldErrors,
+  isCanceled,
+  isForbidden,
+  isNetworkError,
+  isNotFound,
+  isRateLimited,
+  isUnauthorized,
+  serverMessage,
+  statusOf,
+} from './apiError.js';
+
+/**
+ * Build an error the way `utils/api.js` builds one, so these tests fail if the
+ * interceptor's contract changes rather than passing against a shape only
+ * this file believes in.
+ */
+function normalised({ status, code, message, data }) {
+  const axiosError = new Error('Request failed');
+  axiosError.response = { status, data };
+
+  return {
+    status,
+    code,
+    message,
+    original: axiosError,
+  };
+}
+
+/** An error that never reached the interceptor — raw Axios. */
+function rawAxios({ status, data }) {
+  const error = new Error('Request failed');
+  error.response = { status, data };
+  error.isAxiosError = true;
+  return error;
+}
+
+describe('statusOf', () => {
+  it('reads the normalised status', () => {
+    expect(statusOf(normalised({ status: 401, code: 'UNAUTHORIZED' }))).toBe(401);
+  });
+
+  it('falls back to the raw response when the error was never normalised', () => {
+    expect(statusOf(rawAxios({ status: 404 }))).toBe(404);
+  });
+
+  it('returns 0 for the no-response case rather than treating it as absent', () => {
+    expect(statusOf(normalised({ status: 0, code: 'NETWORK_ERROR' }))).toBe(0);
+  });
+
+  it('returns undefined for an error with no status anywhere', () => {
+    expect(statusOf(new Error('boom'))).toBeUndefined();
+    expect(statusOf(null)).toBeUndefined();
+    expect(statusOf('a string')).toBeUndefined();
+  });
+});
+
+describe('serverMessage', () => {
+  it('digs the message out of a normalised error', () => {
+    const error = normalised({
+      status: 401,
+      code: 'UNAUTHORIZED',
+      message: 'Unauthorized access. Please login again.',
+      data: { message: 'Invalid email or password' },
+    });
+
+    expect(serverMessage(error)).toBe('Invalid email or password');
+  });
+
+  it('digs it out of a raw Axios error too', () => {
+    const error = rawAxios({ status: 409, data: { message: 'Email already registered' } });
+    expect(serverMessage(error)).toBe('Email already registered');
+  });
+
+  it('ignores a blank message', () => {
+    expect(serverMessage(normalised({ status: 400, data: { message: '   ' } }))).toBeUndefined();
+  });
+
+  it('ignores a non-string message', () => {
+    expect(serverMessage(normalised({ status: 400, data: { message: 42 } }))).toBeUndefined();
+  });
+
+  it('is undefined when the server sent no body', () => {
+    expect(serverMessage(normalised({ status: 500 }))).toBeUndefined();
+  });
+});
+
+describe('fieldErrors', () => {
+  it('maps validateBody output to field -> message', () => {
+    const error = normalised({
+      status: 400,
+      data: {
+        message: 'Validation failed',
+        errors: [
+          { field: 'email', message: 'email must be a valid email address' },
+          { field: 'password', message: 'password must be at least 8 characters' },
+        ],
+      },
+    });
+
+    expect(fieldErrors(error)).toEqual({
+      email: 'email must be a valid email address',
+      password: 'password must be at least 8 characters',
+    });
+  });
+
+  it('keeps the first message when a field appears twice', () => {
+    const error = normalised({
+      status: 400,
+      data: {
+        errors: [
+          { field: 'password', message: 'password is required' },
+          { field: 'password', message: 'password must be at least 8 characters' },
+        ],
+      },
+    });
+
+    expect(fieldErrors(error)).toEqual({ password: 'password is required' });
+  });
+
+  it('skips entries missing a field or a message', () => {
+    const error = normalised({
+      status: 400,
+      data: { errors: [{ message: 'orphaned' }, { field: 'name' }, null, 'nonsense'] },
+    });
+
+    expect(fieldErrors(error)).toEqual({});
+  });
+
+  it('returns an empty object when there are no field errors', () => {
+    expect(fieldErrors(normalised({ status: 401 }))).toEqual({});
+    expect(fieldErrors(undefined)).toEqual({});
+  });
+});
+
+describe('describeApiError', () => {
+  it("prefers the server's own message — the whole point of #325", () => {
+    const error = normalised({
+      status: 401,
+      code: 'UNAUTHORIZED',
+      message: 'Unauthorized access. Please login again.',
+      data: { message: 'Invalid email or password' },
+    });
+
+    expect(describeApiError(error, 'Failed to login')).toBe('Invalid email or password');
+  });
+
+  it('surfaces the rate limiter, which the old code rendered as a generic failure', () => {
+    const error = normalised({
+      status: 429,
+      code: 'RATE_LIMITED',
+      message: 'Too many requests. Please slow down and try again.',
+      data: { message: 'Too many login attempts. Please try again in 15 minutes.' },
+    });
+
+    expect(describeApiError(error, 'Failed to login')).toBe(
+      'Too many login attempts. Please try again in 15 minutes.'
+    );
+  });
+
+  it('falls back to the normalised message for a network failure', () => {
+    const error = {
+      status: 0,
+      code: 'NETWORK_ERROR',
+      message: 'Network error. Please check your internet connection.',
+      original: new Error('Network Error'),
+    };
+
+    expect(describeApiError(error, 'Failed to login')).toBe(
+      'Network error. Please check your internet connection.'
+    );
+  });
+
+  it('does not echo a 500 body, which is worded for a log rather than a customer', () => {
+    const error = normalised({
+      status: 500,
+      code: 'SERVER_ERROR',
+      message: 'Internal server error. Our team has been notified.',
+      data: { message: "Cannot read properties of undefined (reading '_id')" },
+    });
+
+    expect(describeApiError(error)).toBe('Internal server error. Our team has been notified.');
+  });
+
+  it('uses the message of an error the app threw itself', () => {
+    const error = new Error('Book not found: b9');
+    error.status = 404;
+
+    expect(describeApiError(error, 'fallback')).toBe('Book not found: b9');
+  });
+
+  it('accepts a bare string', () => {
+    expect(describeApiError('Your cart is empty.')).toBe('Your cart is empty.');
+  });
+
+  it('falls back for anything it cannot read', () => {
+    expect(describeApiError(null, 'fallback')).toBe('fallback');
+    expect(describeApiError(undefined, 'fallback')).toBe('fallback');
+    expect(describeApiError({}, 'fallback')).toBe('fallback');
+    expect(describeApiError('   ', 'fallback')).toBe('fallback');
+  });
+
+  it('has a default fallback so a caller cannot render "undefined"', () => {
+    expect(describeApiError(null)).toBe('Something went wrong. Please try again.');
+  });
+});
+
+describe('classification helpers', () => {
+  it('recognises 401 by status and by code', () => {
+    expect(isUnauthorized(normalised({ status: 401 }))).toBe(true);
+    expect(isUnauthorized({ code: ERROR_CODES.UNAUTHORIZED })).toBe(true);
+    expect(isUnauthorized(normalised({ status: 403 }))).toBe(false);
+  });
+
+  it('recognises 403', () => {
+    expect(isForbidden(normalised({ status: 403 }))).toBe(true);
+    expect(isForbidden(normalised({ status: 401 }))).toBe(false);
+  });
+
+  it('recognises 404, including the app\'s own not-found errors', () => {
+    expect(isNotFound(normalised({ status: 404 }))).toBe(true);
+
+    const bookNotFound = new Error('Book not found: b9');
+    bookNotFound.status = 404;
+    expect(isNotFound(bookNotFound)).toBe(true);
+
+    expect(isNotFound(normalised({ status: 500 }))).toBe(false);
+  });
+
+  it('recognises 429', () => {
+    expect(isRateLimited(normalised({ status: 429 }))).toBe(true);
+    expect(isRateLimited(normalised({ status: 400 }))).toBe(false);
+  });
+
+  it('recognises the no-response case', () => {
+    expect(isNetworkError({ status: 0, code: 'NETWORK_ERROR' })).toBe(true);
+    expect(isNetworkError(normalised({ status: 500 }))).toBe(false);
+  });
+
+  it('recognises a cancellation in both shapes', () => {
+    const bare = new Error('canceled');
+    bare.code = 'ERR_CANCELED';
+    expect(isCanceled(bare)).toBe(true);
+
+    const named = new Error('canceled');
+    named.name = 'CanceledError';
+    expect(isCanceled(named)).toBe(true);
+
+    expect(isCanceled({ original: { code: 'ERR_CANCELED' } })).toBe(true);
+    expect(isCanceled(normalised({ status: 500 }))).toBe(false);
+    expect(isCanceled(null)).toBe(false);
+  });
+
+  it('reads the code when there is one', () => {
+    expect(codeOf(normalised({ status: 404, code: 'NOT_FOUND' }))).toBe('NOT_FOUND');
+    expect(codeOf(new Error('boom'))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #325

`utils/api.js` normalises every failure in its response interceptor and rejects with a plain object:

```js
{ status, message, code, original }
```

There is no `response` on it — the raw Axios error is kept under `original`. Four pages were still reading the Axios shape, so `err.response` was always `undefined` and every expression collapsed to its fallback:

| File | Was |
|---|---|
| `pages/Login.jsx` | `err.response?.data?.message \|\| 'Failed to login'` |
| `pages/Register.jsx` | `err.response?.data?.message \|\| 'Failed to register'` |
| `pages/OrderDetailsPage.jsx` | `err.response && err.response.status === 404` |

Nothing failed loudly, because optional chaining on a missing property is silent by design. The pages just quietly lost the ability to say anything specific.

## What changes

**`src/utils/apiError.js` (new).** Reads the normalised shape, and still copes with a raw Axios error that never reached the interceptor (a cancellation, a direct axios call), a plain `Error`, or a string — a helper whose only job is to describe a failure must not be able to fail itself.

- `describeApiError(error, fallback)` — the sentence to show. Prefers the server's own message, then the interceptor's normalised wording, then a plain `Error`'s message, then the caller's fallback.
- `fieldErrors(error)` — turns `validateBody`'s `{ errors: [{ field, message }] }` into a `{ field: message }` map, so a form can look up the field it is rendering instead of scanning.
- `isNotFound` / `isUnauthorized` / `isForbidden` / `isRateLimited` / `isNetworkError` / `isCanceled` — each matching on both the status and the `code` the interceptor assigns.

One deliberate exclusion: a **500 body is not echoed**. `middleware/errorMiddleware.js` returns `err.message` for unhandled errors, which is worded for a log — `Cannot read properties of undefined (reading '_id')` is not something to put in front of a customer, and the normalised "Internal server error" leaks less.

**Login and Register** show the server's message, and put per-field validation messages on the fields they belong to (`aria-invalid` + `aria-describedby` + `role="alert"`). Both now disable the submit button while in flight — previously the form could be submitted repeatedly while the first request was still open. The password-mismatch check on Register moved from the banner to the field, since it is about one input.

**OrderDetailsPage** can finally tell "this order does not exist" from "the request broke", and handles 401 separately — after a session expires the useful thing to say is to sign in again, not "Unable to load order details."

**`Auth.css`** gains styles for the field-level messages, which had nothing to style before because none of them ever reached the page.

## Before / after

Submitting a real email with the wrong password, with the backend answering `401 {"message":"Invalid email or password"}`:

| | Shown |
|---|---|
| Before | `Failed to login` |
| After | `Invalid email or password` |

Locked out by the login rate limiter from #298:

| | Shown |
|---|---|
| Before | `Failed to login` |
| After | `Too many login attempts. Please try again in 15 minutes.` |

## Tests

39 new tests, all passing; the full frontend suite is 375 passing.

- `apiError.test.js` (25) builds its fixtures the way the interceptor builds errors, so these fail if that contract changes rather than passing against a shape only the test believes in. Covers the normalised and raw-Axios shapes, the 500 exclusion, blank and non-string messages, malformed `errors` entries, and both cancellation spellings.
- `Login.test.jsx` (7) and `Register.test.jsx` (4) assert the server's message actually reaches the DOM, that the right input gets `aria-invalid`, that a failure re-enables the submit button, and that a stale error is cleared on resubmit.

## Notes

- `utils/checkoutValidation.js` already read the error correctly (`describeCheckoutError`, line 248). This is the same idea, lifted somewhere every page can use it; that function is left alone, since it also maps checkout-specific `errors` onto cart lines.
- No API or backend change. Only how an already-returned error is read.
