### PR TITLE
fix(currency): charge the currency the shop displays

### DIFF
--- a/bookshelf-backend/.env.example
+++ b/bookshelf-backend/.env.example
@@ -29,6 +29,15 @@ JWT_EXPIRES_IN=7d
 # are only returned to clients when this is exactly "development".
 NODE_ENV=development
 
+# The currency the shop prices and charges in: INR or USD.
+#
+# Defaults to INR, which is what data/books.json is priced in. This must match
+# VITE_CURRENCY in the frontend — the backend is what creates the payment
+# intent, so a mismatch means displaying one currency and charging another.
+# The server refuses to start on an unsupported value rather than quietly
+# falling back.
+CURRENCY=INR
+
 # Origin allowed by CORS. Must match where the frontend is served from,
 # and credentials are sent, so it cannot be "*".
 FRONTEND_URL=http://localhost:5173

--- a/bookshelf-backend/config/currency.js
+++ b/bookshelf-backend/config/currency.js
@@ -1,0 +1,168 @@
+/**
+ * The currency the shop trades in, resolved once and validated.
+ *
+ * There was no such thing before, and the app held three incompatible opinions
+ * at the same time (#335):
+ *
+ *   - `data/books.json` prices books at 349, 499, 299 — rupee amounts.
+ *   - The catalogue, the cart drawer and the checkout summary rendered them
+ *     with a `₹` sign.
+ *   - `services/stripeService.js` created every payment intent with
+ *     `currency = 'usd'`, and the order history rendered the result with `$`.
+ *
+ * A customer saw ₹349 and was charged $349.00. The number was right and the
+ * unit was wrong, which is the worst way for a price to be wrong: nothing
+ * looks broken until the card statement arrives.
+ *
+ * So the currency is configuration now, it has exactly one home, and both the
+ * amount charged and the amount displayed are derived from it. The frontend
+ * mirror lives in `bookshelf-frontend/src/utils/currency.js` and is kept
+ * honest by `tests/currency.test.js` asserting the two tables agree.
+ */
+
+export class CurrencyConfigError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'CurrencyConfigError';
+  }
+}
+
+/**
+ * What the shop knows how to price in.
+ *
+ * `exponent` is the number of decimal places the currency has, which is also
+ * what Stripe means by minor units. It is 2 for both of these, but it is
+ * stated rather than assumed because it is not universal — JPY is 0, and
+ * `Math.round(amount * 100)` would charge a Japanese customer a hundred times
+ * the price. Adding a zero-decimal currency to this table should not require
+ * finding every place that hardcoded 100.
+ *
+ * `defaultShipping` is in major units. It was a single hardcoded 5.99 in
+ * utils/checkout.js — a dollar figure sitting next to a catalogue of rupee
+ * prices, charged unchanged whichever currency the intent was created in.
+ */
+export const SUPPORTED_CURRENCIES = Object.freeze({
+  INR: Object.freeze({
+    code: 'INR',
+    // What Stripe wants: lowercase ISO 4217.
+    stripeCode: 'inr',
+    symbol: '₹',
+    // Spoken form, for an aria-label. "Minimum price in ₹" is what a screen
+    // reader is handed if the symbol is used there, and how a symbol is
+    // announced varies by screen reader and by voice — some say nothing at
+    // all. "Minimum price in rupees" is unambiguous.
+    name: 'rupees',
+    locale: 'en-IN',
+    exponent: 2,
+    defaultShipping: 49,
+  }),
+  USD: Object.freeze({
+    code: 'USD',
+    stripeCode: 'usd',
+    symbol: '$',
+    name: 'dollars',
+    locale: 'en-US',
+    exponent: 2,
+    defaultShipping: 5.99,
+  }),
+});
+
+/**
+ * INR, because that is what the catalogue is priced in.
+ *
+ * Defaulting to USD would keep the Stripe call unchanged and leave every
+ * displayed price wrong, which is the bug. Defaulting to the currency the
+ * data is actually in means an existing deployment that sets nothing starts
+ * charging what it has been advertising.
+ */
+export const DEFAULT_CURRENCY = 'INR';
+
+/**
+ * Resolve a currency code to its definition.
+ *
+ * Case-insensitive, because `CURRENCY=inr` in a .env file is not a mistake
+ * worth refusing to start over.
+ */
+export function resolveCurrency(code) {
+  if (code === undefined || code === null || String(code).trim() === '') {
+    return SUPPORTED_CURRENCIES[DEFAULT_CURRENCY];
+  }
+
+  const normalised = String(code).trim().toUpperCase();
+  const currency = SUPPORTED_CURRENCIES[normalised];
+
+  if (!currency) {
+    throw new CurrencyConfigError(
+      `CURRENCY is set to "${code}", which this shop does not support. ` +
+        `Supported values: ${Object.keys(SUPPORTED_CURRENCIES).join(', ')}. ` +
+        'Adding one means adding it to config/currency.js here and to ' +
+        'bookshelf-frontend/src/utils/currency.js, which must agree.'
+    );
+  }
+
+  return currency;
+}
+
+export function loadCurrencyConfig(env = process.env) {
+  return resolveCurrency(env.CURRENCY);
+}
+
+let cached = null;
+
+/**
+ * Resolved lazily, for the same reason getStripeConfig() is: importing a
+ * module must not be able to throw on configuration, because app.js is
+ * imported by tests that have no interest in it.
+ */
+export function getCurrencyConfig() {
+  if (!cached) {
+    cached = loadCurrencyConfig();
+  }
+  return cached;
+}
+
+/** Test seam. Not used by application code. */
+export function resetCurrencyConfigCache() {
+  cached = null;
+}
+
+/** Minor units per major unit for a currency — 100 for a 2-decimal one. */
+export function minorUnitsPerMajor(currency) {
+  return 10 ** currency.exponent;
+}
+
+/**
+ * Format for a log line or an error message. Not for the UI — the UI formats
+ * with Intl, in the browser's own idea of the locale.
+ */
+export function formatAmount(majorUnits, currency = getCurrencyConfig()) {
+  /*
+   * Checked before any coercion, because `Number(null)` and `Number('')` are
+   * both 0 — so a missing amount would be logged as "₹0.00", which reads as a
+   * fact rather than as an absence. The same trap is guarded the same way in
+   * the frontend's utils/currency.js.
+   */
+  if (typeof majorUnits !== 'number' && typeof majorUnits !== 'string') {
+    return `${currency.symbol}—`;
+  }
+
+  const value = Number(majorUnits);
+
+  if (!Number.isFinite(value)) {
+    return `${currency.symbol}—`;
+  }
+
+  return `${currency.symbol}${value.toFixed(currency.exponent)}`;
+}
+
+export default {
+  SUPPORTED_CURRENCIES,
+  DEFAULT_CURRENCY,
+  CurrencyConfigError,
+  resolveCurrency,
+  loadCurrencyConfig,
+  getCurrencyConfig,
+  resetCurrencyConfigCache,
+  minorUnitsPerMajor,
+  formatAmount,
+};

--- a/bookshelf-backend/controllers/paymentController.js
+++ b/bookshelf-backend/controllers/paymentController.js
@@ -6,7 +6,7 @@ import {
   restoreInventory,
 } from '../repositories/bookRepository.js';
 import { prepareCheckout, CheckoutValidationError } from '../utils/checkout.js';
