### PR TITLE
fix(checkout): give back stock that an unpaid checkout is holding

### DIFF
--- a/bookshelf-backend/controllers/paymentController.js
+++ b/bookshelf-backend/controllers/paymentController.js
@@ -55,6 +55,9 @@ export const createIntent = async (req, res, next) => {
   }
 
   let reservationHeld = true;
+  // Declared before `release` so the closure can mark it; it is only
+  // assigned once the order has actually been created.
+  let savedOrder;
 
   const release = (reason) => {
     if (!reservationHeld) {
@@ -64,6 +67,13 @@ export const createIntent = async (req, res, next) => {
     reservationHeld = false;
 
     const { failed } = restoreInventory(checkout.reservation);
+
+    // If the order exists, record that its hold is gone. Without this the
+    // sweeper would find it still `pending` and restore the same lines a
+    // second time. See #329.
+    if (savedOrder && !savedOrder.reservationReleasedAt) {
+      savedOrder.reservationReleasedAt = new Date();
+    }
 
     if (failed.length > 0) {
       // Worth a loud log: the shop's stock is now understated and only a
@@ -76,8 +86,6 @@ export const createIntent = async (req, res, next) => {
     }
   };
 
-  let savedOrder;
-
   try {
     savedOrder = await orderRepository.create({
       userId: req.user ? req.user._id : null,
@@ -89,6 +97,14 @@ export const createIntent = async (req, res, next) => {
       total: checkout.total,
       status: 'pending',
       paymentStatus: 'pending',
+      /*
+       * When the hold started. The reservation above is a durable change to
+       * books.json, so it needs a durable record of when it happened —
+       * otherwise nothing can tell an abandoned checkout from one the
+       * customer is still filling in, and the stock is held forever. See
+       * #329.
+       */
+      reservedAt: new Date(),
     });
   } catch (error) {
     release('the order could not be saved');

--- a/bookshelf-backend/middleware/rateLimiter.js
+++ b/bookshelf-backend/middleware/rateLimiter.js
@@ -187,4 +187,24 @@ export const registerLimiter = createRateLimiter({
     'Too many accounts created from this address. Please try again later.',
 });
 
+/**
+ * Creating a payment intent.
+ *
+ * This endpoint is anonymous — guests can check out — and every successful
+ * call takes inventory off the shelf before anything is paid. With 78 units
+ * across the whole catalogue, an unthrottled loop emptied the shop in under a
+ * minute. See #329.
+ *
+ * 20 an hour per address is far above what a real customer needs (a checkout
+ * is one call, retried at most a handful of times) and far below what it
+ * takes to drain the stock. It bounds the damage; the sweeper is what
+ * actually gives the stock back.
+ */
+export const checkoutLimiter = createRateLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 20,
+  message:
+    'Too many checkout attempts from this address. Please try again later.',
+});
+
 export default createRateLimiter;

--- a/bookshelf-backend/models/Order.js
+++ b/bookshelf-backend/models/Order.js
@@ -52,6 +52,24 @@ const orderSchema = new mongoose.Schema(
     paidAt: {
       type: Date,
     },
+    /*
+     * Inventory is taken before the payment intent exists (see #297), so an
+     * order that is still `pending` is holding stock it has not paid for.
+     * Recording when that hold started makes the reservation a fact in the
+     * database rather than an implicit side effect, which is what lets it be
+     * swept when the customer never comes back. See #329.
+     */
+    reservedAt: {
+      type: Date,
+    },
+    /*
+     * Set when the hold has been handed back. `restoreInventory` is not
+     * idempotent — it adds units unconditionally — so this marker is what
+     * stops a second sweep restoring the same lines twice.
+     */
+    reservationReleasedAt: {
+      type: Date,
+    },
   },
   {
     timestamps: true,
@@ -59,6 +77,8 @@ const orderSchema = new mongoose.Schema(
 );
 
 orderSchema.index({ userId: 1, createdAt: -1 });
+// The sweeper's query: unreleased holds older than the TTL.
+orderSchema.index({ paymentStatus: 1, reservationReleasedAt: 1, reservedAt: 1 });
 orderSchema.index({ status: 1 });
 orderSchema.index({ paymentStatus: 1 });
 

--- a/bookshelf-backend/repositories/orderRepository.js
+++ b/bookshelf-backend/repositories/orderRepository.js
@@ -13,6 +13,50 @@ class OrderRepository {
     return await Order.find({}).sort({ createdAt: -1 });
   }
 
+  /**
+   * Orders still holding inventory they have not paid for, reserved before
+   * `before`.
+   *
+   * Filtered on `paymentStatus` rather than on `status`: an order sits at
+   * `status: 'pending'` with `paymentStatus: 'paid'` for as long as
+   * fulfilment takes to pick it up, and sweeping that would take stock away
+   * from a customer who has already been charged.
+   *
+   * `reservationReleasedAt: null` also matches documents where the field is
+   * absent, which is every order written before #329.
+   */
+  async findExpiredReservations({ before, limit = 200 } = {}) {
+    return await Order.find({
+      reservationReleasedAt: null,
+      $or: [
+        {
+          // Still ambiguous — the customer may be mid-card-form — so these
+          // only qualify once the hold is older than the TTL.
+          paymentStatus: 'pending',
+          $or: [
+            { reservedAt: { $lte: before } },
+            // Orders from before `reservedAt` existed fall back to
+            // createdAt, so they are swept rather than held forever by a
+            // missing field.
+            { reservedAt: { $exists: false }, createdAt: { $lte: before } },
+          ],
+        },
+        {
+          /*
+           * Terminal and unpaid: a declined card, or a canceled intent.
+           * Nobody is going to pay for these, so there is nothing to wait
+           * for. They are here because the webhook marks them and never
+           * calls restoreInventory — the stock was being destroyed just as
+           * permanently as by an abandoned tab.
+           */
+          paymentStatus: { $in: ['failed', 'canceled'] },
+        },
+      ],
+    })
+      .sort({ createdAt: 1 })
+      .limit(limit);
+  }
+
   async create(orderData) {
     const order = new Order(orderData);
     return await order.save();

--- a/bookshelf-backend/routes/paymentRoutes.js
+++ b/bookshelf-backend/routes/paymentRoutes.js
@@ -1,10 +1,19 @@
 import express from 'express';
 import { createIntent } from '../controllers/paymentController.js';
-// import { protect } from '../middleware/authMiddleware.js'; // Can be used to protect the route
+import { checkoutLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
 
-// Allow guests to checkout for now, or use protect middleware if strictly users only
-router.post('/create-intent', createIntent);
+/*
+ * Guests can check out, so this route stays unauthenticated — but it is not
+ * free to call. Every successful request reserves inventory in books.json
+ * before any money changes hands, and there was nothing here stopping a loop
+ * from calling it: no auth, and no limiter, while /api/auth has had one since
+ * #275. 78 units across the catalogue went to zero in well under a minute.
+ *
+ * The limiter bounds how fast stock can be taken. services/
+ * reservationSweeper.js is what gives it back. See #329.
+ */
+router.post('/create-intent', checkoutLimiter, createIntent);
 
 export default router;

--- a/bookshelf-backend/server.js
+++ b/bookshelf-backend/server.js
@@ -4,9 +4,21 @@ dotenv.config();
 import mongoose from 'mongoose';
 import app from './app.js';
 import { assertJwtConfig, ConfigError } from './config/jwt.js';
+import { startReservationSweeper } from './services/reservationSweeper.js';
+import { DEFAULT_RESERVATION_TTL_MS } from './utils/reservations.js';
 
 const PORT = process.env.PORT || 5000;
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/bookshelf';
+
+/**
+ * How long an unpaid checkout may hold inventory, and how often to look.
+ *
+ * Both are read from the environment so the numbers can be tuned without a
+ * deploy of new code; the defaults are sensible for a small shop.
+ */
+const RESERVATION_TTL_MS = Number(process.env.RESERVATION_TTL_MS) || DEFAULT_RESERVATION_TTL_MS;
+const RESERVATION_SWEEP_INTERVAL_MS =
+  Number(process.env.RESERVATION_SWEEP_INTERVAL_MS) || 5 * 60 * 1000;
 
 /**
  * Validate configuration before anything else happens.
@@ -31,6 +43,29 @@ try {
 mongoose.connect(MONGODB_URI)
   .then(() => {
     console.log('Connected to MongoDB');
+
+    /*
+     * Checkout takes inventory before the payment intent exists, and nothing
+     * put it back when the customer never came back — no expiry, no sweeper,
+     * and a webhook that marks an order failed without restoring its lines.
+     * Stock leaked away permanently, one abandoned tab and one declined card
+     * at a time. See #329.
+     *
+     * Started after the Mongo connection, because its first pass queries
+     * immediately: a process that crashed mid-checkout left stock reserved
+     * against an order nobody will ever pay for, and waiting a full interval
+     * to notice is a whole interval of a shop being wrong.
+     */
+    startReservationSweeper({
+      ttlMs: RESERVATION_TTL_MS,
+      intervalMs: RESERVATION_SWEEP_INTERVAL_MS,
+    });
+
+    console.log(
+      `Reservation sweeper running every ${Math.round(RESERVATION_SWEEP_INTERVAL_MS / 1000)}s ` +
+        `(holds expire after ${Math.round(RESERVATION_TTL_MS / 60000)}m)`
+    );
+
     app.listen(PORT, () => {
       console.log(`Server running on port ${PORT}`);
     });

--- a/bookshelf-backend/services/reservationSweeper.js
+++ b/bookshelf-backend/services/reservationSweeper.js
@@ -1,0 +1,146 @@
+import orderRepository from '../repositories/orderRepository.js';
+import { restoreInventory } from '../repositories/bookRepository.js';
+import { DEFAULT_RESERVATION_TTL_MS, planSweep } from '../utils/reservations.js';
+
+/**
+ * Put back stock held by checkouts that were never completed.
+ *
+ * The decisions live in `utils/reservations.js` and are pure; this is the
+ * part that talks to Mongo and to books.json.
+ *
+ * Built as a factory so tests can drive it with fake repositories, the same
+ * way `createStripeWebhookHandler` is built. The default export at the bottom
+ * wires in the real ones.
+ */
+export function createReservationSweeper({
+  orders = orderRepository,
+  restore = restoreInventory,
+  ttlMs = DEFAULT_RESERVATION_TTL_MS,
+  logger = console,
+  now = () => Date.now(),
+} = {}) {
+  // Guards against two runs overlapping. The interval keeps firing even if a
+  // sweep is slow, and two passes over the same order would hand the same
+  // units back twice — `restoreInventory` is deliberately not version-checked
+  // and would happily do it.
+  let running = false;
+
+  async function sweep() {
+    if (running) {
+      logger.warn?.('[reservations] previous sweep still running, skipping this pass');
+      return { released: 0, restored: 0, failed: 0, skipped: 0 };
+    }
+
+    running = true;
+
+    try {
+      const pending = await orders.findExpiredReservations({
+        before: new Date(now() - ttlMs),
+      });
+
+      const { releases } = planSweep(pending, { now: now(), ttlMs });
+
+      let restoredLines = 0;
+      let failedLines = 0;
+      let releasedOrders = 0;
+
+      for (const { order, lines, changes } of releases) {
+        /*
+         * Order of operations. The inventory goes back first, and only then
+         * is the order marked released.
+         *
+         * The other way round loses stock outright: if the write to
+         * books.json failed after the order had been marked, the marker
+         * would stop the next sweep from ever retrying it. Doing it this way
+         * risks the opposite — a crash between the two restores the stock
+         * without recording it, and the next sweep restores it again. That
+         * is a bounded over-count on a shop's own catalogue, against
+         * permanently vanished stock. The safer failure is the recoverable
+         * one.
+         */
+        const result = restore(lines);
+
+        restoredLines += result.restored.length;
+        failedLines += result.failed.length;
+
+        if (result.failed.length > 0) {
+          logger.error(
+            `[reservations] order ${order._id}: ${result.failed.length} line(s) ` +
+              'could not be restored:',
+            result.failed
+          );
+        }
+
+        try {
+          Object.assign(order, changes);
+          await orders.save(order);
+          releasedOrders += 1;
+        } catch (saveError) {
+          // The stock is back, which is the part that matters. The order is
+          // still 'pending', so the next sweep will try again — and
+          // re-restore. Loud, because it needs a human eventually.
+          logger.error(
+            `[reservations] restored stock for order ${order._id} but could not ` +
+              `mark it released: ${saveError.message}`
+          );
+        }
+      }
+
+      if (releasedOrders > 0 || failedLines > 0) {
+        logger.log(
+          `[reservations] released ${releasedOrders} abandoned checkout(s), ` +
+            `restored ${restoredLines} line(s), ${failedLines} failed`
+        );
+      }
+
+      return {
+        released: releasedOrders,
+        restored: restoredLines,
+        failed: failedLines,
+        skipped: pending.length - releases.length,
+      };
+    } catch (error) {
+      // A sweeper that throws into an interval takes the process down. It
+      // runs again in a few minutes; the next pass picks up whatever this
+      // one missed.
+      logger.error(`[reservations] sweep failed: ${error.message}`);
+      return { released: 0, restored: 0, failed: 0, skipped: 0, error };
+    } finally {
+      running = false;
+    }
+  }
+
+  return { sweep };
+}
+
+/**
+ * Run the sweep on a schedule.
+ *
+ * Also runs once immediately: a process that crashed mid-checkout left stock
+ * reserved against an order nobody will ever pay for, and waiting a full
+ * interval to notice is a whole interval of a shop being wrong.
+ *
+ * `unref()` so the timer does not hold the event loop open — otherwise the
+ * process will not exit on its own, and neither will a test run.
+ */
+export function startReservationSweeper({
+  intervalMs = 5 * 60 * 1000,
+  ...options
+} = {}) {
+  const sweeper = createReservationSweeper(options);
+
+  sweeper.sweep();
+
+  const timer = setInterval(() => {
+    sweeper.sweep();
+  }, intervalMs);
+
+  timer.unref?.();
+
+  return {
+    stop: () => clearInterval(timer),
+    sweep: sweeper.sweep,
+  };
+}
+
+export default createReservationSweeper;

--- a/bookshelf-backend/tests/checkoutLimiter.test.js
+++ b/bookshelf-backend/tests/checkoutLimiter.test.js
@@ -1,0 +1,81 @@
+import test, { describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+import express from 'express';
+import { checkoutLimiter } from '../middleware/rateLimiter.js';
+
+/**
+ * POST /api/payments/create-intent is anonymous — guests can check out — and
+ * every successful call reserves inventory in books.json before any money
+ * changes hands. There was nothing throttling it, while /api/auth has had a
+ * limiter since #275. 78 units across the whole catalogue went to zero in
+ * well under a minute. See #329.
+ *
+ * The limiter is mounted on a bare route here rather than on the real
+ * controller: the controller reserves stock and talks to Stripe, and the
+ * thing under test is whether the limiter answers 429 before any of that is
+ * reached.
+ */
+
+let server;
+let baseUrl;
+
+before(async () => {
+  const app = express();
+  app.use(express.json());
+  app.post('/api/payments/create-intent', checkoutLimiter, (req, res) => {
+    res.status(200).json({ reached: true });
+  });
+
+  await new Promise((resolve) => {
+    server = app.listen(0, resolve);
+  });
+
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await new Promise((resolve) => server.close(resolve));
+  checkoutLimiter.reset();
+});
+
+function createIntent() {
+  return fetch(`${baseUrl}/api/payments/create-intent`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ items: [{ bookId: 'b1', quantity: 1 }] }),
+  });
+}
+
+describe('checkout rate limit', () => {
+  test('lets an ordinary checkout through', async () => {
+    checkoutLimiter.reset();
+
+    const response = await createIntent();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('x-ratelimit-limit'), '20');
+    assert.equal(response.headers.get('x-ratelimit-remaining'), '19');
+  });
+
+  test('answers 429 once the budget is spent, before the controller runs', async () => {
+    checkoutLimiter.reset();
+
+    // The limit is 20 an hour: far above what a real customer needs, far
+    // below what it takes to drain a shop of 78 units.
+    for (let i = 0; i < 20; i += 1) {
+      const allowed = await createIntent();
+      assert.equal(allowed.status, 200, `request ${i + 1} should have been allowed`);
+    }
+
+    const blocked = await createIntent();
+
+    assert.equal(blocked.status, 429);
+    assert.ok(blocked.headers.get('retry-after'));
+
+    const body = await blocked.json();
+    assert.match(body.message, /Too many checkout attempts/);
+    // The 200 handler stands in for the controller; a 429 must not reach it.
+    assert.equal(body.reached, undefined);
+  });
+});

--- a/bookshelf-backend/tests/reservationSweeper.test.js
+++ b/bookshelf-backend/tests/reservationSweeper.test.js
@@ -1,0 +1,298 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createReservationSweeper } from '../services/reservationSweeper.js';
+
+const NOW = Date.UTC(2026, 2, 14, 12, 0, 0);
+const MINUTE = 60 * 1000;
+
+const silentLogger = { log() {}, warn() {}, error() {} };
+
+function order(overrides = {}) {
+  return {
+    _id: overrides._id ?? 'order-1',
+    status: 'pending',
+    paymentStatus: 'pending',
+    items: [{ bookId: 'b1', title: 'The Quiet Ones', price: 349, quantity: 2 }],
+    createdAt: new Date(NOW - 60 * MINUTE),
+    reservedAt: new Date(NOW - 60 * MINUTE),
+    ...overrides,
+  };
+}
+
+/**
+ * A stand-in for orderRepository. `findExpiredReservations` returns whatever
+ * it is given, so these tests drive the sweeper's behaviour rather than
+ * Mongo's query semantics.
+ */
+function fakeOrders(pending = []) {
+  const saved = [];
+
+  return {
+    saved,
+    calls: [],
+    async findExpiredReservations(args) {
+      this.calls.push(args);
+      return pending;
+    },
+    async save(doc) {
+      saved.push(doc);
+      return doc;
+    },
+  };
+}
+
+/** A stand-in for restoreInventory, recording what it was asked to put back. */
+function fakeRestore({ failFor = [] } = {}) {
+  const calls = [];
+
+  const restore = (lines) => {
+    calls.push(lines);
+
+    const failed = lines
+      .filter((line) => failFor.includes(line.bookId))
+      .map((line) => ({ bookId: line.bookId, reason: 'book not found' }));
+
+    return {
+      restored: lines.filter((line) => !failFor.includes(line.bookId)),
+      failed,
+    };
+  };
+
+  restore.calls = calls;
+  return restore;
+}
+
+test('reservation sweeper', async (t) => {
+  await t.test('puts back the stock an abandoned checkout was holding', async () => {
+    const orders = fakeOrders([order()]);
+    const restore = fakeRestore();
+
+    const sweeper = createReservationSweeper({
+      orders,
+      restore,
+      logger: silentLogger,
+      now: () => NOW,
+    });
+
+    const result = await sweeper.sweep();
+
+    assert.deepEqual(restore.calls, [[{ bookId: 'b1', quantity: 2 }]]);
+    assert.equal(result.released, 1);
+    assert.equal(result.restored, 1);
+  });
+
+  await t.test('marks the order so a second sweep cannot restore it again', async () => {
+    const held = order();
+    const orders = fakeOrders([held]);
+
+    const sweeper = createReservationSweeper({
+      orders,
+      restore: fakeRestore(),
+      logger: silentLogger,
+      now: () => NOW,
+    });
+
+    await sweeper.sweep();
+
+    assert.equal(orders.saved.length, 1);
+    assert.equal(held.status, 'canceled');
+    assert.equal(held.paymentStatus, 'canceled');
+    assert.ok(held.reservationReleasedAt instanceof Date);
+  });
+
+  await t.test('a second sweep over the same order is a no-op', async () => {
+    const held = order();
+    const orders = fakeOrders([held]);
+    const restore = fakeRestore();
+
+    const sweeper = createReservationSweeper({
+      orders,
+      restore,
+      logger: silentLogger,
+      now: () => NOW,
+    });
+
+    await sweeper.sweep();
+    await sweeper.sweep();
+
+    // Restored once, not twice — this is what the marker is for.
+    assert.equal(restore.calls.length, 1);
+  });
+
+  await t.test('leaves a checkout that is still inside the TTL', async () => {
+    const orders = fakeOrders([order({ reservedAt: new Date(NOW - 2 * MINUTE) })]);
+    const restore = fakeRestore();
+
+    const sweeper = createReservationSweeper({
+      orders,
+      restore,
+      logger: silentLogger,
+      now: () => NOW,
+    });
+
+    const result = await sweeper.sweep();
+
+    assert.equal(restore.calls.length, 0);
+    assert.equal(result.released, 0);
+    assert.equal(result.skipped, 1);
+  });
+
+  await t.test('never touches an order that has been paid for', async () => {
+    const orders = fakeOrders([order({ paymentStatus: 'paid' })]);
+    const restore = fakeRestore();
+
+    const sweeper = createReservationSweeper({
+      orders,
+      restore,
+      logger: silentLogger,
+      now: () => NOW,
+    });
+
+    await sweeper.sweep();
+
+    assert.equal(restore.calls.length, 0);
+    assert.equal(orders.saved.length, 0);
+  });
+
+  await t.test('queries for holds older than the TTL', async () => {
+    const orders = fakeOrders([]);
+
+    const sweeper = createReservationSweeper({
+      orders,
+      restore: fakeRestore(),
+      ttlMs: 30 * MINUTE,
+      logger: silentLogger,
+      now: () => NOW,
+    });
+
+    await sweeper.sweep();
+
+    assert.equal(orders.calls.length, 1);
+    assert.equal(orders.calls[0].before.getTime(), NOW - 30 * MINUTE);
+  });
+
+  await t.test('restores the stock even when marking the order fails', async () => {
+    // The stock is the part that matters. The order stays pending and the
+    // next sweep will try again.
+    const orders = fakeOrders([order()]);
+    orders.save = async () => {
+      throw new Error('mongo is down');
+    };
+
+    const restore = fakeRestore();
+    const errors = [];
+
+    const sweeper = createReservationSweeper({
+      orders,
+      restore,
+      logger: { ...silentLogger, error: (msg) => errors.push(msg) },
+      now: () => NOW,
+    });
+
+    const result = await sweeper.sweep();
+
+    assert.equal(restore.calls.length, 1);
+    assert.equal(result.released, 0);
+    assert.ok(errors.some((e) => String(e).includes('could not')));
+  });
+
+  await t.test('reports lines that could not be restored', async () => {
+    const orders = fakeOrders([order()]);
+    const restore = fakeRestore({ failFor: ['b1'] });
+    const errors = [];
+
+    const sweeper = createReservationSweeper({
+      orders,
+      restore,
+      logger: { ...silentLogger, error: (msg) => errors.push(msg) },
+      now: () => NOW,
+    });
+
+    const result = await sweeper.sweep();
+
+    assert.equal(result.failed, 1);
+    assert.equal(errors.length, 1);
+  });
+
+  await t.test('a query failure does not throw into the interval', async () => {
+    // A sweeper that throws on a schedule takes the process down with it.
+    const orders = {
+      async findExpiredReservations() {
+        throw new Error('mongo is down');
+      },
+      async save(doc) {
+        return doc;
+      },
+    };
+
+    const sweeper = createReservationSweeper({
+      orders,
+      restore: fakeRestore(),
+      logger: silentLogger,
+      now: () => NOW,
+    });
+
+    const result = await sweeper.sweep();
+
+    assert.equal(result.released, 0);
+    assert.ok(result.error instanceof Error);
+  });
+
+  await t.test('will not run two overlapping sweeps', async () => {
+    let release;
+    const gate = new Promise((resolve) => {
+      release = resolve;
+    });
+
+    const orders = {
+      queries: 0,
+      async findExpiredReservations() {
+        this.queries += 1;
+        await gate;
+        return [];
+      },
+      async save(doc) {
+        return doc;
+      },
+    };
+
+    const sweeper = createReservationSweeper({
+      orders,
+      restore: fakeRestore(),
+      logger: silentLogger,
+      now: () => NOW,
+    });
+
+    const first = sweeper.sweep();
+    const second = await sweeper.sweep(); // returns immediately
+
+    release();
+    await first;
+
+    assert.equal(orders.queries, 1);
+    assert.equal(second.released, 0);
+  });
+
+  await t.test('handles a batch of mixed orders in one pass', async () => {
+    const orders = fakeOrders([
+      order({ _id: 'abandoned' }),
+      order({ _id: 'fresh', reservedAt: new Date(NOW - MINUTE) }),
+      order({ _id: 'paid', paymentStatus: 'paid' }),
+      order({ _id: 'declined', paymentStatus: 'failed', reservedAt: new Date(NOW - MINUTE) }),
+    ]);
+
+    const sweeper = createReservationSweeper({
+      orders,
+      restore: fakeRestore(),
+      logger: silentLogger,
+      now: () => NOW,
+    });
+
+    const result = await sweeper.sweep();
+
+    assert.equal(result.released, 2);
+    assert.equal(result.skipped, 2);
+    assert.deepEqual(orders.saved.map((o) => o._id), ['abandoned', 'declined']);
+  });
+});

--- a/bookshelf-backend/tests/reservations.test.js
+++ b/bookshelf-backend/tests/reservations.test.js
@@ -1,0 +1,238 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEFAULT_RESERVATION_TTL_MS,
+  decideRelease,
+  holdsReservation,
+  isExpired,
+  planSweep,
+  requiresExpiry,
+  reservationLines,
+} from '../utils/reservations.js';
+
+const NOW = Date.UTC(2026, 2, 14, 12, 0, 0);
+const MINUTE = 60 * 1000;
+
+function order(overrides = {}) {
+  return {
+    _id: '507f1f77bcf86cd799439011',
+    status: 'pending',
+    paymentStatus: 'pending',
+    items: [{ bookId: 'b1', title: 'The Quiet Ones', price: 349, quantity: 2 }],
+    createdAt: new Date(NOW - 60 * MINUTE),
+    reservedAt: new Date(NOW - 60 * MINUTE),
+    ...overrides,
+  };
+}
+
+test('holdsReservation', async (t) => {
+  await t.test('a pending order with lines is holding stock', () => {
+    assert.equal(holdsReservation(order()), true);
+  });
+
+  await t.test('a paid order is never swept — the customer was charged', () => {
+    assert.equal(holdsReservation(order({ paymentStatus: 'paid' })), false);
+  });
+
+  await t.test('paid is judged on paymentStatus, not on fulfilment status', () => {
+    // An order sits at status 'pending' with paymentStatus 'paid' until
+    // fulfilment picks it up. Sweeping that takes stock from a paying
+    // customer.
+    assert.equal(
+      holdsReservation(order({ status: 'pending', paymentStatus: 'paid' })),
+      false
+    );
+  });
+
+  await t.test('a failed payment is still holding stock, because nothing gave it back', () => {
+    // The webhook marks the order and never calls restoreInventory.
+    assert.equal(holdsReservation(order({ paymentStatus: 'failed' })), true);
+    assert.equal(holdsReservation(order({ paymentStatus: 'canceled' })), true);
+  });
+
+  await t.test('an already-released hold is not released twice', () => {
+    assert.equal(
+      holdsReservation(order({ reservationReleasedAt: new Date(NOW) })),
+      false
+    );
+  });
+
+  await t.test('an order with no lines is holding nothing', () => {
+    assert.equal(holdsReservation(order({ items: [] })), false);
+    assert.equal(holdsReservation(order({ items: undefined })), false);
+  });
+
+  await t.test('rejects anything that is not an order', () => {
+    assert.equal(holdsReservation(null), false);
+    assert.equal(holdsReservation(undefined), false);
+    assert.equal(holdsReservation('an order'), false);
+  });
+});
+
+test('requiresExpiry', async (t) => {
+  await t.test('pending has to wait — the customer may still be typing', () => {
+    assert.equal(requiresExpiry(order({ paymentStatus: 'pending' })), true);
+  });
+
+  await t.test('failed and canceled do not — nobody is going to pay', () => {
+    assert.equal(requiresExpiry(order({ paymentStatus: 'failed' })), false);
+    assert.equal(requiresExpiry(order({ paymentStatus: 'canceled' })), false);
+  });
+});
+
+test('isExpired', async (t) => {
+  await t.test('true once the hold is older than the TTL', () => {
+    const held = order({ reservedAt: new Date(NOW - 31 * MINUTE) });
+    assert.equal(isExpired(held, { now: NOW }), true);
+  });
+
+  await t.test('false while it is still inside the TTL', () => {
+    const held = order({ reservedAt: new Date(NOW - 29 * MINUTE) });
+    assert.equal(isExpired(held, { now: NOW }), false);
+  });
+
+  await t.test('true exactly at the boundary', () => {
+    const held = order({ reservedAt: new Date(NOW - DEFAULT_RESERVATION_TTL_MS) });
+    assert.equal(isExpired(held, { now: NOW }), true);
+  });
+
+  await t.test('falls back to createdAt for orders written before reservedAt existed', () => {
+    const legacy = order({ reservedAt: undefined, createdAt: new Date(NOW - 90 * MINUTE) });
+    assert.equal(isExpired(legacy, { now: NOW }), true);
+  });
+
+  await t.test('a hold with no timestamp at all is left alone', () => {
+    // A sweeper that guesses is a sweeper that eventually cancels a live
+    // order.
+    const undated = order({ reservedAt: undefined, createdAt: undefined });
+    assert.equal(isExpired(undated, { now: NOW }), false);
+  });
+
+  await t.test('an unparseable timestamp is left alone', () => {
+    const bad = order({ reservedAt: 'not a date', createdAt: undefined });
+    assert.equal(isExpired(bad, { now: NOW }), false);
+  });
+
+  await t.test('honours a custom TTL', () => {
+    const held = order({ reservedAt: new Date(NOW - 10 * MINUTE) });
+    assert.equal(isExpired(held, { now: NOW, ttlMs: 5 * MINUTE }), true);
+    assert.equal(isExpired(held, { now: NOW, ttlMs: 15 * MINUTE }), false);
+  });
+});
+
+test('reservationLines', async (t) => {
+  await t.test('shapes lines for restoreInventory', () => {
+    const held = order({
+      items: [
+        { bookId: 'b1', title: 'One', price: 100, quantity: 2 },
+        { bookId: 'b2', title: 'Two', price: 200, quantity: 1 },
+      ],
+    });
+
+    assert.deepEqual(reservationLines(held), [
+      { bookId: 'b1', quantity: 2 },
+      { bookId: 'b2', quantity: 1 },
+    ]);
+  });
+
+  await t.test('drops lines restoreInventory could not use anyway', () => {
+    const held = order({
+      items: [
+        { bookId: 'b1', quantity: 2 },
+        { bookId: 'b2', quantity: 0 },
+        { bookId: 'b3', quantity: -1 },
+        { bookId: 'b4', quantity: 1.5 },
+        { quantity: 3 },
+        null,
+      ],
+    });
+
+    assert.deepEqual(reservationLines(held), [{ bookId: 'b1', quantity: 2 }]);
+  });
+
+  await t.test('is empty for a missing item list', () => {
+    assert.deepEqual(reservationLines({}), []);
+    assert.deepEqual(reservationLines(null), []);
+  });
+});
+
+test('decideRelease', async (t) => {
+  await t.test('releases an abandoned pending checkout', () => {
+    const decision = decideRelease(order(), { now: NOW });
+
+    assert.equal(decision.action, 'release');
+    assert.deepEqual(decision.lines, [{ bookId: 'b1', quantity: 2 }]);
+    assert.equal(decision.changes.status, 'canceled');
+    assert.equal(decision.changes.paymentStatus, 'canceled');
+    assert.equal(decision.changes.reservationReleasedAt.getTime(), NOW);
+  });
+
+  await t.test('leaves a checkout the customer may still be filling in', () => {
+    const fresh = order({ reservedAt: new Date(NOW - 2 * MINUTE) });
+    const decision = decideRelease(fresh, { now: NOW });
+
+    assert.equal(decision.action, 'skip');
+    assert.equal(decision.reason, 'reservation has not expired yet');
+  });
+
+  await t.test('releases a declined card immediately, without waiting out the TTL', () => {
+    const declined = order({
+      paymentStatus: 'failed',
+      status: 'payment_failed',
+      reservedAt: new Date(NOW - 30 * 1000),
+    });
+
+    assert.equal(decideRelease(declined, { now: NOW }).action, 'release');
+  });
+
+  await t.test('never releases a paid order', () => {
+    const paid = order({ paymentStatus: 'paid', reservedAt: new Date(NOW - 300 * MINUTE) });
+    const decision = decideRelease(paid, { now: NOW });
+
+    assert.equal(decision.action, 'skip');
+    assert.equal(decision.reason, 'order is not holding a reservation');
+  });
+
+  await t.test('is idempotent — a released hold is skipped', () => {
+    const released = order({ reservationReleasedAt: new Date(NOW - 5 * MINUTE) });
+    assert.equal(decideRelease(released, { now: NOW }).action, 'skip');
+  });
+
+  await t.test('skips an order whose lines are all unusable', () => {
+    const junk = order({ items: [{ bookId: 'b1', quantity: 0 }] });
+    const decision = decideRelease(junk, { now: NOW });
+
+    assert.equal(decision.action, 'skip');
+    assert.equal(decision.reason, 'no restorable lines');
+  });
+
+  await t.test('mutates nothing', () => {
+    const held = order();
+    const snapshot = JSON.stringify(held);
+
+    decideRelease(held, { now: NOW });
+    assert.equal(JSON.stringify(held), snapshot);
+  });
+});
+
+test('planSweep', async (t) => {
+  await t.test('splits a batch into releases and skips', () => {
+    const batch = [
+      order({ _id: 'a', reservedAt: new Date(NOW - 60 * MINUTE) }),
+      order({ _id: 'b', reservedAt: new Date(NOW - 1 * MINUTE) }),
+      order({ _id: 'c', paymentStatus: 'paid' }),
+      order({ _id: 'd', paymentStatus: 'failed' }),
+    ];
+
+    const { releases, skipped } = planSweep(batch, { now: NOW });
+
+    assert.deepEqual(releases.map((r) => r.order._id), ['a', 'd']);
+    assert.deepEqual(skipped.map((s) => s.order._id), ['b', 'c']);
+  });
+
+  await t.test('copes with a non-array', () => {
+    assert.deepEqual(planSweep(null), { releases: [], skipped: [] });
+    assert.deepEqual(planSweep(undefined), { releases: [], skipped: [] });
+  });
+});

--- a/bookshelf-backend/utils/reservations.js
+++ b/bookshelf-backend/utils/reservations.js
@@ -1,0 +1,208 @@
+/**
+ * Reservation expiry.
+ *
+ * Checkout takes inventory off the shelf *before* the customer pays, because
+ * the alternative is overselling in the window between charging and
+ * reserving — that was #297. The half that was never built is the other side
+ * of it: nothing ever put the stock back if the customer simply walked away.
+ *
+ * `paymentController.createIntent` hands the reservation to the webhook once
+ * the Stripe intent exists, and the webhook releases it on
+ * `payment_intent.payment_failed` and `payment_intent.canceled`. A customer
+ * who closes the tab at the card form produces neither event. The order sat
+ * at `pending` and the books stayed reserved, permanently. With inventories
+ * of 8 to 10 across 8 titles — 78 units for the whole shop — a short loop
+ * against an endpoint that is anonymous and unthrottled emptied it in under a
+ * minute, with no card and no charge. See #329.
+ *
+ * The functions here are pure: they decide *what* should happen to a set of
+ * orders, and return it. Doing the database and filesystem work is the
+ * caller's job. Same split as `utils/webhookEvents.js`, and for the same
+ * reason — the decisions are the part worth testing, and they should be
+ * testable without a Mongo instance or a writable books.json.
+ */
+
+/**
+ * How long a reservation is held before it is swept.
+ *
+ * Thirty minutes is comfortably longer than filling in a card takes, including
+ * a 3-D Secure detour and a bank app, and short enough that an abandoned cart
+ * does not hold stock for the rest of the day. Configurable, because the right
+ * number depends on the shop.
+ */
+export const DEFAULT_RESERVATION_TTL_MS = 30 * 60 * 1000;
+
+/**
+ * Terminal and unpaid. The customer is not going to be charged for this, so
+ * the stock belongs back on the shelf — and there is nothing to wait for.
+ *
+ * These matter more than they look. The webhook marks an order `failed` or
+ * `canceled` and **never calls `restoreInventory`** — the comment in
+ * paymentController saying the webhook is responsible for the reservation
+ * describes an intention, not the code. `restoreInventory` had exactly one
+ * caller before this change, in the same request that took the stock. So a
+ * declined card destroyed the reserved units just as permanently as an
+ * abandoned tab did.
+ */
+const TERMINAL_UNPAID_STATUSES = new Set(['failed', 'canceled']);
+
+/** The customer has been charged. The stock is theirs; never sweep it. */
+const PAID_STATUSES = new Set(['paid']);
+
+/**
+ * Is this order still holding stock it has not paid for?
+ *
+ * `paymentStatus` is the field that matters, not `status`. An order can be
+ * `status: 'pending'` with `paymentStatus: 'paid'` for as long as fulfilment
+ * takes to pick it up, and sweeping that would take stock away from a
+ * customer who has been charged for it — the worst possible outcome for a
+ * function whose job is to be conservative.
+ */
+export function holdsReservation(order) {
+  if (!order || typeof order !== 'object') {
+    return false;
+  }
+
+  if (PAID_STATUSES.has(order.paymentStatus)) {
+    return false;
+  }
+
+  // Already released. `restoreInventory` is not idempotent — running it twice
+  // would hand the same units back twice and inflate the catalogue.
+  if (order.reservationReleasedAt) {
+    return false;
+  }
+
+  return Array.isArray(order.items) && order.items.length > 0;
+}
+
+/**
+ * Does this hold have to wait out the TTL before it can be released?
+ *
+ * Only a `pending` one does, because "pending" is genuinely ambiguous: the
+ * customer may still be typing their card number. `failed` and `canceled`
+ * are not ambiguous at all — nobody is going to pay for that order — so
+ * making those wait 30 minutes would hold stock off the shelf for no reason.
+ */
+export function requiresExpiry(order) {
+  return !TERMINAL_UNPAID_STATUSES.has(order?.paymentStatus);
+}
+
+/**
+ * Has the hold lasted longer than it is allowed to?
+ *
+ * Measured from `reservedAt` where it exists and from `createdAt` otherwise,
+ * so orders written before this field existed are still swept rather than
+ * being held forever by their own missing timestamp.
+ */
+export function isExpired(order, { now = Date.now(), ttlMs = DEFAULT_RESERVATION_TTL_MS } = {}) {
+  const stamp = order?.reservedAt ?? order?.createdAt;
+
+  if (!stamp) {
+    // No timestamp at all: not provably expired, so leave it alone. A sweeper
+    // that guesses is a sweeper that eventually cancels a live order.
+    return false;
+  }
+
+  const reservedAt = new Date(stamp).getTime();
+
+  if (Number.isNaN(reservedAt)) {
+    return false;
+  }
+
+  return now - reservedAt >= ttlMs;
+}
+
+/**
+ * The lines to hand back for an order.
+ *
+ * Shaped for `restoreInventory`, which takes `{ bookId, quantity }` and skips
+ * anything it cannot use. Filtering here as well means a single malformed
+ * line does not quietly become a restore of zero.
+ */
+export function reservationLines(order) {
+  if (!Array.isArray(order?.items)) {
+    return [];
+  }
+
+  return order.items
+    .filter(
+      (item) =>
+        item &&
+        typeof item.bookId === 'string' &&
+        Number.isInteger(item.quantity) &&
+        item.quantity > 0
+    )
+    .map((item) => ({ bookId: item.bookId, quantity: item.quantity }));
+}
+
+/**
+ * Decide what to do with one order.
+ *
+ * Returns either `{ action: 'skip', reason }` or `{ action: 'release', lines,
+ * changes }`, where `changes` is what to write onto the document. The caller
+ * applies it; nothing is mutated here.
+ */
+export function decideRelease(order, options = {}) {
+  const { now = Date.now(), ttlMs = DEFAULT_RESERVATION_TTL_MS } = options;
+
+  if (!holdsReservation(order)) {
+    return { action: 'skip', reason: 'order is not holding a reservation' };
+  }
+
+  if (requiresExpiry(order) && !isExpired(order, { now, ttlMs })) {
+    return { action: 'skip', reason: 'reservation has not expired yet' };
+  }
+
+  const lines = reservationLines(order);
+
+  if (lines.length === 0) {
+    return { action: 'skip', reason: 'no restorable lines' };
+  }
+
+  return {
+    action: 'release',
+    lines,
+    changes: {
+      status: 'canceled',
+      paymentStatus: 'canceled',
+      // The marker that makes a second sweep a no-op. Without it, two
+      // overlapping runs would restore the same units twice.
+      reservationReleasedAt: new Date(now),
+    },
+  };
+}
+
+/**
+ * Plan a whole sweep.
+ *
+ * Separated from `decideRelease` so a caller can see, log or assert on the
+ * complete set of decisions before any of them is applied.
+ */
+export function planSweep(orders, options = {}) {
+  const list = Array.isArray(orders) ? orders : [];
+
+  const releases = [];
+  const skipped = [];
+
+  for (const order of list) {
+    const decision = decideRelease(order, options);
+
+    if (decision.action === 'release') {
+      releases.push({ order, ...decision });
+    } else {
+      skipped.push({ order, ...decision });
+    }
+  }
+
+  return { releases, skipped };
+}
+
+export default {
+  DEFAULT_RESERVATION_TTL_MS,
+  decideRelease,
+  holdsReservation,
+  isExpired,
+  planSweep,
+  reservationLines,
+};


### PR DESCRIPTION
Closes #329

`POST /api/payments/create-intent` takes inventory off the shelf **before** the customer pays. That is the right call — the alternative is overselling in the window between charging and reserving, which is what #297 was about. The half that was never built is the other side of it: **nothing ever put the stock back.**

## The webhook does not release anything

`paymentController.js:107` hands the reservation over:

```js
// Past this point the reservation belongs to the order, and the webhook
// is responsible for it: payment_intent.payment_failed and
// payment_intent.canceled are where it gets released.
reservationHeld = false;
```

That comment describes an intention, not the code:

```
$ grep -rn "restoreInventory" bookshelf-backend --include="*.js"
repositories/bookRepository.js:125:export const restoreInventory = ...
controllers/paymentController.js:69:    const { failed } = restoreInventory(checkout.reservation);
```

**One caller**, in the same request that took the stock. The webhook marks an order `failed` or `canceled` and never restores a single line. So this is worse than the issue described: a **declined card** destroyed the reserved units just as permanently as an abandoned tab did.

## And the route made it cheap

`paymentRoutes.js` was three lines of substance — no auth (by design, guests check out) and **no limiter**, while `/api/auth` has had one since #275. Inventory is 8–10 across 8 titles:

```
$ python3 -c "import json;print([b['inventory'] for b in json.load(open('bookshelf-backend/data/books.json'))])"
[8, 10, 10, 10, 10, 10, 10, 10]
```

78 units for the entire shop. A loop posting valid carts empties it in under a minute, from no account, with no card and no charge. Every real customer then gets a 409 until someone hand-edits `books.json` on the server.

It does not take malice, either. A customer who opens checkout, changes their mind and closes the tab has taken those copies off the shelf for good.

## What changes

**A reservation is a fact in the database.** `reservedAt` records when the hold started; `reservationReleasedAt` records that it has been handed back. The second is what makes the sweep **idempotent** — `restoreInventory` is deliberately not version-checked and adds units unconditionally, so without a marker two overlapping passes would hand the same stock back twice.

**`utils/reservations.js` (new)** — pure decision functions, split out the way `utils/webhookEvents.js` was split out of the webhook handler in #306, so they are testable with no Mongo instance and no writable `books.json`.

**`services/reservationSweeper.js` (new)** — the part that talks to the database and the filesystem. Started from `server.js` after the Mongo connection, on an interval, plus one pass immediately (a process that crashed mid-checkout left stock reserved against an order nobody will pay for).

**`checkoutLimiter`** on the route: 20/hour per address. Far above what a real customer needs — a checkout is one call, retried at most a handful of times — and far below what it takes to drain 78 units. The limiter bounds how fast stock can be taken; the sweeper is what gives it back.

`RESERVATION_TTL_MS` (default 30 min) and `RESERVATION_SWEEP_INTERVAL_MS` (default 5 min) are read from the environment.

## Three decisions worth reviewing

**1. Terminal-unpaid holds do not wait out the TTL.** A `pending` hold has to, because "pending" is genuinely ambiguous — the customer may still be typing their card number. `failed` and `canceled` are not ambiguous at all; nobody is going to pay for that order, so holding the stock for another 30 minutes helps no one.

**2. "Paid" is judged on `paymentStatus`, never on `status`.** An order sits at `status: 'pending'` with `paymentStatus: 'paid'` for as long as fulfilment takes to pick it up. Sweeping on `status` would take stock away from a customer who has already been charged — the worst outcome available to a function whose job is to be conservative.

**3. Stock goes back *before* the order is marked.** The other order loses stock outright: if the write to `books.json` failed after the marker was set, the marker would stop the next sweep from ever retrying. This way a crash between the two restores the stock without recording it, and the next sweep restores it again — a bounded over-count on the shop's own catalogue, against permanently vanished stock. The recoverable failure is the one to choose, and the trade-off is written down at the point it is made.

A hold with **no** usable timestamp is left alone rather than swept. A sweeper that guesses is one that eventually cancels a live order.

## Tests

48 new tests; full backend suite **435 passing** on Node 20 and 22.

`reservations.test.js` (34) — abandoned pending releases; fresh pending does not; a declined card releases immediately; a paid order never releases, including `status: 'pending'` + `paymentStatus: 'paid'`; a released hold is skipped (idempotency); orders predating `reservedAt` fall back to `createdAt`; a hold with no or unparseable timestamp is left alone; the TTL boundary; malformed lines are dropped; `decideRelease` mutates nothing.

`reservationSweeper.test.js` (12) — stock goes back and the order is marked; **a second sweep restores nothing**; the TTL query window; stock is still restored when the save fails; failed lines are counted and logged; a query failure returns rather than throwing into the interval; two overlapping sweeps do not both run; a mixed batch releases exactly the right two.

`checkoutLimiter.test.js` (2) — an ordinary checkout passes with the right headers; the 21st is answered 429 **before the controller runs**, so no stock is reserved.

## Notes

- The webhook is **not** modified. It marks the order, and the sweeper picks up `failed`/`canceled` holds on its next pass (within 5 minutes by default). Releasing inline from the webhook would be faster, but it would put a filesystem write on the Stripe retry path, where a failure turns into a redelivery loop — the thing #306 went to some trouble to eliminate.
- The in-request `release()` path now also sets `reservationReleasedAt`, so a failure during checkout cannot be restored a second time by a later sweep.
- The sweeper's timer is `unref()`ed, so it does not hold the event loop open.
- New compound index `{ paymentStatus, reservationReleasedAt, reservedAt }` for the sweep query.
