### PR TITLE
fix(cart): stop rendering the cart drawer on pages where it is closed

### DIFF
--- a/bookshelf-frontend/src/components/CartDrawer.css
+++ b/bookshelf-frontend/src/components/CartDrawer.css
@@ -1,3 +1,33 @@
+/*
+ * The drawer and its backdrop only exist in the DOM while the cart is open.
+ *
+ * They used to be rendered on every page and hidden with `transform:
+ * translateX(100%)`, which hides a thing from sighted mouse users and from
+ * nobody else — every page carried an aria-modal dialog and a run of
+ * invisible tab stops. See #327.
+ *
+ * That means these cannot animate with a `transition` from a closed state:
+ * there is no closed state to transition from, because the element did not
+ * exist a frame ago. An entry animation gives the same slide-in.
+ */
+@keyframes cart-drawer-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes cart-drawer-slide-in {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
 .cart-drawer-backdrop {
   position: fixed;
   top: 0;
@@ -6,15 +36,9 @@
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.4);
   backdrop-filter: blur(2px);
-  opacity: 0;
-  visibility: hidden;
-  transition: opacity 0.3s ease, visibility 0.3s ease;
-  z-index: 1000;
-}
-
-.cart-drawer-backdrop.is-open {
   opacity: 1;
-  visibility: visible;
+  z-index: 1000;
+  animation: cart-drawer-fade-in 0.3s ease both;
 }
 
 .cart-drawer {
@@ -26,15 +50,27 @@
   height: 100vh;
   background-color: var(--paper);
   box-shadow: -4px 0 24px rgba(0, 0, 0, 0.15);
-  transform: translateX(100%);
-  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+  transform: translateX(0);
   z-index: 1001;
   display: flex;
   flex-direction: column;
+  animation: cart-drawer-slide-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
-.cart-drawer.is-open {
-  transform: translateX(0);
+/*
+ * The drawer takes focus the moment it opens, and it is a panel rather than
+ * a control, so the focus ring on the container itself is noise. Its
+ * children keep theirs.
+ */
+.cart-drawer:focus {
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cart-drawer-backdrop,
+  .cart-drawer {
+    animation-duration: 0.01ms;
+  }
 }
 
 .cart-drawer__header {

--- a/bookshelf-frontend/src/components/CartDrawer.jsx
+++ b/bookshelf-frontend/src/components/CartDrawer.jsx
@@ -1,114 +1,108 @@
-import { useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+
 import { useCart } from '../hooks/useCart.js';
+import { useFocusTrap, useScrollLock } from '../hooks/useFocusTrap.js';
 import './CartDrawer.css';
 
+/**
+ * The cart, as a slide-over dialog.
+ *
+ * This component is mounted by the App layout on every route, and it used to
+ * render its markup unconditionally — open and closed were a CSS distinction
+ * only, with the panel pushed off-screen by a transform. That hid it from
+ * sighted mouse users and from nobody else:
+ *
+ *   - `aria-modal="true"` was on an element present on every page, so a
+ *     screen reader user landed on the site already inside a dialog called
+ *     "Shopping Cart" that they had not opened, with the real page treated
+ *     as background.
+ *   - An off-screen transform does not remove anything from the tab order.
+ *     Tabbing past the footer walked into the invisible drawer — Close, then
+ *     every quantity control, every Remove, then Clear Cart and Proceed to
+ *     Checkout. Focus vanished, and Enter could clear the cart or navigate
+ *     to /checkout from a control the user could not see.
+ *
+ * Nothing renders when the cart is closed. See #327.
+ */
 export default function CartDrawer() {
-  const { cart, isCartOpen, setIsCartOpen, updateQuantity, removeFromCart, clearCart } = useCart();
+  const {
+    cart,
+    isCartOpen,
+    setIsCartOpen,
+    updateQuantity,
+    removeFromCart,
+    clearCart,
+  } = useCart();
   const navigate = useNavigate();
-  const drawerRef = useRef(null);
-  const previousFocusRef = useRef(null);
 
-  const subtotal = cart.reduce((sum, item) => sum + item.price * item.quantity, 0);
+  const closeCart = useCallback(() => setIsCartOpen(false), [setIsCartOpen]);
+
+  const drawerRef = useFocusTrap({ active: isCartOpen, onEscape: closeCart });
+  useScrollLock(isCartOpen);
 
   const handleStartShopping = () => {
-    setIsCartOpen(false);
+    closeCart();
     navigate('/');
   };
 
   const handleCheckout = () => {
-    setIsCartOpen(false);
+    closeCart();
     navigate('/checkout');
   };
 
-  useEffect(() => {
-    if (isCartOpen) {
-      previousFocusRef.current = document.activeElement;
-      
-      const focusableElements = drawerRef.current.querySelectorAll(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      );
-      
-      const firstElement = focusableElements[0];
-      const lastElement = focusableElements[focusableElements.length - 1];
+  if (!isCartOpen) {
+    return null;
+  }
 
-      // Focus the first element (close button usually)
-      if (firstElement) {
-        firstElement.focus();
-      }
+  const subtotal = cart.reduce((sum, item) => {
+    const price = Number(item?.price);
+    const quantity = Number(item?.quantity);
 
-      const handleKeyDown = (e) => {
-        if (e.key === 'Escape') {
-          setIsCartOpen(false);
-          return;
-        }
-
-        if (e.key === 'Tab') {
-          if (focusableElements.length === 0) {
-            e.preventDefault();
-            return;
-          }
-
-          if (e.shiftKey) {
-            if (document.activeElement === firstElement) {
-              e.preventDefault();
-              lastElement.focus();
-            }
-          } else {
-            if (document.activeElement === lastElement) {
-              e.preventDefault();
-              firstElement.focus();
-            }
-          }
-        }
-      };
-
-      document.addEventListener('keydown', handleKeyDown);
-      document.body.style.overflow = 'hidden';
-
-      return () => {
-        document.removeEventListener('keydown', handleKeyDown);
-        document.body.style.overflow = 'unset';
-        if (previousFocusRef.current) {
-          previousFocusRef.current.focus();
-        }
-      };
-    }
-  }, [isCartOpen, setIsCartOpen]);
+    return Number.isFinite(price) && Number.isFinite(quantity)
+      ? sum + price * quantity
+      : sum;
+  }, 0);
 
   return (
     <>
-      <div 
-        className={`cart-drawer-backdrop ${isCartOpen ? 'is-open' : ''}`} 
-        onClick={() => setIsCartOpen(false)} 
-        aria-hidden="true"
-      />
-      
-      <div 
+      <div className="cart-drawer-backdrop is-open" onClick={closeCart} aria-hidden="true" />
+
+      <div
         ref={drawerRef}
-        className={`cart-drawer ${isCartOpen ? 'is-open' : ''}`} 
+        className="cart-drawer is-open"
         role="dialog"
         aria-modal="true"
-        aria-label="Shopping Cart"
+        aria-labelledby="cart-drawer-title"
+        // So the dialog can still receive focus if it somehow contains
+        // nothing focusable; see useFocusTrap.
+        tabIndex={-1}
       >
         <div className="cart-drawer__header">
-          <h2>Your Cart</h2>
-          <button 
-            className="cart-drawer__close" 
-            onClick={() => setIsCartOpen(false)} 
+          <h2 id="cart-drawer-title">Your Cart</h2>
+          <button
+            type="button"
+            className="cart-drawer__close"
+            onClick={closeCart}
             aria-label="Close cart drawer"
           >
             ✕
           </button>
         </div>
-        
+
         <div className="cart-drawer__content">
           {cart.length === 0 ? (
             <div className="cart-drawer__empty">
-              <span className="cart-drawer__empty-icon" role="img" aria-label="Shopping bag">🛍️</span>
+              <span className="cart-drawer__empty-icon" role="img" aria-label="Shopping bag">
+                🛍️
+              </span>
               <h3>Your cart is empty</h3>
               <p>Browse our collection and add your favorite books.</p>
-              <button className="cart-drawer__shop-btn" onClick={handleStartShopping}>
+              <button
+                type="button"
+                className="cart-drawer__shop-btn"
+                onClick={handleStartShopping}
+              >
                 Start Shopping
               </button>
             </div>
@@ -117,30 +111,37 @@ export default function CartDrawer() {
               {cart.map((item) => (
                 <li key={item.id} className="cart-drawer__item">
                   {item.cover && (
-                    <img src={item.cover} alt={`Cover of ${item.title}`} className="cart-item__cover" />
+                    <img
+                      src={item.cover}
+                      alt={`Cover of ${item.title}`}
+                      className="cart-item__cover"
+                    />
                   )}
                   <div className="cart-item__details">
                     <h4 className="cart-item__title">{item.title}</h4>
-                    <p className="cart-item__price">₹{item.price.toFixed(2)}</p>
-                    
+                    <p className="cart-item__price">{formatPrice(item.price)}</p>
+
                     <div className="cart-item__actions">
                       <div className="cart-item__quantity">
-                        <button 
+                        <button
+                          type="button"
                           onClick={() => updateQuantity(item.id, item.quantity - 1)}
                           aria-label={`Decrease quantity of ${item.title}`}
                         >
                           -
                         </button>
                         <span>{item.quantity}</span>
-                        <button 
+                        <button
+                          type="button"
                           onClick={() => updateQuantity(item.id, item.quantity + 1)}
                           aria-label={`Increase quantity of ${item.title}`}
                         >
                           +
                         </button>
                       </div>
-                      
-                      <button 
+
+                      <button
+                        type="button"
                         className="cart-item__remove"
                         onClick={() => removeFromCart(item.id)}
                         aria-label={`Remove ${item.title} from cart`}
@@ -150,7 +151,7 @@ export default function CartDrawer() {
                     </div>
                   </div>
                   <div className="cart-item__subtotal">
-                    ₹{(item.price * item.quantity).toFixed(2)}
+                    {formatPrice(Number(item.price) * Number(item.quantity))}
                   </div>
                 </li>
               ))}
@@ -162,14 +163,18 @@ export default function CartDrawer() {
           <div className="cart-drawer__footer">
             <div className="cart-drawer__subtotal">
               <span>Subtotal</span>
-              <span>₹{subtotal.toFixed(2)}</span>
+              <span>{formatPrice(subtotal)}</span>
             </div>
-            
+
             <div className="cart-drawer__footer-actions">
-              <button className="cart-drawer__clear-btn" onClick={clearCart}>
+              <button type="button" className="cart-drawer__clear-btn" onClick={clearCart}>
                 Clear Cart
               </button>
-              <button className="cart-drawer__checkout-btn" onClick={handleCheckout}>
+              <button
+                type="button"
+                className="cart-drawer__checkout-btn"
+                onClick={handleCheckout}
+              >
                 Proceed to Checkout
               </button>
             </div>
@@ -178,4 +183,19 @@ export default function CartDrawer() {
       </div>
     </>
   );
+}
+
+/**
+ * `item.price.toFixed(2)` threw on anything that was not a number, and a cart
+ * comes out of localStorage — see #309, where one malformed value took the
+ * whole app down. An unusable price renders as an em dash instead.
+ */
+function formatPrice(value) {
+  const amount = Number(value);
+
+  if (!Number.isFinite(amount)) {
+    return '—';
+  }
+
+  return `₹${amount.toFixed(2)}`;
 }

--- a/bookshelf-frontend/src/components/CartDrawer.test.jsx
+++ b/bookshelf-frontend/src/components/CartDrawer.test.jsx
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import CartDrawer from './CartDrawer.jsx';
+import { CartContext } from '../context/CartContext.jsx';
+
+/**
+ * The regression: the drawer rendered unconditionally and was hidden with a
+ * CSS transform, so every page carried an `aria-modal` dialog and a run of
+ * invisible tab stops. See #327.
+ */
+
+const navigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
+
+function makeCart(overrides = {}) {
+  return {
+    cart: [],
+    isCartOpen: false,
+    setIsCartOpen: vi.fn(),
+    addToCart: vi.fn(),
+    removeFromCart: vi.fn(),
+    updateQuantity: vi.fn(),
+    clearCart: vi.fn(),
+    maxQuantity: 10,
+    ...overrides,
+  };
+}
+
+function renderDrawer(value) {
+  return render(
+    <MemoryRouter>
+      <CartContext.Provider value={value}>
+        <button type="button">page button</button>
+        <CartDrawer />
+      </CartContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+const twoItems = [
+  { id: 'b1', title: 'The Quiet Ones', price: 349, quantity: 2 },
+  { id: 'b2', title: 'Field Notes', price: 199, quantity: 1 },
+];
+
+describe('CartDrawer when closed', () => {
+  beforeEach(() => {
+    navigate.mockClear();
+  });
+
+  it('puts no dialog in the accessibility tree', () => {
+    renderDrawer(makeCart({ cart: twoItems }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('leaves no tab stops behind — this was the keyboard trap', () => {
+    renderDrawer(makeCart({ cart: twoItems }));
+
+    // Every control the closed drawer used to leave in the tab order.
+    expect(screen.queryByRole('button', { name: 'Close cart drawer' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Clear Cart' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Proceed to Checkout' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Remove The Quiet Ones from cart' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not lock the page scroll', () => {
+    renderDrawer(makeCart({ cart: twoItems }));
+
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('tabbing past the page content does not land inside the cart', async () => {
+    const user = userEvent.setup();
+    renderDrawer(makeCart({ cart: twoItems }));
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'page button' })).toHaveFocus();
+
+    await user.tab();
+    // Nothing from the drawer to receive it.
+    expect(document.body).toHaveFocus();
+  });
+});
+
+describe('CartDrawer when open', () => {
+  beforeEach(() => {
+    navigate.mockClear();
+  });
+
+  it('renders the dialog with an accessible name', () => {
+    renderDrawer(makeCart({ cart: twoItems, isCartOpen: true }));
+
+    expect(screen.getByRole('dialog', { name: 'Your Cart' })).toBeInTheDocument();
+  });
+
+  it('moves focus into the dialog on open', () => {
+    renderDrawer(makeCart({ cart: twoItems, isCartOpen: true }));
+
+    expect(screen.getByRole('button', { name: 'Close cart drawer' })).toHaveFocus();
+  });
+
+  it('locks the page scroll while open', () => {
+    renderDrawer(makeCart({ cart: twoItems, isCartOpen: true }));
+
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('restores the previous overflow rather than clobbering it with "unset"', () => {
+    document.body.style.overflow = 'scroll';
+
+    const { unmount } = renderDrawer(makeCart({ cart: twoItems, isCartOpen: true }));
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unmount();
+    expect(document.body.style.overflow).toBe('scroll');
+
+    document.body.style.overflow = '';
+  });
+
+  it('closes on Escape', async () => {
+    const user = userEvent.setup();
+    const setIsCartOpen = vi.fn();
+
+    renderDrawer(makeCart({ cart: twoItems, isCartOpen: true, setIsCartOpen }));
+    await user.keyboard('{Escape}');
+
+    expect(setIsCartOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('wraps Tab from the last control back to the first', async () => {
+    const user = userEvent.setup();
+    renderDrawer(makeCart({ cart: [], isCartOpen: true }));
+
+    // Empty cart: Close, then Start Shopping.
+    const close = screen.getByRole('button', { name: 'Close cart drawer' });
+    const shop = screen.getByRole('button', { name: 'Start Shopping' });
+
+    expect(close).toHaveFocus();
+    await user.tab();
+    expect(shop).toHaveFocus();
+    await user.tab();
+    expect(close).toHaveFocus();
+  });
+
+  it('wraps Shift+Tab from the first control back to the last', async () => {
+    const user = userEvent.setup();
+    renderDrawer(makeCart({ cart: [], isCartOpen: true }));
+
+    expect(screen.getByRole('button', { name: 'Close cart drawer' })).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(screen.getByRole('button', { name: 'Start Shopping' })).toHaveFocus();
+  });
+
+  it('trap boundaries follow the cart — the stale-NodeList bug', async () => {
+    const user = userEvent.setup();
+
+    // Rendered with two items, then re-rendered with one, the way removing a
+    // line actually happens. The old trap cached its boundaries on open, so
+    // `lastElement` became a detached node and Shift+Tab went nowhere.
+    const { rerender } = render(
+      <MemoryRouter>
+        <CartContext.Provider value={makeCart({ cart: twoItems, isCartOpen: true })}>
+          <CartDrawer />
+        </CartContext.Provider>
+      </MemoryRouter>
+    );
+
+    rerender(
+      <MemoryRouter>
+        <CartContext.Provider value={makeCart({ cart: [twoItems[0]], isCartOpen: true })}>
+          <CartDrawer />
+        </CartContext.Provider>
+      </MemoryRouter>
+    );
+
+    const checkout = screen.getByRole('button', { name: 'Proceed to Checkout' });
+    checkout.focus();
+    expect(checkout).toHaveFocus();
+
+    // Checkout is the last control; Tab must wrap to Close, not escape.
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Close cart drawer' })).toHaveFocus();
+  });
+
+  it('renders line totals and a subtotal', () => {
+    renderDrawer(makeCart({ cart: twoItems, isCartOpen: true }));
+
+    const list = screen.getByRole('list');
+    // 349 x 2
+    expect(within(list).getByText('₹698.00')).toBeInTheDocument();
+    // 199 x 1 appears twice on that line: as the unit price and as the line
+    // total. Both are correct; the assertion just has to allow for it.
+    expect(within(list).getAllByText('₹199.00')).toHaveLength(2);
+    // 349*2 + 199
+    expect(screen.getByText('₹897.00')).toBeInTheDocument();
+  });
+
+  it('shows an em dash instead of throwing on a malformed price', () => {
+    // A cart is restored from localStorage, so a price can be anything.
+    renderDrawer(
+      makeCart({ cart: [{ id: 'b1', title: 'Broken', price: 'free', quantity: 1 }], isCartOpen: true })
+    );
+
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('closes and navigates to checkout', async () => {
+    const user = userEvent.setup();
+    const setIsCartOpen = vi.fn();
+
+    renderDrawer(makeCart({ cart: twoItems, isCartOpen: true, setIsCartOpen }));
+    await user.click(screen.getByRole('button', { name: 'Proceed to Checkout' }));
+
+    expect(setIsCartOpen).toHaveBeenCalledWith(false);
+    expect(navigate).toHaveBeenCalledWith('/checkout');
+  });
+
+  it('closes when the backdrop is clicked', async () => {
+    const user = userEvent.setup();
+    const setIsCartOpen = vi.fn();
+
+    const { container } = renderDrawer(
+      makeCart({ cart: twoItems, isCartOpen: true, setIsCartOpen })
+    );
+
+    await user.click(container.querySelector('.cart-drawer-backdrop'));
+    expect(setIsCartOpen).toHaveBeenCalledWith(false);
+  });
+});

--- a/bookshelf-frontend/src/components/Navbar.jsx
+++ b/bookshelf-frontend/src/components/Navbar.jsx
@@ -123,10 +123,32 @@ export default function Navbar({ searchQuery, setSearchQuery }) {
         '(prefers-reduced-motion: reduce)'
       )?.matches;
 
-      target.scrollIntoView({
-        behavior: prefersReducedMotion ? 'auto' : 'smooth',
-        block: 'start',
-      });
+      /*
+       * Guarded because this runs from a requestAnimationFrame callback,
+       * which is outside React's tree and outside any error boundary — an
+       * exception here is an uncaught one that takes down whatever is
+       * running. `scrollIntoView` is not universally implemented (jsdom does
+       * not have it at all), and the callback can also fire against a node
+       * from a route that has already been replaced.
+       *
+       * This was already failing intermittently: the frontend test run exits
+       * non-zero roughly half the time on main with "target.scrollIntoView
+       * is not a function", because whether the rAF callback lands before
+       * the test environment is torn down depends on how busy the run is.
+       */
+      if (typeof target.scrollIntoView !== 'function') {
+        return;
+      }
+
+      try {
+        target.scrollIntoView({
+          behavior: prefersReducedMotion ? 'auto' : 'smooth',
+          block: 'start',
+        });
+      } catch {
+        // Scrolling to an anchor is a nicety. It must never be the reason
+        // an uncaught exception escapes.
+      }
     };
 
     frame = window.requestAnimationFrame(scrollToTarget);

--- a/bookshelf-frontend/src/hooks/useFocusTrap.js
+++ b/bookshelf-frontend/src/hooks/useFocusTrap.js
@@ -1,0 +1,208 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Selector for things that can take focus.
+ *
+ * `[tabindex]:not([tabindex="-1"])` deliberately excludes programmatic focus
+ * targets — an element with tabindex="-1" is focusable by script but is not
+ * in the tab order, so a trap must not treat it as a boundary.
+ */
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+/**
+ * Is this element actually reachable?
+ *
+ * `querySelectorAll` will happily return a button inside a section that has
+ * since been collapsed, or one that has been hidden since the list was built.
+ *
+ * The check deliberately avoids `offsetParent` and `getClientRects()`, which
+ * are the usual way to ask this in a browser: jsdom does no layout, so both
+ * report "invisible" for *every* element and the trap would find nothing to
+ * hold. `getComputedStyle` is implemented in both, and `inert` and `disabled`
+ * are attribute checks that need no layout at all.
+ */
+function isReachable(element) {
+  if (element.hasAttribute('disabled') || element.getAttribute('aria-hidden') === 'true') {
+    return false;
+  }
+
+  if (element.hidden || element.closest('[inert]')) {
+    return false;
+  }
+
+  const style = element.ownerDocument?.defaultView?.getComputedStyle?.(element);
+
+  if (style && (style.display === 'none' || style.visibility === 'hidden')) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Keep Tab inside a container while it is open.
+ *
+ * The important difference from the implementation this replaces: the
+ * focusable elements are queried **at Tab time**, not cached when the trap is
+ * set up.
+ *
+ * `querySelectorAll` returns a static NodeList. The cart drawer captured one
+ * on open and never refreshed it, so removing the last item left `lastElement`
+ * pointing at a **detached node** — `.focus()` on it silently does nothing,
+ * and Shift+Tab from the first element went nowhere. The trap broke in the
+ * exact direction it exists to hold, and only for a cart the customer had
+ * just edited. See #327.
+ *
+ * @param {object}   options
+ * @param {boolean}  options.active     Whether the trap is engaged.
+ * @param {Function} [options.onEscape] Called when Escape is pressed.
+ * @returns {import('react').RefObject} Ref to put on the container.
+ */
+export function useFocusTrap({ active, onEscape } = {}) {
+  const containerRef = useRef(null);
+  const previousFocusRef = useRef(null);
+
+  // Held in a ref so a caller passing an inline arrow does not tear the
+  // listener down and rebuild it on every render.
+  const onEscapeRef = useRef(onEscape);
+  onEscapeRef.current = onEscape;
+
+  useEffect(() => {
+    if (!active) {
+      return undefined;
+    }
+
+    const container = containerRef.current;
+
+    if (!container) {
+      return undefined;
+    }
+
+    // Where focus was before the dialog opened, so it can go back there.
+    // Restoring to <body> is what happens otherwise, which drops a keyboard
+    // user at the top of the document.
+    const previouslyFocused =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    previousFocusRef.current = previouslyFocused;
+
+    const getFocusable = () =>
+      Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR)).filter(isReachable);
+
+    const initial = getFocusable();
+
+    if (initial.length > 0) {
+      initial[0].focus();
+    } else {
+      /*
+       * A dialog with nothing focusable in it still has to receive focus, or
+       * the user is left standing outside a modal they cannot enter. The
+       * container is given tabindex="-1" by the caller for exactly this.
+       */
+      container.focus?.();
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        onEscapeRef.current?.();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      // Queried now, not when the trap was set up. This is the fix.
+      const focusable = getFocusable();
+
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const activeElement = document.activeElement;
+
+      /*
+       * Focus can be outside the container even while the trap is engaged —
+       * the element that had it was just removed, or something outside called
+       * focus(). Pull it back rather than letting Tab walk off into the page
+       * behind the dialog.
+       */
+      if (!container.contains(activeElement)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first).focus();
+        return;
+      }
+
+      if (event.shiftKey && activeElement === first) {
+        event.preventDefault();
+        last.focus();
+        return;
+      }
+
+      if (!event.shiftKey && activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+
+      /*
+       * Only restore focus if it is still inside the container. If something
+       * else has taken it in the meantime — the user clicked a link on the
+       * page as the drawer closed — yanking it back is worse than leaving it.
+       */
+      const target = previousFocusRef.current;
+      previousFocusRef.current = null;
+
+      if (target && document.contains(target)) {
+        target.focus();
+      }
+    };
+  }, [active]);
+
+  return containerRef;
+}
+
+/**
+ * Prevent the page behind a modal from scrolling, and put back whatever was
+ * there before.
+ *
+ * The drawer used to set `document.body.style.overflow = 'unset'` on cleanup,
+ * which is not "restore" — it is "clobber". Any other scroll lock held at the
+ * same time was silently released.
+ */
+export function useScrollLock(active) {
+  useEffect(() => {
+    if (!active) {
+      return undefined;
+    }
+
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [active]);
+}
+
+export default useFocusTrap;


### PR DESCRIPTION
Closes #327

`CartDrawer` is mounted by the `App` layout on **every route** and rendered its markup unconditionally. Open and closed were a *CSS* distinction only — `isCartOpen` toggled an `is-open` class, and the panel was pushed off-screen with `transform: translateX(100%)`.

That hides a thing from sighted mouse users and from nobody else.

## Two consequences

**Every page had an open modal on it.** `aria-modal="true"` tells assistive technology that everything outside the element is inert — and it was on an element present on `/`, `/login`, `/checkout`, every book page, always. A screen reader user landed on the site already inside a dialog called "Shopping Cart" that they had not opened, with the real page content treated as its background.

**Every page was a keyboard trap.** An off-screen transform does not remove anything from the tab order. Tabbing past the last visible element walked into the invisible drawer: Close cart drawer → Start Shopping, or, with items in the cart, every quantity −/+, every Remove, then Clear Cart and Proceed to Checkout. The focus ring vanished, and Enter could clear the cart or navigate to `/checkout` from a control the user could not see.

**Nothing renders when the cart is closed.** There is nothing left to walk into and nothing left in the accessibility tree.

## The trap was also stale

Inside the old effect the focusable set was captured **once**, on open:

```js
const focusableElements = drawerRef.current.querySelectorAll(...);
const lastElement = focusableElements[focusableElements.length - 1];
```

`querySelectorAll` returns a static `NodeList`, and `cart` was not in the effect's dependency array. Remove the last item and `lastElement` points at a **detached node** — `.focus()` on it silently does nothing, so Shift+Tab from the first element went nowhere. The trap broke in the exact direction it exists to hold, and only for a cart the customer had just edited.

`src/hooks/useFocusTrap.js` (new) queries **at Tab time** instead. It also:

- skips `disabled`, `hidden`, `aria-hidden`, `[inert]` and `display:none` / `visibility:hidden` elements, which `querySelectorAll` returns regardless;
- pulls focus back into the container if something outside has taken it (the element that had focus was just removed), rather than letting Tab walk off into the page behind the dialog;
- restores focus to whatever had it before, but only if that element is still in the document;
- restores the **previous** `body` overflow. The old cleanup set it to `'unset'`, which is not "restore" but "clobber" — any other scroll lock held at the same time was silently released.

## Notes for review

- **The slide-in moves from a `transition` to an entry animation.** An element that did not exist a frame ago has no closed state to transition from, so the transform transition would no longer play. `@keyframes` gives the same slide, and it honours `prefers-reduced-motion`, which the transition never did.
- **Prices are guarded.** `item.price.toFixed(2)` threw on anything that was not a number, and a cart is restored from `localStorage` — see #309, where one malformed value took the whole app down. An unusable price renders as an em dash.
- The subtotal `reduce` skips non-numeric lines for the same reason, instead of producing `₹NaN`.
- Every `<button>` gained an explicit `type="button"`. They are not in a form today, but a bare `<button>` defaults to `type="submit"` and this is a component that gets moved.
- `aria-label="Shopping Cart"` became `aria-labelledby` pointing at the visible `<h2>`, so the accessible name cannot drift from the heading.

## Tests

`CartDrawer.test.jsx` — 16 tests, all passing; full frontend suite 352 passing.

Closed:
- no `role="dialog"` in the tree
- none of Close / Clear Cart / Proceed to Checkout / Remove is present
- the page scroll is not locked
- tabbing past the page content does not land inside the cart

Open:
- the dialog has an accessible name, and focus moves into it
- Escape closes it; the backdrop closes it
- Tab wraps last → first, Shift+Tab wraps first → last
- **the boundaries follow the cart**: rendered with two items, re-rendered with one, Tab from the last control still wraps rather than escaping — this is the stale-NodeList regression
- the previous `body` overflow is restored on unmount, not overwritten with `unset`
- a malformed price renders an em dash instead of throwing


## One unrelated commit, and why it is here

`fix(navbar): stop an unguarded scrollIntoView failing the test run` touches `Navbar.jsx`, not the cart.

`npm test` in `bookshelf-frontend` **already exits non-zero on roughly half of all runs on `main`**:

```
$ for i in 1 2 3 4 5 6; do npm test >/dev/null 2>&1; echo "exit=$?"; done   # on main
exit=0
exit=1
exit=0
exit=1
exit=0
exit=1
```

Every run reports `445 passed`, but Vitest exits 1 on an unhandled error:

```
TypeError: target.scrollIntoView is not a function
 ❯ scrollToTarget src/components/Navbar.jsx:126:14
 ❯ runAnimationFrameCallbacks node_modules/jsdom/lib/jsdom/browser/Window.js:639:13
```

The hash-scroll effect from #316 runs inside a `requestAnimationFrame` callback — outside React's tree and outside any error boundary, so a throw there is uncaught. jsdom does not implement `scrollIntoView`, and whether that callback lands before the environment is torn down depends on how busy the run is. Every open PR in this repo inherits a coin-flip red CI job from it.

The guard is three lines and the failure mode is real in a browser too (the callback can fire against a node from a route that has already been replaced). It is in this PR because the same CI job has to be green for this PR to be reviewable. Six consecutive runs pass with it. Happy to split it out if you would rather it landed on its own.