-import { format } from '../utils/money.js';
+import { getCurrencyConfig, formatAmount } from '../config/currency.js';
 
 /**
  * @desc    Create a payment intent for a cart
@@ -31,10 +31,18 @@ import { format } from '../utils/money.js';
 export const createIntent = async (req, res, next) => {
   const { items, shippingAddress } = req.body ?? {};
 
+  /*
+   * One currency, read once, used for the price, for the payment intent and
+   * for the record kept on the order. The intent used to be created with a
+   * hardcoded 'usd' while the shop displayed every price with a `₹` sign, so
+   * a customer saw ₹349 and was charged $349.00. See #335.
+   */
+  const currency = getCurrencyConfig();
+
   let checkout;
 
   try {
-    checkout = prepareCheckout(items, getBookById);
+    checkout = prepareCheckout(items, getBookById, { currency });
   } catch (error) {
     if (error instanceof CheckoutValidationError) {
       return res.status(400).json({
@@ -91,6 +99,13 @@ export const createIntent = async (req, res, next) => {
       userId: req.user ? req.user._id : null,
       items: checkout.orderItems,
       shippingAddress: shippingAddress || {},
+      /*
+       * Recorded on the order rather than resolved at render time. An order
+       * placed before the shop changed currency was charged in the currency
+       * it was placed in, and its history must keep saying so — reading the
+       * *current* setting would silently relabel every historical total.
+       */
+      currency: checkout.currency,
       subtotal: checkout.subtotal,
       tax: checkout.tax,
       shipping: checkout.shipping,
@@ -112,10 +127,22 @@ export const createIntent = async (req, res, next) => {
   }
 
   try {
-    const paymentIntent = await createPaymentIntent(checkout.total, 'usd', {
-      orderId: savedOrder._id.toString(),
-      userId: req.user ? req.user._id.toString() : 'guest',
-    });
+    /*
+     * The integer minor-unit total goes to Stripe directly. Handing over the
+     * major-unit number meant stripeService did its own `Math.round(x * 100)`
+     * on a value money.js had already rounded exactly once — a second
+     * rounding of an already-exact number, and one that assumed two decimal
+     * places for every currency in the world.
+     */
+    const paymentIntent = await createPaymentIntent(
+      checkout.minorUnits.total,
+      currency.stripeCode,
+      {
+        orderId: savedOrder._id.toString(),
+        userId: req.user ? req.user._id.toString() : 'guest',
+        currency: currency.code,
+      }
+    );
 
     savedOrder.stripePaymentIntentId = paymentIntent.id;
     await orderRepository.save(savedOrder);
@@ -128,7 +155,12 @@ export const createIntent = async (req, res, next) => {
     return res.status(200).json({
       clientSecret: paymentIntent.client_secret,
       orderId: savedOrder._id,
+      // The currency is part of the amount, not a separate fact the frontend
+      // is expected to already know. The checkout summary renders what this
+      // says rather than what it assumes.
+      currency: checkout.currency,
       amount: {
+        currency: checkout.currency,
         subtotal: checkout.subtotal,
         tax: checkout.tax,
         shipping: checkout.shipping,
@@ -153,7 +185,7 @@ export const createIntent = async (req, res, next) => {
 
     console.error(
       `[checkout] payment intent failed for order ${savedOrder._id} ` +
-        `(total ${format(checkout.minorUnits.total)}):`,
+        `(total ${formatAmount(checkout.total, currency)}):`,
       error.message
     );
 

--- a/bookshelf-backend/models/Order.js
+++ b/bookshelf-backend/models/Order.js
@@ -22,6 +22,20 @@ const orderSchema = new mongoose.Schema(
       postalCode: { type: String },
       country: { type: String },
     },
+    /*
+     * The currency the order was priced and charged in.
+     *
+     * Not optional in spirit, but not `required` either: orders written before
+     * #335 have no such field, and refusing to load them would turn a display
+     * bug into a broken order history. `orderFormat.js` on the frontend falls
+     * back for exactly those documents.
+     */
+    currency: {
+      type: String,
+      uppercase: true,
+      trim: true,
+      default: 'INR',
+    },
     subtotal: { type: Number, required: true },
     tax: { type: Number, required: true, default: 0 },
     shipping: { type: Number, required: true, default: 0 },

--- a/bookshelf-backend/services/stripeService.js
+++ b/bookshelf-backend/services/stripeService.js
@@ -31,11 +31,44 @@ export function resetStripeClient() {
   client = null;
 }
 
-export const createPaymentIntent = async (amount, currency = 'usd', metadata = {}) => {
+/**
+ * Create a payment intent.
+ *
+ * `minorUnits` is an integer number of the currency's smallest unit — paise,
+ * cents — and it is passed to Stripe untouched. This used to take a
+ * major-unit amount and do its own conversion:
+ *
+ *   amount: Math.round(amount * 100), // Stripe expects amounts in cents
+ *
+ * which was wrong twice. It re-rounded a value `utils/money.js` had already
+ * rounded exactly once, deliberately, from an integer it was holding — and it
+ * assumed every currency has two decimal places, so a zero-decimal currency
+ * would have been charged a hundred times the price.
+ *
+ * `currency` has no default. It used to default to 'usd' while the shop
+ * displayed rupees, so a customer saw ₹349 and was charged $349.00. The
+ * caller reads it from config/currency.js; there is no safe guess to make
+ * here. See #335.
+ */
+export const createPaymentIntent = async (minorUnits, currency, metadata = {}) => {
+  if (!Number.isSafeInteger(minorUnits) || minorUnits < 0) {
+    throw new Error(
+      `Stripe PaymentIntent Error: amount must be a non-negative integer ` +
+        `number of minor units, received ${minorUnits}`
+    );
+  }
+
+  if (typeof currency !== 'string' || currency.trim() === '') {
+    throw new Error(
+      'Stripe PaymentIntent Error: currency is required. Read it from ' +
+        'config/currency.js rather than defaulting it.'
+    );
+  }
+
   try {
     const paymentIntent = await getStripeClient().paymentIntents.create({
-      amount: Math.round(amount * 100), // Stripe expects amounts in cents
-      currency,
+      amount: minorUnits,
+      currency: currency.trim().toLowerCase(),
       automatic_payment_methods: {
         enabled: true,
       },

--- a/bookshelf-backend/tests/checkout.test.js
+++ b/bookshelf-backend/tests/checkout.test.js
@@ -9,7 +9,9 @@ import {
   priceOrder,
   toReservation,
   prepareCheckout,
+  defaultShipping,
 } from '../utils/checkout.js';
+import { SUPPORTED_CURRENCIES } from '../config/currency.js';
 
 /**
  * A three-book catalogue. The real one is read from disk; the lookup is
@@ -201,8 +203,43 @@ describe('priceOrder', () => {
 
     assert.equal(pricing.subtotal, 1047);
     assert.equal(pricing.tax, 52.35); // not 52.35000000000001
-    assert.equal(pricing.shipping, 5.99);
-    assert.equal(pricing.total, 1105.34);
+    // 49, not 5.99: shipping is a major-unit amount in the shop's own
+    // currency, which is INR. It used to be a hardcoded dollar figure
+    // charged next to a rupee-priced catalogue. See #335.
+    assert.equal(pricing.shipping, 49);
+    assert.equal(pricing.total, 1148.35);
+  });
+
+  test('prices in the shop currency and says which one', () => {
+    const items = validateItems([{ id: 'b1', quantity: 3 }], lookupBook);
+
+    assert.equal(priceOrder(items).currency, 'INR');
+    assert.equal(
+      priceOrder(items, { currency: SUPPORTED_CURRENCIES.USD }).currency,
+      'USD'
+    );
+  });
+
+  test('shipping follows the currency it is priced in', () => {
+    const items = validateItems([{ id: 'b1', quantity: 3 }], lookupBook);
+
+    assert.equal(priceOrder(items).shipping, 49);
+    assert.equal(
+      priceOrder(items, { currency: SUPPORTED_CURRENCIES.USD }).shipping,
+      5.99
+    );
+
+    // The helper and the default used by priceOrder are the same number.
+    assert.equal(defaultShipping(), 49);
+    assert.equal(defaultShipping(SUPPORTED_CURRENCIES.USD), 5.99);
+  });
+
+  test('an explicit shipping override still wins over the currency default', () => {
+    const items = validateItems([{ id: 'b1', quantity: 3 }], lookupBook);
+    const pricing = priceOrder(items, { shipping: 0 });
+
+    assert.equal(pricing.shipping, 0);
+    assert.equal(pricing.total, 1099.35);
   });
 
   test('reports the integer minor units alongside the major ones', () => {
@@ -212,8 +249,8 @@ describe('priceOrder', () => {
     assert.deepEqual(minorUnits, {
       subtotal: 104700,
       tax: 5235,
-      shipping: 599,
-      total: 110534,
+      shipping: 4900,
+      total: 114835,
     });
   });
 
@@ -298,7 +335,8 @@ describe('prepareCheckout', () => {
   test('returns everything the controller needs in one call', () => {
     const result = prepareCheckout([{ id: 'b1', quantity: 2 }], lookupBook);
 
-    assert.equal(result.total, 738.89);
+    assert.equal(result.total, 781.9);
+    assert.equal(result.currency, 'INR');
     assert.equal(result.orderItems.length, 1);
     assert.deepEqual(result.reservation, [
       { bookId: 'b1', quantity: 2, expectedVersion: 2 },

--- a/bookshelf-backend/tests/currency.test.js
+++ b/bookshelf-backend/tests/currency.test.js
@@ -1,0 +1,223 @@
+import test, { describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import {
+  SUPPORTED_CURRENCIES,
+  DEFAULT_CURRENCY,
+  CurrencyConfigError,
+  resolveCurrency,
+  loadCurrencyConfig,
+  getCurrencyConfig,
+  resetCurrencyConfigCache,
+  minorUnitsPerMajor,
+  formatAmount,
+} from '../config/currency.js';
+
+/**
+ * The currency of the shop.
+ *
+ * The bug these cover (#335): the catalogue is priced in rupees, the UI
+ * rendered `₹`, and `createPaymentIntent(total, 'usd')` charged dollars. The
+ * number was right and the unit was wrong — ₹349 displayed, $349.00 taken.
+ *
+ * The last test in this file is the one that matters most. There are two
+ * currency tables, one per package, because the frontend cannot import from
+ * the backend. Two tables that must agree and are never compared are two
+ * tables that will stop agreeing, so this reads the frontend's and asserts
+ * the codes, symbols, locales and exponents line up.
+ */
+
+describe('resolveCurrency', () => {
+  test('defaults to the currency the catalogue is priced in', () => {
+    assert.equal(DEFAULT_CURRENCY, 'INR');
+    assert.equal(resolveCurrency(undefined).code, 'INR');
+    assert.equal(resolveCurrency(null).code, 'INR');
+    assert.equal(resolveCurrency('').code, 'INR');
+    assert.equal(resolveCurrency('   ').code, 'INR');
+  });
+
+  test('accepts a supported code in any case', () => {
+    assert.equal(resolveCurrency('usd').code, 'USD');
+    assert.equal(resolveCurrency('USD').code, 'USD');
+    assert.equal(resolveCurrency(' Usd ').code, 'USD');
+    assert.equal(resolveCurrency('inr').code, 'INR');
+  });
+
+  test('refuses a currency the shop cannot price in', () => {
+    assert.throws(() => resolveCurrency('EUR'), CurrencyConfigError);
+    assert.throws(() => resolveCurrency('JPY'), CurrencyConfigError);
+  });
+
+  test('the refusal names the supported values and both tables to update', () => {
+    try {
+      resolveCurrency('GBP');
+      assert.fail('should have thrown');
+    } catch (error) {
+      assert.match(error.message, /INR, USD/);
+      assert.match(error.message, /config\/currency\.js/);
+      assert.match(error.message, /bookshelf-frontend\/src\/utils\/currency\.js/);
+    }
+  });
+
+  test('every supported currency is fully described', () => {
+    for (const [key, currency] of Object.entries(SUPPORTED_CURRENCIES)) {
+      assert.equal(currency.code, key, `${key}: code should match its key`);
+      assert.equal(
+        currency.stripeCode,
+        key.toLowerCase(),
+        `${key}: Stripe wants a lowercase ISO code`
+      );
+      assert.equal(typeof currency.symbol, 'string');
+      assert.notEqual(currency.symbol, '');
+      assert.equal(typeof currency.name, 'string');
+      assert.notEqual(currency.name, '');
+      assert.match(currency.locale, /^[a-z]{2}-[A-Z]{2}$/);
+      assert.ok(Number.isInteger(currency.exponent) && currency.exponent >= 0);
+      assert.ok(Number.isFinite(currency.defaultShipping));
+      assert.ok(currency.defaultShipping >= 0);
+    }
+  });
+
+  test('the tables are frozen, so nothing can edit the shop currency at runtime', () => {
+    assert.throws(() => {
+      SUPPORTED_CURRENCIES.INR.symbol = '$';
+    }, TypeError);
+
+    assert.equal(SUPPORTED_CURRENCIES.INR.symbol, '₹');
+  });
+});
+
+describe('loadCurrencyConfig', () => {
+  test('reads CURRENCY from the environment it is given', () => {
+    assert.equal(loadCurrencyConfig({ CURRENCY: 'USD' }).code, 'USD');
+    assert.equal(loadCurrencyConfig({ CURRENCY: 'INR' }).code, 'INR');
+    assert.equal(loadCurrencyConfig({}).code, 'INR');
+  });
+
+  test('a bad CURRENCY is a startup-time refusal, not a silent fallback', () => {
+    assert.throws(
+      () => loadCurrencyConfig({ CURRENCY: 'dollars' }),
+      CurrencyConfigError
+    );
+  });
+});
+
+describe('getCurrencyConfig', () => {
+  test('caches, and the cache can be dropped for a test', () => {
+    resetCurrencyConfigCache();
+
+    const first = getCurrencyConfig();
+    const second = getCurrencyConfig();
+
+    assert.equal(first, second, 'should hand back the same frozen object');
+
+    resetCurrencyConfigCache();
+    assert.equal(getCurrencyConfig().code, first.code);
+  });
+});
+
+describe('minorUnitsPerMajor', () => {
+  test('derives from the exponent rather than assuming 100', () => {
+    assert.equal(minorUnitsPerMajor(SUPPORTED_CURRENCIES.INR), 100);
+    assert.equal(minorUnitsPerMajor(SUPPORTED_CURRENCIES.USD), 100);
+
+    // The reason it is a function at all: a zero-decimal currency would make
+    // `Math.round(amount * 100)` charge a hundred times the price.
+    assert.equal(minorUnitsPerMajor({ exponent: 0 }), 1);
+    assert.equal(minorUnitsPerMajor({ exponent: 3 }), 1000);
+  });
+});
+
+describe('formatAmount', () => {
+  test('uses the symbol and decimal places of the currency it is given', () => {
+    assert.equal(formatAmount(1047, SUPPORTED_CURRENCIES.INR), '₹1047.00');
+    assert.equal(formatAmount(1047, SUPPORTED_CURRENCIES.USD), '$1047.00');
+    assert.equal(formatAmount(52.35, SUPPORTED_CURRENCIES.INR), '₹52.35');
+  });
+
+  test('does not print NaN into a log line', () => {
+    assert.equal(formatAmount(undefined, SUPPORTED_CURRENCIES.INR), '₹—');
+    assert.equal(formatAmount(null, SUPPORTED_CURRENCIES.INR), '₹—');
+    assert.equal(formatAmount('nonsense', SUPPORTED_CURRENCIES.INR), '₹—');
+  });
+
+  test('defaults to the configured currency', () => {
+    resetCurrencyConfigCache();
+    assert.equal(formatAmount(10), '₹10.00');
+  });
+});
+
+describe('the frontend currency table agrees with this one', () => {
+  /**
+   * Read as text and parsed with a regex rather than imported: the frontend
+   * module is ESM built for Vite and reads `import.meta.env`, which does not
+   * exist under plain Node. The table itself is a plain object literal, and
+   * the point is to catch a symbol or an exponent changing on one side only.
+   */
+  const source = readFileSync(
+    fileURLToPath(
+      new URL('../../bookshelf-frontend/src/utils/currency.js', import.meta.url)
+    ),
+    'utf8'
+  );
+
+  function frontendEntry(code) {
+    const block = source.match(
+      new RegExp(`${code}:\\s*Object\\.freeze\\(\\{([\\s\\S]*?)\\}\\)`)
+    );
+
+    assert.ok(block, `frontend currency table has no ${code} entry`);
+
+    const field = (name) => {
+      const match = block[1].match(new RegExp(`${name}:\\s*'([^']*)'`));
+      return match ? match[1] : null;
+    };
+
+    const numeric = (name) => {
+      const match = block[1].match(new RegExp(`${name}:\\s*([0-9.]+)`));
+      return match ? Number(match[1]) : null;
+    };
+
+    return {
+      code: field('code'),
+      symbol: field('symbol'),
+      name: field('name'),
+      locale: field('locale'),
+      exponent: numeric('exponent'),
+    };
+  }
+
+  for (const code of Object.keys(SUPPORTED_CURRENCIES)) {
+    test(`${code} matches`, () => {
+      const mine = SUPPORTED_CURRENCIES[code];
+      const theirs = frontendEntry(code);
+
+      assert.equal(theirs.code, mine.code, `${code}: code`);
+      assert.equal(theirs.symbol, mine.symbol, `${code}: symbol`);
+      assert.equal(theirs.name, mine.name, `${code}: spoken name`);
+      assert.equal(theirs.locale, mine.locale, `${code}: locale`);
+      assert.equal(theirs.exponent, mine.exponent, `${code}: exponent`);
+    });
+  }
+
+  test('the frontend supports exactly the currencies the backend does', () => {
+    const declared = [...source.matchAll(/^\s{2}([A-Z]{3}):\s*Object\.freeze/gm)].map(
+      (match) => match[1]
+    );
+
+    assert.deepEqual(
+      declared.sort(),
+      Object.keys(SUPPORTED_CURRENCIES).sort(),
+      'a currency added on one side must be added on the other'
+    );
+  });
+
+  test('the frontend default is the backend default', () => {
+    const match = source.match(/DEFAULT_CURRENCY_CODE\s*=\s*'([A-Z]{3})'/);
+
+    assert.ok(match, 'frontend does not declare DEFAULT_CURRENCY_CODE');
+    assert.equal(match[1], DEFAULT_CURRENCY);
+  });
+});

--- a/bookshelf-backend/utils/checkout.js
+++ b/bookshelf-backend/utils/checkout.js
@@ -19,12 +19,26 @@ import {
   toMajorUnits,
   toMinorUnits,
 } from './money.js';
+import { getCurrencyConfig } from '../config/currency.js';
 
 /** 5% mock tax, as before. Kept here so the number has one home. */
 export const TAX_RATE = 0.05;
 
-/** Flat shipping, in major units, as before. */
-export const SHIPPING_MAJOR_UNITS = 5.99;
+/**
+ * Flat shipping, in major units of the shop's currency.
+ *
+ * This was a hardcoded `5.99` — a dollar figure, charged unchanged next to a
+ * catalogue priced in rupees, because nothing in the pricing path knew what
+ * currency it was working in. It comes from config/currency.js now, which is
+ * the same place the payment intent gets its currency from. See #335.
+ *
+ * Read through a function rather than exported as a constant: the config is
+ * resolved lazily, and a module-scope read would fix the value at import time
+ * and defeat that.
+ */
+export function defaultShipping(currency = getCurrencyConfig()) {
+  return currency.defaultShipping;
+}
 
 /**
  * Bounds. None of these are business rules — they are the limits past which a
@@ -221,7 +235,10 @@ function describe(value) {
  * major-unit numbers (what goes on the order document and to Stripe), so a
  * caller never has to divide by 100 itself and get it subtly wrong.
  */
-export function priceOrder(items, { taxRate = TAX_RATE, shipping = SHIPPING_MAJOR_UNITS } = {}) {
+export function priceOrder(
+  items,
+  { taxRate = TAX_RATE, currency = getCurrencyConfig(), shipping = currency.defaultShipping } = {}
+) {
   const orderItems = [];
   const lineTotals = [];
 
@@ -246,6 +263,11 @@ export function priceOrder(items, { taxRate = TAX_RATE, shipping = SHIPPING_MAJO
 
   return {
     orderItems,
+    // Carried through so the caller never has to ask a second source what
+    // currency these numbers are in. The order document records it and the
+    // API response returns it, so the amount displayed and the amount
+    // charged cannot drift apart again.
+    currency: currency.code,
     minorUnits: {
       subtotal: subtotalMinor,
       tax: taxMinor,
@@ -296,7 +318,7 @@ export function prepareCheckout(rawItems, lookupBook, options) {
 
 export default {
   TAX_RATE,
-  SHIPPING_MAJOR_UNITS,
+  defaultShipping,
   MAX_LINE_ITEMS,
   MAX_QUANTITY_PER_LINE,
   CheckoutValidationError,

--- a/bookshelf-frontend/.env.example
+++ b/bookshelf-frontend/.env.example
@@ -12,3 +12,12 @@ VITE_API_BASE_URL=http://localhost:5000/api
 # Stripe publishable key (pk_...). Safe to ship in the bundle — the secret
 # key belongs in the backend .env and must never appear here.
 VITE_STRIPE_PUBLISHABLE_KEY=pk_test_your_key_here
+
+# The currency prices are displayed in: INR or USD.
+#
+# Defaults to INR. Must match CURRENCY in the backend .env — the backend
+# prices the order and creates the payment intent, so a mismatch means
+# showing a customer one currency and charging them another. An unsupported
+# value falls back to INR rather than throwing, because this is read by a
+# formatter that runs during render.
+VITE_CURRENCY=INR

--- a/bookshelf-frontend/src/components/BookPrice.jsx
+++ b/bookshelf-frontend/src/components/BookPrice.jsx
@@ -1,11 +1,20 @@
+import { currencySymbol, formatMoney } from '../utils/currency.js';
 import './BookPrice.css';
 
+/**
+ * Nothing imports this component yet. It is corrected anyway: it defaulted
+ * `currency` to a hardcoded '₹' and concatenated the raw number after it,
+ * which is the same class of bug #335 was filed for, waiting for whoever
+ * wires it up. `currency` now takes a *code* and the amounts are formatted,
+ * so `1234.5` renders as ₹1,234.50 rather than ₹1234.5.
+ */
 export default function BookPrice({
   price,
   originalPrice,
-  currency = '₹',
+  currency,
   size = 'medium',
 }) {
+  const symbol = currencySymbol(currency);
   const hasDiscount = originalPrice && Number(originalPrice) > Number(price);
 
   const discount = hasDiscount
@@ -15,15 +24,13 @@ export default function BookPrice({
   return (
     <div className={`book-price book-price--${size}`}>
       <span className="book-price__current">
-        {currency}
-        {price}
+        {formatMoney(price, { currency, fallback: `${symbol}—` })}
       </span>
 
       {hasDiscount && (
         <>
           <span className="book-price__original">
-            {currency}
-            {originalPrice}
+            {formatMoney(originalPrice, { currency, fallback: `${symbol}—` })}
           </span>
 
           <span className="book-price__discount">{discount}% OFF</span>

--- a/bookshelf-frontend/src/components/CartDrawer.jsx
+++ b/bookshelf-frontend/src/components/CartDrawer.jsx
@@ -3,6 +3,17 @@ import { useNavigate } from 'react-router-dom';
 
 import { useCart } from '../hooks/useCart.js';
 import { useFocusTrap, useScrollLock } from '../hooks/useFocusTrap.js';
+/*
+ * `item.price.toFixed(2)` threw on anything that was not a number, and a cart
+ * comes out of localStorage — see #309, where one malformed value took the
+ * whole app down. `formatMoney` returns an em dash for an unusable amount.
+ *
+ * It was replaced by a local `₹${amount.toFixed(2)}` helper, which was the
+ * third of four disagreeing money formatters in this app and the only one
+ * that did no digit grouping — ₹1234.00 in the drawer for the same cart the
+ * checkout summary showed as ₹1,234.00. See #335.
+ */
+import { formatMoney } from '../utils/currency.js';
 import './CartDrawer.css';
 
 /**
@@ -119,7 +130,7 @@ export default function CartDrawer() {
                   )}
                   <div className="cart-item__details">
                     <h4 className="cart-item__title">{item.title}</h4>
-                    <p className="cart-item__price">{formatPrice(item.price)}</p>
+                    <p className="cart-item__price">{formatMoney(item.price)}</p>
 
                     <div className="cart-item__actions">
                       <div className="cart-item__quantity">
@@ -151,7 +162,7 @@ export default function CartDrawer() {
                     </div>
                   </div>
                   <div className="cart-item__subtotal">
-                    {formatPrice(Number(item.price) * Number(item.quantity))}
+                    {formatMoney(lineTotal(item))}
                   </div>
                 </li>
               ))}
@@ -163,7 +174,7 @@ export default function CartDrawer() {
           <div className="cart-drawer__footer">
             <div className="cart-drawer__subtotal">
               <span>Subtotal</span>
-              <span>{formatPrice(subtotal)}</span>
+              <span>{formatMoney(subtotal)}</span>
             </div>
 
             <div className="cart-drawer__footer-actions">
@@ -186,16 +197,16 @@ export default function CartDrawer() {
 }
 
 /**
- * `item.price.toFixed(2)` threw on anything that was not a number, and a cart
- * comes out of localStorage — see #309, where one malformed value took the
- * whole app down. An unusable price renders as an em dash instead.
+ * What one line costs, or undefined when either half is unusable — so
+ * `formatMoney` shows a dash rather than claiming the line was free.
  */
-function formatPrice(value) {
-  const amount = Number(value);
+function lineTotal(item) {
+  const price = Number(item?.price);
+  const quantity = Number(item?.quantity);
 
-  if (!Number.isFinite(amount)) {
-    return '—';
+  if (!Number.isFinite(price) || !Number.isFinite(quantity)) {
+    return undefined;
   }
 
-  return `₹${amount.toFixed(2)}`;
+  return price * quantity;
 }

--- a/bookshelf-frontend/src/components/FavoriteBooks.jsx
+++ b/bookshelf-frontend/src/components/FavoriteBooks.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import { formatMoney } from "../utils/currency.js";
 import "./FavoriteBooksEmpty.css";
 
 export default function FavoriteBooks({
@@ -197,7 +198,7 @@ export default function FavoriteBooks({
 
                             <span>
 
-                                ₹ {book.price || 0}
+                                {formatMoney(book.price ?? 0)}
 
                             </span>
 

--- a/bookshelf-frontend/src/components/FilterSidebar.jsx
+++ b/bookshelf-frontend/src/components/FilterSidebar.jsx
@@ -1,3 +1,4 @@
+import { currencyName, currencySymbol } from '../utils/currency.js';
 import './FilterSidebar.css';
 
 /**
@@ -31,6 +32,13 @@ export default function FilterSidebar({
   isOpen,
   onToggle,
 }) {
+  // Was a hardcoded ₹ with a comment noting it had been changed from a
+  // hardcoded $. Neither was right for a shop whose currency is configuration;
+  // it reads the configured one now. See #335.
+  const symbol = currencySymbol();
+  // A word, not the symbol — see currencyName().
+  const name = currencyName();
+
   const hasActiveFilters =
     selectedGenres.length > 0 ||
     minPrice !== '' ||
@@ -86,29 +94,28 @@ export default function FilterSidebar({
 
         {/* ── Price range ────────────────────────────────── */}
         <fieldset className="filter-group">
-          <legend className="filter-group__title">Price (₹)</legend>
+          <legend className="filter-group__title">Price ({symbol})</legend>
           <div className="filter-price-inputs">
             <label className="filter-price-input">
-              {/* Fixed: was '$', corrected to '₹' to match app currency */}
-              <span className="filter-price-input__prefix">Min ₹</span>
+              <span className="filter-price-input__prefix">Min {symbol}</span>
               <input
                 type="number"
                 min="0"
                 value={minPrice}
                 onChange={(e) => onMinPriceChange(e.target.value)}
                 placeholder="0"
-                aria-label="Minimum price in rupees"
+                aria-label={`Minimum price in ${name}`}
               />
             </label>
             <label className="filter-price-input">
-              <span className="filter-price-input__prefix">Max ₹</span>
+              <span className="filter-price-input__prefix">Max {symbol}</span>
               <input
                 type="number"
                 min="0"
                 value={maxPrice}
                 onChange={(e) => onMaxPriceChange(e.target.value)}
                 placeholder="Any"
-                aria-label="Maximum price in rupees"
+                aria-label={`Maximum price in ${name}`}
               />
             </label>
           </div>

--- a/bookshelf-frontend/src/components/orders/OrderCard.jsx
+++ b/bookshelf-frontend/src/components/orders/OrderCard.jsx
@@ -4,8 +4,8 @@ import { Link } from 'react-router-dom';
 import OrderDetails from './OrderDetails.jsx';
 import {
   countOrderItems,
-  formatMoney,
   formatOrderDate,
+  orderMoney,
   orderReference,
   primaryStatus,
 } from '../../utils/orderFormat.js';
@@ -25,6 +25,10 @@ import './OrderCard.css';
 export default function OrderCard({ order }) {
   const [expanded, setExpanded] = useState(false);
 
+  // Bound to this order's recorded currency rather than to whatever the shop
+  // is configured for today — an order charged in one currency must not be
+  // relabelled with another. See #335.
+  const money = orderMoney(order);
   const status = primaryStatus(order);
   const reference = orderReference(order);
   const bookCount = countOrderItems(order);
@@ -46,7 +50,7 @@ export default function OrderCard({ order }) {
         </div>
 
         <div className="order-total">
-          <p>Total: {formatMoney(order?.total)}</p>
+          <p>Total: {money(order?.total)}</p>
         </div>
 
         <div className="order-expand">

--- a/bookshelf-frontend/src/components/orders/OrderDetails.jsx
+++ b/bookshelf-frontend/src/components/orders/OrderDetails.jsx
@@ -1,4 +1,4 @@
-import { formatMoney, lineTotal } from '../../utils/orderFormat.js';
+import { lineTotal, orderMoney } from '../../utils/orderFormat.js';
 import './OrderDetails.css';
 
 /**
@@ -14,6 +14,10 @@ import './OrderDetails.css';
  * `item.price.toFixed(2)` unguarded. See #326.
  */
 export default function OrderDetails({ order }) {
+  // Every amount on this panel is labelled with the currency the order was
+  // charged in, taken from the order document. See #335.
+  const money = orderMoney(order);
+
   const items = Array.isArray(order?.items) ? order.items : [];
 
   return (
@@ -32,10 +36,10 @@ export default function OrderDetails({ order }) {
             <div key={`${item?.bookId ?? 'item'}-${index}`} className="order-item">
               <div className="order-item-info">
                 <h5>{item?.title || 'Untitled book'}</h5>
-                <p className="order-item-unit">{formatMoney(item?.price)} each</p>
+                <p className="order-item-unit">{money(item?.price)} each</p>
               </div>
               <div className="order-item-price-qty">
-                <p className="order-item-line-total">{formatMoney(lineTotal(item))}</p>
+                <p className="order-item-line-total">{money(lineTotal(item))}</p>
                 <p>Qty: {item?.quantity ?? '—'}</p>
               </div>
             </div>
@@ -46,19 +50,19 @@ export default function OrderDetails({ order }) {
       <dl className="order-details__totals">
         <div className="order-details__total-row">
           <dt>Subtotal</dt>
-          <dd>{formatMoney(order?.subtotal)}</dd>
+          <dd>{money(order?.subtotal)}</dd>
         </div>
         <div className="order-details__total-row">
           <dt>Tax</dt>
-          <dd>{formatMoney(order?.tax)}</dd>
+          <dd>{money(order?.tax)}</dd>
         </div>
         <div className="order-details__total-row">
           <dt>Shipping</dt>
-          <dd>{formatMoney(order?.shipping)}</dd>
+          <dd>{money(order?.shipping)}</dd>
         </div>
         <div className="order-details__total-row order-details__total-row--grand">
           <dt>Total</dt>
-          <dd>{formatMoney(order?.total)}</dd>
+          <dd>{money(order?.total)}</dd>
         </div>
       </dl>
     </div>

--- a/bookshelf-frontend/src/config/env.js
+++ b/bookshelf-frontend/src/config/env.js
@@ -49,6 +49,18 @@ function readApiBaseUrl() {
 
 export const API_BASE_URL = readApiBaseUrl();
 
+/**
+ * The currency this deployment trades in.
+ *
+ * Must match `CURRENCY` in the backend's environment — the backend is what
+ * actually prices the order and creates the payment intent, so a mismatch
+ * means displaying one currency and charging another, which is the bug #335
+ * was filed for. Left unvalidated here on purpose: `utils/currency.js`
+ * resolves it against the supported table and falls back rather than
+ * throwing, because a formatter runs during render.
+ */
+export const CURRENCY_CODE = (import.meta.env?.VITE_CURRENCY ?? '').trim();
+
 export const IS_PRODUCTION = import.meta.env?.PROD === true;
 
 /**
@@ -62,4 +74,4 @@ if (IS_PRODUCTION && API_BASE_URL.includes('localhost')) {
   );
 }
 
-export default { API_BASE_URL, IS_PRODUCTION, normaliseBaseUrl };
+export default { API_BASE_URL, CURRENCY_CODE, IS_PRODUCTION, normaliseBaseUrl };

--- a/bookshelf-frontend/src/pages/Checkout.jsx
+++ b/bookshelf-frontend/src/pages/Checkout.jsx
@@ -16,6 +16,7 @@ import {
   toOrderItems,
   validateAddress,
 } from '../utils/checkoutValidation.js';
+import { formatMoney } from '../utils/currency.js';
 import './Checkout.css';
 
 /**
@@ -30,11 +31,19 @@ import './Checkout.css';
 const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY;
 const stripePromise = publishableKey ? loadStripe(publishableKey) : null;
 
-const formatRupees = (amount) =>
-  `₹${Number(amount ?? 0).toLocaleString('en-IN', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
+/**
+ * The summary renders in the currency the *server* priced the order in, not
+ * in one this page assumes.
+ *
+ * This used to be a local `formatRupees`, while the payment intent behind the
+ * card form was created in USD — so the panel said ₹1,157.84 and the Stripe
+ * element next to it said $1,157.84. `POST /api/payments/create-intent`
+ * returns the currency now, and it is what the totals below are labelled
+ * with. Before the call has been made there is nothing authoritative to go
+ * on, so the deployment's own currency stands in. See #335.
+ */
+const money = (amount, currency) =>
+  formatMoney(amount ?? 0, { currency, fallback: formatMoney(0, { currency }) });
 
 /**
  * Checkout, in two steps.
@@ -58,6 +67,9 @@ export default function Checkout() {
   const [clientSecret, setClientSecret] = useState('');
   const [orderId, setOrderId] = useState('');
   const [amount, setAmount] = useState(null);
+  // Only known once the server has priced the cart; until then the summary
+  // labels its subtotal with this deployment's configured currency.
+  const [currency, setCurrency] = useState(undefined);
 
   const items = useMemo(() => toOrderItems(cart), [cart]);
   const bookCount = useMemo(() => countItems(cart), [cart]);
@@ -113,6 +125,7 @@ export default function Checkout() {
       setClientSecret(data.clientSecret);
       setOrderId(data.orderId ?? '');
       setAmount(data.amount ?? null);
+      setCurrency(data.currency ?? data.amount?.currency);
     } catch (error) {
       // The old page swallowed this into console.error and left the customer
       // on a spinner forever. Say what happened and let them retry.
@@ -243,7 +256,7 @@ export default function Checkout() {
                   <span className="checkout__line-qty"> × {item.quantity}</span>
                 </span>
                 <span className="checkout__line-price">
-                  {formatRupees(Number(item.price ?? 0) * Number(item.quantity ?? 0))}
+                  {money(Number(item.price ?? 0) * Number(item.quantity ?? 0), currency)}
                 </span>
               </li>
             ))}
@@ -252,7 +265,7 @@ export default function Checkout() {
           <dl className="checkout__totals">
             <div className="checkout__total-row">
               <dt>Subtotal ({bookCount} {bookCount === 1 ? 'book' : 'books'})</dt>
-              <dd>{formatRupees(amount ? amount.subtotal : subtotal)}</dd>
+              <dd>{money(amount ? amount.subtotal : subtotal, currency)}</dd>
             </div>
 
             {/*
@@ -264,15 +277,15 @@ export default function Checkout() {
               <>
                 <div className="checkout__total-row">
                   <dt>Tax</dt>
-                  <dd>{formatRupees(amount.tax)}</dd>
+                  <dd>{money(amount.tax, currency)}</dd>
                 </div>
                 <div className="checkout__total-row">
                   <dt>Shipping</dt>
-                  <dd>{formatRupees(amount.shipping)}</dd>
+                  <dd>{money(amount.shipping, currency)}</dd>
                 </div>
                 <div className="checkout__total-row checkout__total-row--grand">
                   <dt>Total</dt>
-                  <dd>{formatRupees(amount.total)}</dd>
+                  <dd>{money(amount.total, currency)}</dd>
                 </div>
               </>
             )}

--- a/bookshelf-frontend/src/pages/Home.jsx
+++ b/bookshelf-frontend/src/pages/Home.jsx
@@ -9,6 +9,7 @@ import Pagination from '../components/Pagination.jsx';
 import SkeletonLoader from '../components/SkeletonLoader.jsx';
 import { useBookCatalog } from '../hooks/useBookCatalog.js';
 import { hasActiveFilters } from '../utils/catalogQuery.js';
+import { currencySymbol } from '../utils/currency.js';
 
 // Genre list is static because the catalogue is. GET /api/books/genres
 // exists and returns these with counts; wiring it up is a separate change.
@@ -33,6 +34,10 @@ export default function Home({ searchQuery: searchQueryProp }) {
   const [maxPrice, setMaxPrice] = useState('');
   const [minRating, setMinRating] = useState(null);
   const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  // The active-filter chips said "Min ₹250" whatever the shop was priced in.
+  // See #335.
+  const symbol = currencySymbol();
 
   const filters = useMemo(
     () => ({
@@ -160,13 +165,13 @@ export default function Home({ searchQuery: searchQueryProp }) {
                   ))}
                   {minPrice !== '' && (
                     <span className="catalog__filter-tag">
-                      Min ₹{minPrice}
+                      Min {symbol}{minPrice}
                       <button onClick={() => setMinPrice('')} aria-label="Remove min price filter">✕</button>
                     </span>
                   )}
                   {maxPrice !== '' && (
                     <span className="catalog__filter-tag">
-                      Max ₹{maxPrice}
+                      Max {symbol}{maxPrice}
                       <button onClick={() => setMaxPrice('')} aria-label="Remove max price filter">✕</button>
                     </span>
                   )}

--- a/bookshelf-frontend/src/pages/OrderDetailsPage.jsx
+++ b/bookshelf-frontend/src/pages/OrderDetailsPage.jsx
@@ -3,6 +3,9 @@ import { useParams, Link } from 'react-router-dom';
 import orderService from '../services/orderService';
 import { OrderStatusBadge, LoadingSkeleton } from '../components/orders/OrderComponents';
 import { describeApiError, isNotFound, isUnauthorized } from '../utils/apiError.js';
+// Was `${order.total?.toFixed(2)}` — a bare dollar sign on a page whose
+// prices came from a rupee-priced catalogue. See #335.
+import { orderMoney } from '../utils/orderFormat.js';
 
 export default function OrderDetailsPage() {
   const { id } = useParams();
@@ -57,6 +60,8 @@ export default function OrderDetailsPage() {
   }
   if (!order) return null;
 
+  const money = orderMoney(order);
+
   return (
     <div style={{ maxWidth: '1000px', margin: '2rem auto', padding: '0 1rem' }}>
       <Link to="/account/orders" style={{ display: 'inline-block', marginBottom: '1.5rem', color: 'var(--leather, #8b5a2b)', textDecoration: 'none', fontWeight: '500' }}>
@@ -82,7 +87,7 @@ export default function OrderDetailsPage() {
                     <p style={{ fontWeight: '600', margin: 0 }}>{item.title}</p>
                     <p style={{ color: '#666', fontSize: '0.875rem', margin: 0 }}>Qty: {item.quantity}</p>
                   </div>
-                  <p style={{ fontWeight: '500', margin: 0 }}>${(item.price * item.quantity).toFixed(2)}</p>
+                  <p style={{ fontWeight: '500', margin: 0 }}>{money(item.price * item.quantity)}</p>
                 </div>
               ))}
             </div>
@@ -92,11 +97,11 @@ export default function OrderDetailsPage() {
           <div style={{ background: '#fff', padding: '1.5rem', borderRadius: '12px', boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}>
             <h3 style={{ marginBottom: '1rem', borderBottom: '1px solid #e5e7eb', paddingBottom: '0.5rem' }}>Order Totals</h3>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between' }}><span>Subtotal</span><span>${order.subtotal?.toFixed(2)}</span></div>
-              <div style={{ display: 'flex', justifyContent: 'space-between' }}><span>Shipping</span><span>${order.shipping?.toFixed(2)}</span></div>
-              <div style={{ display: 'flex', justifyContent: 'space-between' }}><span>Tax</span><span>${order.tax?.toFixed(2)}</span></div>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}><span>Subtotal</span><span>{money(order.subtotal)}</span></div>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}><span>Shipping</span><span>{money(order.shipping)}</span></div>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}><span>Tax</span><span>{money(order.tax)}</span></div>
               <div style={{ display: 'flex', justifyContent: 'space-between', fontWeight: 'bold', borderTop: '1px solid #e5e7eb', paddingTop: '0.5rem', marginTop: '0.5rem' }}>
-                <span>Total</span><span>${order.total?.toFixed(2)}</span>
+                <span>Total</span><span>{money(order.total)}</span>
               </div>
             </div>
           </div>

--- a/bookshelf-frontend/src/pages/OrderHistory.jsx
+++ b/bookshelf-frontend/src/pages/OrderHistory.jsx
@@ -4,7 +4,7 @@ import OrderCard from '../components/orders/OrderCard.jsx';
 import EmptyOrders from '../components/orders/EmptyOrders.jsx';
 import SkeletonLoader from '../components/SkeletonLoader.jsx';
 import { useOrders } from '../hooks/useOrders.js';
-import { countOrderItems, formatMoney } from '../utils/orderFormat.js';
+import { countOrderItems, formatTotalSpent } from '../utils/orderFormat.js';
 import './OrderHistory.css';
 
 /**
@@ -24,17 +24,17 @@ export default function OrderHistory() {
   const orderCount = orders.length;
   const bookCount = orders.reduce((total, order) => total + countOrderItems(order), 0);
 
-  // Only orders that were actually paid for count towards what was spent.
-  // Including a failed or pending payment would tell a customer they had
-  // spent money they have not been charged.
-  const totalSpent = orders.reduce((total, order) => {
-    if (order.paymentStatus !== 'paid') {
-      return total;
-    }
-
-    const amount = Number(order.total);
-    return Number.isFinite(amount) ? total + amount : total;
-  }, 0);
+  /*
+   * Only orders that were actually paid for count towards what was spent —
+   * including a failed or pending payment would tell a customer they had
+   * spent money they have not been charged.
+   *
+   * The sum is per currency. This was a plain `reduce` adding every total
+   * together, which was correct only while the currency was hardcoded; a
+   * history spanning two currencies would have produced a number that is not
+   * an amount of anything. See #335.
+   */
+  const spent = formatTotalSpent(orders);
 
   return (
     <div className="page-container order-history-page">
@@ -44,7 +44,7 @@ export default function OrderHistory() {
           <p className="order-history__summary" data-testid="order-history-summary">
             {`${orderCount} ${orderCount === 1 ? 'order' : 'orders'}`} &middot;{' '}
             {`${bookCount} ${bookCount === 1 ? 'book' : 'books'}`} &middot;{' '}
-            {`${formatMoney(totalSpent)} paid`}
+            {`${spent} paid`}
           </p>
         )}
       </header>

--- a/bookshelf-frontend/src/pages/OrderHistory.test.jsx
+++ b/bookshelf-frontend/src/pages/OrderHistory.test.jsx
@@ -75,11 +75,13 @@ describe('OrderHistory', () => {
 
     renderPage();
 
-    // 2 orders; 2 + 1 + 1 = 4 books; only the paid order's 947.84 counts.
+    // 2 orders; 2 + 1 + 1 = 4 books; only the paid order's 947.84 counts,
+    // rendered in the shop's currency rather than the `$` this used to
+    // assert while the catalogue was priced in rupees. See #335.
     const summary = await screen.findByTestId('order-history-summary');
     expect(summary).toHaveTextContent('2 orders');
     expect(summary).toHaveTextContent('4 books');
-    expect(summary).toHaveTextContent('$947.84 paid');
+    expect(summary).toHaveTextContent('₹947.84 paid');
   });
 
   it('shows the empty state only when the request actually succeeded', async () => {
@@ -180,7 +182,7 @@ describe('OrderHistory', () => {
     expect(screen.getByText('The Quiet Ones')).toBeInTheDocument();
     expect(screen.getByText('Field Notes')).toBeInTheDocument();
     // 349 x 2
-    expect(screen.getByText('$698.00')).toBeInTheDocument();
+    expect(screen.getByText('₹698.00')).toBeInTheDocument();
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
   });
 

--- a/bookshelf-frontend/src/utils/bookFormat.js
+++ b/bookshelf-frontend/src/utils/bookFormat.js
@@ -12,6 +12,8 @@
  * took down the whole page rather than leaving one line blank. See #317.
  */
 
+import { formatPrice as formatCurrencyPrice } from './currency.js';
+
 /** Books whose stock is at or below this are worth warning about. */
 export const LOW_STOCK_THRESHOLD = 3;
 
@@ -36,22 +38,18 @@ export function formatRating(rating) {
   return value.toFixed(1);
 }
 
-/** Rupees, grouped the Indian way, matching the rest of the shop. */
+/**
+ * A catalogue price, in the shop's currency.
+ *
+ * This used to hardcode `₹` and `en-IN` while `utils/orderFormat.js`
+ * hardcoded `$` and `en-US` and the payment intent was created in USD — so
+ * the same book was ₹349 on its card and $349.00 in the order history, and
+ * the card was charged dollars. It delegates to `utils/currency.js` now,
+ * which is the one formatter and mirrors the backend's currency config.
+ * See #335.
+ */
 export function formatPrice(price) {
-  if (price === null || price === undefined || price === '') {
-    return null;
-  }
-
-  const value = Number(price);
-
-  if (!Number.isFinite(value)) {
-    return null;
-  }
-
-  return `₹${value.toLocaleString('en-IN', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  })}`;
+  return formatCurrencyPrice(price);
 }
 
 /**

--- a/bookshelf-frontend/src/utils/currency.js
+++ b/bookshelf-frontend/src/utils/currency.js
@@ -1,0 +1,191 @@
+import { CURRENCY_CODE } from '../config/env.js';
+
+/**
+ * Money, formatted one way.
+ *
+ * There were four money formatters in this app and they did not agree (#335):
+ *
+ *   utils/bookFormat.js  formatPrice   ₹, en-IN, 0–2 decimals
+ *   components/CartDrawer.jsx formatPrice ₹, no grouping, 2 decimals
+ *   pages/Checkout.jsx   formatRupees  ₹, en-IN, 2 decimals
+ *   utils/orderFormat.js formatMoney   $, en-US, 2 decimals
+ *
+ * So the same book was ₹349 in the grid, ₹349.00 in the drawer, ₹349.00 at
+ * checkout and $349.00 in the order history — and the payment intent behind
+ * all of it was created in USD, which meant the last of those four was the
+ * only one telling the truth about what the card was charged.
+ *
+ * This is the only formatter now. It mirrors `bookshelf-backend/config/
+ * currency.js`, which is the authority: the backend prices the order, creates
+ * the intent, records the currency on the order document and returns it in
+ * the create-intent response. `bookshelf-backend/tests/currency.test.js`
+ * reads this file and asserts the two tables agree, so they cannot drift.
+ */
+
+/**
+ * Must match SUPPORTED_CURRENCIES in bookshelf-backend/config/currency.js.
+ *
+ * `exponent` is the number of decimal places, which is also what Stripe means
+ * by minor units. Both entries are 2; it is stated rather than assumed
+ * because it is not universal, and because a hardcoded 100 is exactly the
+ * assumption that made the backend's old `Math.round(amount * 100)` unsafe.
+ */
+export const SUPPORTED_CURRENCIES = Object.freeze({
+  INR: Object.freeze({
+    code: 'INR',
+    symbol: '₹',
+    // Spoken form, for an aria-label — see the note in the backend table.
+    name: 'rupees',
+    locale: 'en-IN',
+    exponent: 2,
+  }),
+  USD: Object.freeze({
+    code: 'USD',
+    symbol: '$',
+    name: 'dollars',
+    locale: 'en-US',
+    exponent: 2,
+  }),
+});
+
+/** Must match DEFAULT_CURRENCY in the backend config. */
+export const DEFAULT_CURRENCY_CODE = 'INR';
+
+/**
+ * The definition for a code, falling back rather than throwing.
+ *
+ * A formatter is called during render, on data that came off the network or
+ * out of localStorage. An unknown code is a reason to show the default's
+ * symbol, not a reason to blank the page — that lesson is #309.
+ */
+export function currencyFor(code) {
+  if (typeof code === 'string') {
+    const found = SUPPORTED_CURRENCIES[code.trim().toUpperCase()];
+    if (found) {
+      return found;
+    }
+  }
+
+  return SUPPORTED_CURRENCIES[DEFAULT_CURRENCY_CODE];
+}
+
+/** What this deployment trades in, from VITE_CURRENCY. */
+export const CURRENCY = currencyFor(CURRENCY_CODE);
+
+/**
+ * Is this something that can be rendered as an amount at all?
+ *
+ * `Number(null)` and `Number('')` are both 0, and `Number(true)` is 1, so
+ * coercing first would render a *missing* total as "₹0.00" — a customer being
+ * told their order was free. Only a number, or a string that is meant to be
+ * one, gets past here.
+ */
+function toAmount(value) {
+  if (typeof value !== 'number' && typeof value !== 'string') {
+    return null;
+  }
+
+  if (typeof value === 'string' && value.trim() === '') {
+    return null;
+  }
+
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+/**
+ * Format an amount.
+ *
+ * Options:
+ *   currency        code to render in; defaults to this deployment's
+ *   minimumFractionDigits / maximumFractionDigits
+ *                   default to the currency's own exponent
+ *   fallback        what to render for an unusable amount; '—' by default,
+ *                   because "₹NaN" and "₹0.00" are both worse than a dash
+ */
+export function formatMoney(value, options = {}) {
+  const {
+    currency: code,
+    minimumFractionDigits,
+    maximumFractionDigits,
+    fallback = '—',
+  } = options;
+
+  const amount = toAmount(value);
+
+  if (amount === null) {
+    return fallback;
+  }
+
+  const currency = code ? currencyFor(code) : CURRENCY;
+
+  const minimum = minimumFractionDigits ?? currency.exponent;
+  const maximum = Math.max(maximumFractionDigits ?? currency.exponent, minimum);
+
+  const digits = Math.abs(amount).toLocaleString(currency.locale, {
+    minimumFractionDigits: minimum,
+    maximumFractionDigits: maximum,
+  });
+
+  /*
+   * The sign goes outside the symbol: -₹25.00, not ₹-25.00. Formatting the
+   * absolute value and putting the sign back is what makes that possible —
+   * `toLocaleString` on a negative produces "-25.00", and prefixing a symbol
+   * to that gives the wrong one of the two.
+   *
+   * `Math.abs` before formatting also means a value that rounds to zero from
+   * below renders as ₹0.00 rather than -₹0.00.
+   */
+  const negative = amount < 0 && Number(digits.replace(/[^0-9]/g, '')) !== 0;
+
+  return `${negative ? '-' : ''}${currency.symbol}${digits}`;
+}
+
+/**
+ * A catalogue price.
+ *
+ * Books are whole numbers in the catalogue, so a trailing `.00` on every card
+ * is noise — this drops it while still showing paise when a price has them.
+ * Returns null for an unusable price so a caller can omit the element
+ * entirely rather than render an empty one; that is what BookCard does.
+ */
+export function formatPrice(value, options = {}) {
+  const amount = toAmount(value);
+
+  if (amount === null) {
+    return null;
+  }
+
+  return formatMoney(amount, {
+    ...options,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: CURRENCY.exponent,
+  });
+}
+
+/** The symbol alone, for a label or an input prefix. */
+export function currencySymbol(code) {
+  return (code ? currencyFor(code) : CURRENCY).symbol;
+}
+
+/**
+ * The spoken name, for an aria-label.
+ *
+ * A symbol is not a substitute here: how a screen reader announces `₹` varies
+ * by reader and by voice, and several say nothing at all. "Minimum price in
+ * rupees" always works.
+ */
+export function currencyName(code) {
+  return (code ? currencyFor(code) : CURRENCY).name;
+}
+
+export default {
+  SUPPORTED_CURRENCIES,
+  DEFAULT_CURRENCY_CODE,
+  CURRENCY,
+  currencyFor,
+  currencySymbol,
+  currencyName,
+  formatMoney,
+  formatPrice,
+};

--- a/bookshelf-frontend/src/utils/currency.test.js
+++ b/bookshelf-frontend/src/utils/currency.test.js
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  SUPPORTED_CURRENCIES,
+  DEFAULT_CURRENCY_CODE,
+  CURRENCY,
+  currencyFor,
+  currencySymbol,
+  formatMoney,
+  formatPrice,
+} from './currency.js';
+
+/**
+ * One formatter, for money.
+ *
+ * The regression (#335): there were four, and they disagreed. The same book
+ * rendered as ₹349 on its card, ₹349.00 in the cart drawer, ₹349.00 at
+ * checkout and $349.00 in the order history — and the payment intent behind
+ * all of it was created in USD, so the card was charged dollars for a
+ * rupee-priced catalogue.
+ *
+ * These tests are about the two properties that broke: an amount is always
+ * labelled with the currency it is actually in, and an unusable amount never
+ * renders as a number.
+ */
+
+describe('the currency table', () => {
+  it('defaults to the currency the catalogue is priced in', () => {
+    expect(DEFAULT_CURRENCY_CODE).toBe('INR');
+    expect(CURRENCY.code).toBe('INR');
+    expect(CURRENCY.symbol).toBe('₹');
+  });
+
+  it('describes every supported currency fully', () => {
+    for (const [code, currency] of Object.entries(SUPPORTED_CURRENCIES)) {
+      expect(currency.code).toBe(code);
+      expect(currency.symbol).toBeTruthy();
+      expect(currency.locale).toMatch(/^[a-z]{2}-[A-Z]{2}$/);
+      expect(Number.isInteger(currency.exponent)).toBe(true);
+    }
+  });
+
+  it('is frozen, so a render cannot mutate the shop currency', () => {
+    expect(() => {
+      SUPPORTED_CURRENCIES.INR.symbol = '$';
+    }).toThrow();
+
+    expect(SUPPORTED_CURRENCIES.INR.symbol).toBe('₹');
+  });
+});
+
+describe('currencyFor', () => {
+  it('resolves a code in any case', () => {
+    expect(currencyFor('usd').code).toBe('USD');
+    expect(currencyFor('USD').code).toBe('USD');
+    expect(currencyFor(' inr ').code).toBe('INR');
+  });
+
+  it('falls back rather than throwing on an unknown code', () => {
+    // A formatter runs during render, on data off the network. #309 is the
+    // lesson: one bad stored value must not be able to blank the page.
+    expect(currencyFor('EUR').code).toBe(DEFAULT_CURRENCY_CODE);
+    expect(currencyFor(null).code).toBe(DEFAULT_CURRENCY_CODE);
+    expect(currencyFor(undefined).code).toBe(DEFAULT_CURRENCY_CODE);
+    expect(currencyFor(42).code).toBe(DEFAULT_CURRENCY_CODE);
+    expect(currencyFor({}).code).toBe(DEFAULT_CURRENCY_CODE);
+  });
+});
+
+describe('currencySymbol', () => {
+  it('gives the configured symbol by default and a named one on request', () => {
+    expect(currencySymbol()).toBe('₹');
+    expect(currencySymbol('USD')).toBe('$');
+    expect(currencySymbol('INR')).toBe('₹');
+  });
+});
+
+describe('formatMoney', () => {
+  it('formats in the shop currency, grouped the way that locale groups', () => {
+    expect(formatMoney(1047)).toBe('₹1,047.00');
+    expect(formatMoney(52.35)).toBe('₹52.35');
+    expect(formatMoney(0)).toBe('₹0.00');
+  });
+
+  it('groups en-IN the Indian way, which en-US does not', () => {
+    // 1,23,456 rather than 123,456 — the reason the locale is part of the
+    // currency definition rather than left to the browser default.
+    expect(formatMoney(123456)).toBe('₹1,23,456.00');
+    expect(formatMoney(123456, { currency: 'USD' })).toBe('$123,456.00');
+  });
+
+  it('labels an amount with the currency it is given', () => {
+    expect(formatMoney(19.99, { currency: 'USD' })).toBe('$19.99');
+    expect(formatMoney(19.99, { currency: 'INR' })).toBe('₹19.99');
+  });
+
+  it('accepts a numeric string, because JSON is not always typed', () => {
+    expect(formatMoney('19.99')).toBe('₹19.99');
+    expect(formatMoney('1047')).toBe('₹1,047.00');
+  });
+
+  it('shows a dash rather than a number for an amount it does not have', () => {
+    // Not "₹0.00" — that tells a customer their order was free. Not "₹NaN"
+    // either. `Number(null)` and `Number('')` are both 0, which is why these
+    // are checked before any coercion.
+    expect(formatMoney(null)).toBe('—');
+    expect(formatMoney(undefined)).toBe('—');
+    expect(formatMoney('')).toBe('—');
+    expect(formatMoney('   ')).toBe('—');
+    expect(formatMoney(NaN)).toBe('—');
+    expect(formatMoney(Infinity)).toBe('—');
+    expect(formatMoney(true)).toBe('—');
+    expect(formatMoney({})).toBe('—');
+    expect(formatMoney([])).toBe('—');
+  });
+
+  it('takes a caller-supplied fallback', () => {
+    expect(formatMoney(null, { fallback: 'Free' })).toBe('Free');
+    expect(formatMoney(undefined, { fallback: '₹0.00' })).toBe('₹0.00');
+  });
+
+  it('honours explicit fraction digits', () => {
+    expect(formatMoney(349, { minimumFractionDigits: 0 })).toBe('₹349');
+    expect(
+      formatMoney(349.456, { minimumFractionDigits: 0, maximumFractionDigits: 2 })
+    ).toBe('₹349.46');
+  });
+
+  it('never lets maximum fall below minimum', () => {
+    // Intl throws a RangeError on min > max, which during a render is a blank
+    // page rather than a badly formatted price.
+    expect(() =>
+      formatMoney(1, { minimumFractionDigits: 2, maximumFractionDigits: 0 })
+    ).not.toThrow();
+  });
+
+  it('formats a negative amount rather than refusing it', () => {
+    // A refund line is a legitimate negative.
+    expect(formatMoney(-25)).toBe('-₹25.00');
+  });
+});
+
+describe('formatPrice', () => {
+  it('drops the trailing zeros a whole-rupee catalogue does not need', () => {
+    expect(formatPrice(349)).toBe('₹349');
+    expect(formatPrice(123456)).toBe('₹1,23,456');
+  });
+
+  it('still shows the minor units when a price has them', () => {
+    expect(formatPrice(349.5)).toBe('₹349.5');
+    expect(formatPrice(349.55)).toBe('₹349.55');
+  });
+
+  it('returns null so a caller can omit the element entirely', () => {
+    // BookCard renders `{priceLabel && <span …>}` — a null means no empty
+    // price element rather than a dash floating in the card.
+    expect(formatPrice(null)).toBeNull();
+    expect(formatPrice(undefined)).toBeNull();
+    expect(formatPrice('')).toBeNull();
+    expect(formatPrice(NaN)).toBeNull();
+    expect(formatPrice('not a price')).toBeNull();
+  });
+
+  it('accepts zero, which is a price and not a missing value', () => {
+    expect(formatPrice(0)).toBe('₹0');
+  });
+});

--- a/bookshelf-frontend/src/utils/orderFormat.js
+++ b/bookshelf-frontend/src/utils/orderFormat.js
@@ -14,6 +14,8 @@
  * input. See #326.
  */
 
+import { formatMoney as formatCurrency } from './currency.js';
+
 /**
  * `status` on the model, which tracks fulfilment.
  * Matches the enum in bookshelf-backend/models/Order.js.
@@ -91,36 +93,36 @@ function formatUnknownStatus(status) {
 /**
  * Money, as the server means it.
  *
- * Totals are major units of the currency the payment intent is created in,
- * which is USD (`createPaymentIntent(checkout.total, 'usd')`). A missing or
- * non-numeric amount renders as an em dash rather than as "$NaN" — an order
- * still being written by the webhook is a normal thing to catch mid-flight.
+ * Totals are major units of the currency the order was *charged* in, which
+ * this hardcoded as USD while every other price in the app was rendered with
+ * a `₹`. The card was charged dollars for a rupee-priced catalogue. See #335.
+ *
+ * `currency` is a code from the order document. Passing it matters for an
+ * order placed before the shop's currency was ever changed: the amount was
+ * charged in whatever was configured at the time, and relabelling it with the
+ * current setting would make the history lie. Orders written before #335 have
+ * no such field, so the fallback is the deployment's own currency — which is
+ * the right guess, because it is the only one that has ever been used.
+ *
+ * A missing or non-numeric amount renders as an em dash rather than as
+ * "₹NaN" — an order still being written by the webhook is a normal thing to
+ * catch mid-flight.
  */
-export function formatMoney(amount) {
-  /*
-   * `Number(null)` and `Number('')` are both 0, and `Number(true)` is 1, so
-   * coercing first would render a *missing* total as "$0.00" — a customer
-   * being told their order was free. Only a number, or a string that is
-   * meant to be one, gets past here.
-   */
-  if (typeof amount !== 'number' && typeof amount !== 'string') {
-    return '—';
-  }
+export function formatMoney(amount, currency) {
+  return formatCurrency(amount, { currency, fallback: '—' });
+}
 
-  if (typeof amount === 'string' && amount.trim() === '') {
-    return '—';
-  }
+/** The currency an order was charged in, or this deployment's. */
+export function orderCurrency(order) {
+  return typeof order?.currency === 'string' && order.currency.trim() !== ''
+    ? order.currency
+    : undefined;
+}
 
-  const value = Number(amount);
-
-  if (!Number.isFinite(value)) {
-    return '—';
-  }
-
-  return `$${value.toLocaleString('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
+/** `formatMoney` bound to one order's currency. */
+export function orderMoney(order) {
+  const currency = orderCurrency(order);
+  return (amount) => formatMoney(amount, currency);
 }
 
 /** A date the customer can read, or an em dash if the value is unusable. */
@@ -193,6 +195,67 @@ export function lineTotal(item) {
  * Anything can come back from the network. A card needs an id to key on and
  * to link to; without one there is nothing to render and nothing to click.
  */
+/**
+ * What a customer has actually paid, and in what.
+ *
+ * Adding up `order.total` across the history was safe only while every order
+ * was in the same currency — which was true by accident, because the currency
+ * was hardcoded. Now that it is configuration, a shop that switches has a
+ * history containing both, and 1047 + 12.99 is not a number that means
+ * anything.
+ *
+ * So this sums per currency and reports whether the history spans more than
+ * one. A caller with `mixed: true` should show the per-currency breakdown
+ * rather than a single figure. See #335.
+ *
+ * Only paid orders count: including a failed or pending payment would tell a
+ * customer they had spent money they have not been charged.
+ *
+ * @returns {{ totals: Array<{currency: string|undefined, amount: number}>,
+ *             mixed: boolean }}
+ */
+export function totalSpent(orders) {
+  const byCurrency = new Map();
+
+  for (const order of Array.isArray(orders) ? orders : []) {
+    if (order?.paymentStatus !== 'paid') {
+      continue;
+    }
+
+    const amount = Number(order?.total);
+
+    if (!Number.isFinite(amount)) {
+      continue;
+    }
+
+    // `undefined` is its own key: an order written before the currency was
+    // recorded is not evidence of a second currency, so it groups with the
+    // other unlabelled ones and renders in the deployment's own.
+    const key = orderCurrency(order);
+    byCurrency.set(key, (byCurrency.get(key) ?? 0) + amount);
+  }
+
+  if (byCurrency.size === 0) {
+    return { totals: [{ currency: undefined, amount: 0 }], mixed: false };
+  }
+
+  const totals = [...byCurrency.entries()].map(([currency, amount]) => ({
+    currency,
+    amount,
+  }));
+
+  return { totals, mixed: totals.length > 1 };
+}
+
+/** `totalSpent` rendered as text: one figure, or one per currency. */
+export function formatTotalSpent(orders) {
+  const { totals } = totalSpent(orders);
+
+  return totals
+    .map(({ currency, amount }) => formatMoney(amount, currency))
+    .join(' + ');
+}
+
 export function isRenderableOrder(order) {
   return Boolean(order && typeof order === 'object' && (order._id || order.id));
 }
@@ -202,7 +265,11 @@ export default {
   PAYMENT_STATUS_LABELS,
   countOrderItems,
   formatMoney,
+  formatTotalSpent,
+  orderCurrency,
+  orderMoney,
   formatOrderDate,
+  totalSpent,
   isRenderableOrder,
   lineTotal,
   orderReference,

--- a/bookshelf-frontend/src/utils/orderFormat.test.js
+++ b/bookshelf-frontend/src/utils/orderFormat.test.js
@@ -4,10 +4,14 @@ import {
   countOrderItems,
   formatMoney,
   formatOrderDate,
+  formatTotalSpent,
   isRenderableOrder,
   lineTotal,
+  orderCurrency,
+  orderMoney,
   orderReference,
   primaryStatus,
+  totalSpent,
 } from './orderFormat.js';
 
 /**
@@ -65,21 +69,136 @@ describe('primaryStatus', () => {
 });
 
 describe('formatMoney', () => {
-  it('formats an amount to two places', () => {
-    expect(formatMoney(1047)).toBe('$1,047.00');
-    expect(formatMoney(52.35)).toBe('$52.35');
-    expect(formatMoney(0)).toBe('$0.00');
+  /*
+   * The `$` these used to assert was the bug, not the expectation. The
+   * catalogue is priced in rupees and the order history rendered the same
+   * numbers with a dollar sign — and the payment intent behind them really
+   * was created in USD, so the card was charged dollars for a rupee price.
+   * See #335. Amounts are formatted in the shop's currency now, which is
+   * INR, and an order that records its own currency is rendered in that.
+   */
+  it('formats an amount in the shop currency', () => {
+    expect(formatMoney(1047)).toBe('₹1,047.00');
+    expect(formatMoney(52.35)).toBe('₹52.35');
+    expect(formatMoney(0)).toBe('₹0.00');
   });
 
   it('accepts a numeric string, which is what a JSON body can carry', () => {
-    expect(formatMoney('19.99')).toBe('$19.99');
+    expect(formatMoney('19.99')).toBe('₹19.99');
   });
 
-  it('shows an em dash rather than "$NaN" for a missing amount', () => {
+  it('renders an order in the currency it was charged in', () => {
+    expect(formatMoney(19.99, 'USD')).toBe('$19.99');
+    expect(formatMoney(19.99, 'INR')).toBe('₹19.99');
+  });
+
+  it('falls back to the shop currency for an order that recorded none', () => {
+    // Every order written before #335 is in this state. The deployment's own
+    // currency is the right guess, because it is the only one ever used.
+    expect(formatMoney(19.99, undefined)).toBe('₹19.99');
+    expect(formatMoney(19.99, '')).toBe('₹19.99');
+  });
+
+  it('shows an em dash rather than "NaN" for a missing amount', () => {
     expect(formatMoney(undefined)).toBe('—');
     expect(formatMoney(null)).toBe('—');
     expect(formatMoney('not a number')).toBe('—');
     expect(formatMoney(Infinity)).toBe('—');
+  });
+});
+
+describe('orderCurrency', () => {
+  it('reads the currency the order recorded', () => {
+    expect(orderCurrency({ currency: 'USD' })).toBe('USD');
+    expect(orderCurrency({ currency: 'INR' })).toBe('INR');
+  });
+
+  it('is undefined when the order has none, rather than guessing here', () => {
+    expect(orderCurrency({})).toBeUndefined();
+    expect(orderCurrency({ currency: '' })).toBeUndefined();
+    expect(orderCurrency({ currency: '   ' })).toBeUndefined();
+    expect(orderCurrency(null)).toBeUndefined();
+    expect(orderCurrency(undefined)).toBeUndefined();
+  });
+});
+
+describe('orderMoney', () => {
+  it('binds a formatter to one order\'s currency', () => {
+    const money = orderMoney({ currency: 'USD' });
+
+    expect(money(10)).toBe('$10.00');
+    expect(money(null)).toBe('—');
+  });
+
+  it('falls back for an order with no recorded currency', () => {
+    expect(orderMoney({})(10)).toBe('₹10.00');
+    expect(orderMoney(null)(10)).toBe('₹10.00');
+  });
+});
+
+describe('totalSpent', () => {
+  const paid = (total, currency) => ({ paymentStatus: 'paid', total, currency });
+
+  it('adds up only what was actually paid for', () => {
+    const { totals, mixed } = totalSpent([
+      paid(100, 'INR'),
+      { paymentStatus: 'pending', total: 999, currency: 'INR' },
+      { paymentStatus: 'failed', total: 500, currency: 'INR' },
+      paid(47.84, 'INR'),
+    ]);
+
+    expect(mixed).toBe(false);
+    expect(totals).toEqual([{ currency: 'INR', amount: 147.84 }]);
+  });
+
+  it('keeps currencies apart rather than adding rupees to dollars', () => {
+    // 1047 + 12.99 is not an amount of anything. This is the case a plain
+    // reduce over `order.total` got silently wrong. See #335.
+    const { totals, mixed } = totalSpent([paid(1047, 'INR'), paid(12.99, 'USD')]);
+
+    expect(mixed).toBe(true);
+    expect(totals).toEqual([
+      { currency: 'INR', amount: 1047 },
+      { currency: 'USD', amount: 12.99 },
+    ]);
+  });
+
+  it('groups orders with no recorded currency together, not as a second one', () => {
+    const { totals, mixed } = totalSpent([paid(10, undefined), paid(5, undefined)]);
+
+    expect(mixed).toBe(false);
+    expect(totals).toEqual([{ currency: undefined, amount: 15 }]);
+  });
+
+  it('ignores a total that is not a number', () => {
+    const { totals } = totalSpent([paid(10, 'INR'), paid(null, 'INR'), paid('x', 'INR')]);
+
+    expect(totals).toEqual([{ currency: 'INR', amount: 10 }]);
+  });
+
+  it('reports zero rather than an empty list for a history with nothing paid', () => {
+    expect(totalSpent([]).totals).toEqual([{ currency: undefined, amount: 0 }]);
+    expect(totalSpent(null).totals).toEqual([{ currency: undefined, amount: 0 }]);
+    expect(totalSpent([{ paymentStatus: 'pending', total: 9 }]).totals).toEqual([
+      { currency: undefined, amount: 0 },
+    ]);
+  });
+});
+
+describe('formatTotalSpent', () => {
+  it('renders a single-currency history as one figure', () => {
+    expect(
+      formatTotalSpent([{ paymentStatus: 'paid', total: 947.84, currency: 'INR' }])
+    ).toBe('₹947.84');
+  });
+
+  it('renders a mixed history as a breakdown, not a meaningless sum', () => {
+    expect(
+      formatTotalSpent([
+        { paymentStatus: 'paid', total: 1047, currency: 'INR' },
+        { paymentStatus: 'paid', total: 12.99, currency: 'USD' },
+      ])
+    ).toBe('₹1,047.00 + $12.99');
   });
 });
 


### PR DESCRIPTION
Closes #335.

The shop displayed rupees and charged dollars. `data/books.json` prices books at 349, every price on screen carried a `₹`, and `createPaymentIntent(checkout.total, 'usd')` created the payment intent in USD. A customer saw ₹349 and was charged $349.00, then saw $384.44 in their order history for the thing the catalogue said cost ₹349.

The number was right and the unit was wrong, which is the worst way for a price to be wrong: nothing looks broken until the card statement arrives.

## Why it happened

Nothing in the app knew what currency it was working in, so each part guessed separately:

| where | currency | grouping | decimals |
|---|---|---|---|
| `utils/bookFormat.js` `formatPrice` | ₹ | `en-IN` | 0–2 |
| `components/CartDrawer.jsx` `formatPrice` | ₹ | none | 2 |
| `pages/Checkout.jsx` `formatRupees` | ₹ | `en-IN` | 2 |
| `utils/orderFormat.js` `formatMoney` | $ | `en-US` | 2 |
| `services/stripeService.js` | `'usd'` | — | assumed 2 |

Four formatters, three of which contradicted the one thing that actually mattered — the currency the card was charged in. The same book was ₹349 on its card, ₹349.00 in the cart drawer, ₹349.00 at checkout and $349.00 in the order history.

## What this does

**One authority.** `bookshelf-backend/config/currency.js` holds the supported currencies — code, Stripe code, symbol, spoken name, locale, decimal exponent and flat shipping — resolved from `CURRENCY` and defaulting to **INR**, because that is what the catalogue is priced in. Defaulting to USD would have kept the Stripe call unchanged and left every displayed price wrong, which is the bug. A deployment that sets nothing now charges what it has been advertising.

**Priced in it.** `priceOrder` takes the currency and returns the code alongside the totals. Shipping comes from the currency rather than the hardcoded `SHIPPING_MAJOR_UNITS = 5.99` — a dollar figure that was being charged unchanged next to a rupee-priced catalogue.

**Recorded on the order.** `Order.currency` is written at checkout, so an order is rendered in the currency it was charged in rather than in whatever the shop is set to today. Orders written before this have no such field and fall back to the deployment's currency, which is the right guess because it is the only one ever used.

**Returned to the client.** `POST /api/payments/create-intent` returns `currency`. The checkout summary labels its totals with what the server replied with instead of assuming — the panel used to say ₹1,157.84 with a Stripe element beside it saying $1,157.84.

**One formatter.** `bookshelf-frontend/src/utils/currency.js` mirrors the backend table and is the only thing that formats money now. `bookFormat`, `orderFormat`, `CartDrawer`, `Checkout`, `OrderDetailsPage`, `OrderCard`, `OrderDetails`, `FilterSidebar` and the `Home` filter chips all go through it. `BookPrice.jsx` and `FavoriteBooks.jsx` are not imported by anything yet, but both hardcoded `₹` too — corrected so the bug is not sitting there waiting for whoever wires them up.

## Two things fixed on the way

**Double rounding, and a two-decimal assumption.** `createPaymentIntent` took a major-unit amount and did `Math.round(amount * 100)`. That re-rounded a number `utils/money.js` had already rounded exactly once, deliberately, from an integer it was holding — and it assumed every currency has two decimal places, so a zero-decimal currency would have been charged a hundred times the price. It takes integer minor units and an explicit currency now, with no default: there is no safe guess to make there, which is precisely what `'usd'` was.

**Adding rupees to dollars.** `OrderHistory` summed `order.total` across the whole history. That is meaningful only while every order shares a currency — true by accident, because the currency was hardcoded. `totalSpent()` sums per currency and reports whether the history spans more than one, and the summary shows a breakdown rather than a number that is not an amount of anything.

Also: the aria-labels on the price filters read "Minimum price in rupees" rather than "Minimum price in ₹". How a screen reader announces `₹` varies by reader and voice, and several say nothing at all — so the currency table carries a spoken name for exactly this.

## Keeping the two tables honest

There are two currency tables, one per package, because the frontend cannot import from the backend. Two tables that must agree and are never compared are two tables that will stop agreeing. `bookshelf-backend/tests/currency.test.js` reads the frontend's source and asserts the codes, symbols, spoken names, locales and exponents line up, that the defaults match, and that neither side supports a currency the other does not.

## Testing

- `bookshelf-backend/tests/currency.test.js` — 20 new tests: resolution and case handling, refusal of an unsupported code, the frozen table, `minorUnitsPerMajor` deriving from the exponent rather than assuming 100, log formatting, and the cross-package agreement checks.
- `bookshelf-frontend/src/utils/currency.test.js` — 19 new tests: `en-IN` grouping (₹1,23,456, which `en-US` does not produce), per-order currency, the `Number(null) === 0` trap, and negative amounts.
- `orderFormat.test.js` gained coverage for `orderCurrency`, `orderMoney`, `totalSpent` and `formatTotalSpent`, including the mixed-currency case.
- `checkout.test.js` updated for the currency-derived shipping, plus new cases asserting the currency is reported and that an explicit shipping override still wins.

Two implementation bugs were caught by the new tests while writing them, and both are fixed here rather than asserted around: `formatMoney(-25)` produced `₹-25.00` instead of `-₹25.00`, and the backend's `formatAmount(null)` produced `₹0.00` because `Number(null)` is 0 — a missing amount logged as a fact rather than an absence.

Backend **455 passing**, frontend **477 passing**. ESLint reports the same 43 errors / 51 warnings as `main`; every file touched here is clean apart from one pre-existing unused-import warning in `OrderDetailsPage.jsx`.

## Deploying

`CURRENCY` (backend) and `VITE_CURRENCY` (frontend) are documented in both `.env.example` files. They must match — the backend creates the payment intent, so a mismatch is this bug again. Both default to INR, so an existing deployment needs no change to get the correct behaviour.
