### PR TITLE
fix(recently-viewed): read the catalogue, not the snapshot of it

### DIFF
--- a/bookshelf-frontend/src/components/RecentlyViewed.jsx
+++ b/bookshelf-frontend/src/components/RecentlyViewed.jsx
@@ -1,18 +1,15 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { matchPath, useLocation } from 'react-router-dom';
 
 import BookCard from './BookCard.jsx';
-import { books } from '../data/books.js';
-import {
-  readRecentlyViewedExcept,
-  recordBookView,
-} from '../utils/recentlyViewed.js';
+import { useRecentlyViewedBooks } from '../hooks/useRecentlyViewedBooks.js';
+import { recordBookView } from '../utils/recentlyViewed.js';
 import './RecentlyViewed.css';
 
 /**
  * A strip of books the reader has looked at recently.
  *
- * Two things were wrong with this component (#318).
+ * Two things were wrong with this component originally (#318).
  *
  * The list it reads was never written. `grep -rn recentlyViewed src` found a
  * single `getItem` and no `setItem` anywhere in the application, so `stored`
@@ -28,10 +25,14 @@ import './RecentlyViewed.css';
  *
  * Rather than move the mount into each page, the component gates itself: one
  * mount point in the shell, an explicit allow-list of routes, and the current
- * book id derived from the path. That keeps the whole feature — the read, the
- * write and the visibility rule — in one file that can be tested on its own,
- * and it leaves BookDetail and Home untouched, which matters while #317 and
- * #319 are open against both of them.
+ * book id derived from the path.
+ *
+ * The third thing, fixed here (#336): the ids were resolved against
+ * `src/data/books.js`, the deprecated local snapshot of the catalogue. That
+ * meant stale prices next to fresh ones on the same page, a missing
+ * `inventory` field reading as "in stock", and a book added to the backend
+ * silently dropped from a history the reader had just made. It reads the API
+ * now, through the same hook the wishlist uses.
  *
  * Props:
  *   currentBookId  optional override; normally derived from the route
@@ -54,7 +55,6 @@ export default function RecentlyViewed({
   title = 'Recently Viewed',
 }) {
   const location = useLocation();
-  const [recentBooks, setRecentBooks] = useState([]);
 
   const bookRouteMatch = useMemo(
     () => matchPath(BOOK_ROUTE, location.pathname),
@@ -83,26 +83,44 @@ export default function RecentlyViewed({
     }
   }, [currentBookId]);
 
-  useEffect(() => {
-    if (!isVisibleRoute) {
-      setRecentBooks([]);
-      return;
-    }
+  /*
+   * `location.key` changes on every navigation, which is what re-reads the
+   * stored ids: `recordBookView` above writes to localStorage from a sibling
+   * effect, so a list read once at mount would be one navigation behind.
+   *
+   * The hook is called unconditionally, because hooks cannot be called
+   * conditionally — `enabled` is how the visibility rule reaches it. Without
+   * that the checkout page would fetch a strip it never renders, once per
+   * navigation.
+   */
+  const { books, loading, error } = useRecentlyViewedBooks({
+    excludeId: currentBookId,
+    locationKey: location.key,
+    enabled: isVisibleRoute,
+  });
 
-    const ids = readRecentlyViewedExcept(currentBookId);
+  if (!isVisibleRoute) {
+    return null;
+  }
 
-    // Ids are resolved against the local catalogue copy. Unknown ids are
-    // dropped rather than rendered as gaps — see #317 for why that copy still
-    // exists and what should replace it.
-    setRecentBooks(
-      ids
-        .map((id) => books.find((book) => String(book.id) === id))
-        .filter(Boolean)
-    );
-  }, [isVisibleRoute, currentBookId, location.key]);
-
-  // Nothing to show — render nothing rather than a heading over an empty row.
-  if (!isVisibleRoute || recentBooks.length === 0) {
+  /*
+   * Nothing to show — render nothing rather than a heading over an empty row.
+   *
+   * Three cases collapse to the same answer here, and they collapse
+   * deliberately:
+   *
+   *   - Nothing viewed yet. Always was this.
+   *   - Still loading. The strip used to appear fully formed because the
+   *     lookup was synchronous; it is a request now, and a heading over a
+   *     row that is about to have an unknown number of cards in it would
+   *     push the footer around as the response lands. It appears when it is
+   *     ready.
+   *   - The request failed. This is a nicety at the bottom of a page the
+   *     reader came for something else — an error panel under "Recently
+   *     Viewed" would be louder than the feature is worth. The wishlist page,
+   *     where the list *is* the page, reports its failures; this does not.
+   */
+  if (loading || error || books.length === 0) {
     return null;
   }
 
@@ -113,7 +131,7 @@ export default function RecentlyViewed({
           {title}
         </h2>
         <div className="recently-viewed__scroll">
-          {recentBooks.map((book) => (
+          {books.map((book) => (
             <div key={book.id} className="recently-viewed__item">
               <BookCard book={book} />
             </div>

--- a/bookshelf-frontend/src/components/RecentlyViewed.test.jsx
+++ b/bookshelf-frontend/src/components/RecentlyViewed.test.jsx
@@ -2,11 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 
-vi.mock('./BookCard.jsx', () => ({
-  default: ({ book }) => <div data-testid="book-card">{book.title}</div>,
-}));
-
-import { books } from '../data/books.js';
+import * as bookService from '../services/bookService.js';
 import {
   STORAGE_KEY,
   readRecentlyViewed,
@@ -14,8 +10,65 @@ import {
 } from '../utils/recentlyViewed.js';
 import RecentlyViewed from './RecentlyViewed.jsx';
 
-const catalogue = books.filter((book) => String(book.id).startsWith('b'));
-const [first, second, third] = catalogue;
+/**
+ * The strip resolves its stored ids against the API.
+ *
+ * The regression (#336): it resolved them against `src/data/books.js`, the
+ * deprecated local snapshot of the catalogue, with
+ * `books.find(...)` + `.filter(Boolean)`. That is three bugs in one line — a
+ * price edited in the backend never reached the strip, a book added to the
+ * backend produced `undefined` and was silently dropped, and the snapshot's
+ * missing `inventory` field made every sold-out book look available.
+ *
+ * The earlier bugs this component had are still covered here: nothing ever
+ * wrote the stored list (#318), and it was mounted in the layout shell with
+ * no `currentBookId`, so it was declared on the checkout and the login form
+ * and a book appeared in its own "recently viewed" strip.
+ */
+
+vi.mock('../services/bookService.js', async () => {
+  const actual = await vi.importActual('../services/bookService.js');
+  return { ...actual, getBooksByIds: vi.fn() };
+});
+
+vi.mock('./BookCard.jsx', () => ({
+  default: ({ book }) => (
+    <div data-testid="book-card" data-price={book.price} data-inventory={book.inventory}>
+      {book.title}
+    </div>
+  ),
+}));
+
+/** What the API serves. Deliberately not what the old local file held. */
+const CATALOGUE = {
+  b1: { id: 'b1', title: 'The Quiet Ones', price: 349, inventory: 8 },
+  b2: { id: 'b2', title: 'Field Notes', price: 299, inventory: 10 },
+  b3: { id: 'b3', title: 'Half Moon Bay', price: 399, inventory: 0 },
+  // A book that exists only in the API — the case the local snapshot could
+  // never render, because it has no record for it.
+  b9: { id: 'b9', title: 'The Ninth', price: 559, inventory: 4 },
+};
+
+const [first, second, third] = [CATALOGUE.b1, CATALOGUE.b2, CATALOGUE.b3];
+
+/** Resolve from CATALOGUE, 404ing anything it does not have. */
+function serveCatalogue(overrides = {}) {
+  bookService.getBooksByIds.mockImplementation(async (ids) => {
+    const books = [];
+    const missingIds = [];
+
+    for (const id of ids) {
+      const book = overrides[id] ?? CATALOGUE[id];
+      if (book) {
+        books.push(book);
+      } else {
+        missingIds.push(id);
+      }
+    }
+
+    return { books, missingIds, failedIds: [] };
+  });
+}
 
 /**
  * The component is mounted in the layout shell, so it is rendered on every
@@ -35,9 +88,13 @@ function renderAt(pathname, props = {}) {
 const titles = () =>
   screen.queryAllByTestId('book-card').map((card) => card.textContent);
 
+const strip = () => document.querySelector('.recently-viewed');
+
 describe('RecentlyViewed', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    vi.clearAllMocks();
+    serveCatalogue();
   });
 
   describe('recording', () => {
@@ -50,20 +107,20 @@ describe('RecentlyViewed', () => {
     it('moves a revisited book to the front rather than duplicating it', async () => {
       window.localStorage.setItem(
         STORAGE_KEY,
-        JSON.stringify(['b4', first.id, 'b6'])
+        JSON.stringify(['b2', first.id, 'b9'])
       );
 
       renderAt(`/book/${first.id}`);
 
       await waitFor(() =>
-        expect(readRecentlyViewed()).toEqual([first.id, 'b4', 'b6'])
+        expect(readRecentlyViewed()).toEqual([first.id, 'b2', 'b9'])
       );
     });
 
     it('records an id that is not in the catalogue without throwing', async () => {
       renderAt('/book/not-a-book');
 
-      await waitFor(() => expect(readRecentlyViewed()).toEqual(['not-a-book']));
+      await waitFor(() => expect(readRecentlyViewed()).toContain('not-a-book'));
     });
 
     it('records nothing on a route that is not a book page', async () => {
@@ -73,30 +130,141 @@ describe('RecentlyViewed', () => {
     });
   });
 
+  describe('reading the API rather than the local snapshot', () => {
+    it('renders what the API returned', async () => {
+      recordBookView(first.id);
+      recordBookView(second.id);
+
+      renderAt('/');
+
+      await waitFor(() => expect(titles()).toEqual([second.title, first.title]));
+      expect(bookService.getBooksByIds).toHaveBeenCalledWith(
+        [second.id, first.id],
+        expect.anything()
+      );
+    });
+
+    it('shows the current price, not the one the snapshot froze', async () => {
+      // The exact symptom: the grid updated and the strip below it did not.
+      serveCatalogue({ b1: { ...CATALOGUE.b1, price: 999 } });
+      recordBookView(first.id);
+
+      renderAt('/');
+
+      await waitFor(() =>
+        expect(screen.getByTestId('book-card')).toHaveAttribute('data-price', '999')
+      );
+    });
+
+    it('carries inventory through, so a sold-out book is not sellable here', async () => {
+      // The local file has no `inventory` field at all, and `isInStock()`
+      // treats a missing one as available — so the strip offered "Add to
+      // cart" for a book the grid above showed as out of stock.
+      recordBookView(third.id);
+
+      renderAt('/');
+
+      await waitFor(() =>
+        expect(screen.getByTestId('book-card')).toHaveAttribute('data-inventory', '0')
+      );
+    });
+
+    it('shows a book the snapshot never had', async () => {
+      // `books.find(...)` returned undefined for this and `.filter(Boolean)`
+      // dropped it: viewed, and then simply absent from the reader's history.
+      recordBookView('b9');
+
+      renderAt('/');
+
+      await waitFor(() => expect(titles()).toEqual(['The Ninth']));
+    });
+
+    it('keeps the stored order rather than the order responses arrived in', async () => {
+      recordBookView('b9');
+      recordBookView(second.id);
+      recordBookView(first.id);
+
+      // Answer in a deliberately different order.
+      bookService.getBooksByIds.mockResolvedValue({
+        books: [CATALOGUE.b9, CATALOGUE.b1, CATALOGUE.b2],
+        missingIds: [],
+        failedIds: [],
+      });
+
+      renderAt('/');
+
+      await waitFor(() =>
+        expect(titles()).toEqual([first.title, second.title, 'The Ninth'])
+      );
+    });
+  });
+
+  describe('ids the catalogue no longer has', () => {
+    it('does not render them', async () => {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify([first.id, 'delisted', second.id])
+      );
+
+      renderAt('/');
+
+      await waitFor(() => expect(titles()).toEqual([first.title, second.title]));
+    });
+
+    it('forgets a 404 so it is not re-requested on every page load', async () => {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify([first.id, 'delisted'])
+      );
+
+      renderAt('/');
+
+      await waitFor(() => expect(readRecentlyViewed()).toEqual([first.id]));
+    });
+
+    it('keeps an id whose request merely failed', async () => {
+      // A book that could not be reached probably still exists. Forgetting a
+      // reader's history because their connection dropped would be worse than
+      // the bug this fixes.
+      bookService.getBooksByIds.mockResolvedValue({
+        books: [CATALOGUE.b1],
+        missingIds: [],
+        failedIds: ['b2'],
+      });
+
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(['b1', 'b2']));
+
+      renderAt('/');
+
+      await waitFor(() => expect(titles()).toEqual([first.title]));
+      expect(readRecentlyViewed()).toEqual(['b1', 'b2']);
+    });
+  });
+
   describe('visibility', () => {
     beforeEach(() => {
       recordBookView(first.id);
       recordBookView(second.id);
     });
 
-    it('shows on the catalogue', () => {
+    it('shows on the catalogue', async () => {
       renderAt('/');
-      expect(titles()).toEqual([second.title, first.title]);
+      await waitFor(() => expect(titles()).toEqual([second.title, first.title]));
     });
 
     it('shows on a book page', async () => {
-      renderAt(`/book/${third.id}`);
-      await waitFor(() =>
-        expect(titles()).toEqual([second.title, first.title])
-      );
+      renderAt('/book/b9');
+      await waitFor(() => expect(titles()).toEqual([second.title, first.title]));
     });
 
     for (const route of ['/login', '/checkout', '/privacy', '/nonsense']) {
-      it(`renders nothing on ${route}`, () => {
+      it(`renders nothing on ${route}`, async () => {
         // It used to be declared on all of these, because the layout shell
         // mounted it unconditionally.
-        const { container } = renderAt(route);
-        expect(container.querySelector('.recently-viewed')).toBeNull();
+        renderAt(route);
+
+        await waitFor(() => expect(strip()).toBeNull());
+        expect(bookService.getBooksByIds).not.toHaveBeenCalled();
       });
     }
   });
@@ -111,14 +279,24 @@ describe('RecentlyViewed', () => {
       await waitFor(() => expect(titles()).toEqual([first.title]));
     });
 
+    it('is not even requested', async () => {
+      recordBookView(first.id);
+      recordBookView(second.id);
+
+      renderAt(`/book/${second.id}`);
+
+      await waitFor(() => expect(titles()).toEqual([first.title]));
+      for (const call of bookService.getBooksByIds.mock.calls) {
+        expect(call[0]).not.toContain(second.id);
+      }
+    });
+
     it('leaves nothing to render when it is the only entry', async () => {
       recordBookView(first.id);
 
-      const { container } = renderAt(`/book/${first.id}`);
+      renderAt(`/book/${first.id}`);
 
-      await waitFor(() =>
-        expect(container.querySelector('.recently-viewed')).toBeNull()
-      );
+      await waitFor(() => expect(strip()).toBeNull());
     });
 
     it('can still be overridden by the prop', async () => {
@@ -132,47 +310,54 @@ describe('RecentlyViewed', () => {
   });
 
   describe('resilience', () => {
-    it('renders nothing when nothing has been viewed', () => {
-      const { container } = renderAt('/');
-      expect(container.querySelector('.recently-viewed')).toBeNull();
-    });
-
-    it('skips ids that no longer resolve to a book', () => {
-      window.localStorage.setItem(
-        STORAGE_KEY,
-        JSON.stringify([first.id, 'deleted-book', third.id])
-      );
-
+    it('renders nothing when nothing has been viewed', async () => {
       renderAt('/');
 
-      expect(titles()).toEqual([first.title, third.title]);
+      await waitFor(() => expect(strip()).toBeNull());
+      expect(bookService.getBooksByIds).not.toHaveBeenCalled();
     });
 
-    it('survives a corrupted stored value', () => {
+    it('renders nothing rather than an error panel when the request fails', async () => {
+      // This is a nicety at the bottom of a page the reader came for
+      // something else. The wishlist page, where the list *is* the page,
+      // reports its failures; this does not.
+      bookService.getBooksByIds.mockRejectedValue({
+        status: 500,
+        message: 'Internal server error.',
+      });
+
+      recordBookView(first.id);
+      renderAt('/');
+
+      await waitFor(() => expect(strip()).toBeNull());
+    });
+
+    it('survives a corrupted stored value', async () => {
       vi.spyOn(console, 'error').mockImplementation(() => {});
       window.localStorage.setItem(STORAGE_KEY, '{not json');
 
-      const { container } = renderAt('/');
-      expect(container.querySelector('.recently-viewed')).toBeNull();
+      renderAt('/');
+
+      await waitFor(() => expect(strip()).toBeNull());
     });
   });
 
   describe('markup', () => {
-    it('labels the section for assistive technology', () => {
+    it('labels the section for assistive technology', async () => {
       recordBookView(first.id);
       renderAt('/');
 
       expect(
-        screen.getByRole('region', { name: 'Recently Viewed' })
+        await screen.findByRole('region', { name: 'Recently Viewed' })
       ).toBeInTheDocument();
     });
 
-    it('accepts a heading override', () => {
+    it('accepts a heading override', async () => {
       recordBookView(first.id);
       renderAt('/', { title: 'Pick up where you left off' });
 
       expect(
-        screen.getByRole('heading', { name: 'Pick up where you left off' })
+        await screen.findByRole('heading', { name: 'Pick up where you left off' })
       ).toBeInTheDocument();
     });
   });

--- a/bookshelf-frontend/src/data/books.js
+++ b/bookshelf-frontend/src/data/books.js
@@ -1,18 +1,19 @@
-// Sample catalog — in the real app this is served by the Node backend
-// from data/books.json. Kept local here for the frontend-only draft.
+// Local data for the frontend.
 //
-// DEPRECATED for anything with an API behind it. `books` below is a snapshot
-// of bookshelf-backend/data/books.json that nothing keeps in sync: it has no
-// `inventory`, its prices go stale the moment the catalogue is edited, and a
-// book added to the backend does not exist here at all. Home (#274) and the
-// book detail page (#317) read the API instead.
+// This file used to also export `books` — a snapshot of
+// bookshelf-backend/data/books.json that nothing kept in sync. Its own header
+// called it deprecated and listed what was wrong with it: no `inventory`
+// field, prices that went stale the moment the catalogue was edited, and no
+// record at all for a book added to the backend.
 //
-// Still imported by pages/Wishlist.jsx, pages/WishlistPage.jsx and
-// components/RecentlyViewed.jsx, which resolve stored book ids to records.
-// Those should move to the API too; until they do, this file stays.
+// Every consumer has moved to the API: Home in #274, the book detail page in
+// #317, the wishlist in #328 and the Recently Viewed strip in #336. The
+// snapshot is gone with the last of them, along with the `genres` list, which
+// GET /api/books/genres serves with counts.
 //
-// `spines` has no API behind it — it drives the decorative shelf strip in
-// Hero.jsx and is genuinely local data.
+// `spines` stays, because it has no API behind it. It drives the decorative
+// shelf strip in Hero.jsx and is genuinely local: colours and heights for a
+// row of book spines, not a catalogue.
 
 export const spines = [
   {
@@ -70,89 +71,5 @@ export const spines = [
     author: 'N. Basu',
     color: '#7A5C2E',
     height: 218,
-  },
-];
-
-export const genres = [
-  'All',
-  'Fiction',
-  'Sci-Fi',
-  'Mystery',
-  'Self-Help',
-  'Poetry',
-];
-
-export const books = [
-  {
-    id: 'b1',
-    title: 'The Quiet Ones',
-    author: 'M. Arora',
-    genre: 'Fiction',
-    price: 349,
-    rating: 4.5,
-    cover: '#7A2E2E',
-  },
-  {
-    id: 'b2',
-    title: 'Field Notes',
-    author: 'D. Kapoor',
-    genre: 'Self-Help',
-    price: 299,
-    rating: 4.2,
-    cover: '#1F4B43',
-  },
-  {
-    id: 'b3',
-    title: 'Half Moon Bay',
-    author: 'S. Rhee',
-    genre: 'Mystery',
-    price: 399,
-    rating: 4.7,
-    cover: '#B85C2C',
-  },
-  {
-    id: 'b4',
-    title: 'Static',
-    author: 'A. Voss',
-    genre: 'Sci-Fi',
-    price: 449,
-    rating: 4.3,
-    cover: '#3A3F63',
-  },
-  {
-    id: 'b5',
-    title: 'Low Tide',
-    author: 'R. Menon',
-    genre: 'Poetry',
-    price: 249,
-    rating: 4.6,
-    cover: '#5F7A61',
-  },
-  {
-    id: 'b6',
-    title: 'The Long Corridor',
-    author: 'K. Iyer',
-    genre: 'Mystery',
-    price: 379,
-    rating: 4.1,
-    cover: '#93461F',
-  },
-  {
-    id: 'b7',
-    title: 'Paper Moths',
-    author: 'L. Fischer',
-    genre: 'Fiction',
-    price: 329,
-    rating: 4.4,
-    cover: '#2E4057',
-  },
-  {
-    id: 'b8',
-    title: 'Ordinary Weather',
-    author: 'N. Basu',
-    genre: 'Self-Help',
-    price: 279,
-    rating: 4.0,
-    cover: '#7A5C2E',
   },
 ];

--- a/bookshelf-frontend/src/hooks/useBooksByIds.js
+++ b/bookshelf-frontend/src/hooks/useBooksByIds.js
@@ -1,0 +1,120 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { getBooksByIds } from '../services/bookService.js';
+
+/**
+ * A request this hook deliberately dropped on unmount.
+ *
+ * A cancellation never reaches the API client's error normalisation, so it
+ * keeps the Axios shape. It is not a failure and must never be rendered — a
+ * page that unmounted mid-request would otherwise flash "canceled" into its
+ * error slot.
+ */
+export function isCanceled(error) {
+  return (
+    error?.name === 'CanceledError' ||
+    error?.code === 'ERR_CANCELED' ||
+    error?.original?.code === 'ERR_CANCELED'
+  );
+}
+
+/**
+ * Resolve a list of book ids against the catalogue.
+ *
+ * This is the shared half of `useWishlistBooks`, extracted because a second
+ * caller appeared: the Recently Viewed strip was still resolving its stored
+ * ids against `src/data/books.js`, the hardcoded local snapshot, and needed
+ * exactly the same thing — see #336 and, for the wishlist, #328.
+ *
+ * Everything that made the wishlist version careful applies identically here,
+ * and none of it is obvious enough to want written twice:
+ *
+ *   - The result follows the order of `ids`, not the order the responses
+ *     happened to arrive in, so a list does not reshuffle between loads.
+ *   - The effect keys on the joined ids rather than on the array, because a
+ *     caller holding the array in state hands back a new identity on every
+ *     render and the effect would refetch forever.
+ *   - The request is aborted on unmount and on a change of ids, and the
+ *     cancellation is swallowed rather than rendered.
+ *   - `missingIds` (the catalogue answered 404) is reported separately from
+ *     `failedIds` (the request did not complete). Saying "no longer in the
+ *     catalogue" about a book that is merely unreachable would be a lie told
+ *     by a flaky network.
+ *
+ * @param {string[]} ids
+ * @param {{ enabled?: boolean }} options
+ *   `enabled: false` holds the hook in its loading state without fetching —
+ *   for a caller whose ids are themselves still loading. Resolving the empty
+ *   interim list would flash an empty state.
+ */
+export function useBooksByIds(ids, { enabled = true } = {}) {
+  const [books, setBooks] = useState([]);
+  const [missingIds, setMissingIds] = useState([]);
+  const [failedIds, setFailedIds] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const key = useMemo(() => (Array.isArray(ids) ? ids.join(',') : ''), [ids]);
+
+  // Read inside the effect so `ids` itself is not a dependency.
+  const idsRef = useRef(ids);
+  idsRef.current = ids;
+
+  useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    const requested = Array.isArray(idsRef.current) ? idsRef.current : [];
+
+    if (requested.length === 0) {
+      setBooks([]);
+      setMissingIds([]);
+      setFailedIds([]);
+      setError(null);
+      setLoading(false);
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    let active = true;
+
+    setLoading(true);
+    setError(null);
+
+    getBooksByIds(requested, { signal: controller.signal })
+      .then((result) => {
+        if (!active) {
+          return;
+        }
+
+        const byId = new Map(result.books.map((book) => [book.id, book]));
+        setBooks(requested.map((id) => byId.get(id)).filter(Boolean));
+
+        setMissingIds(result.missingIds);
+        setFailedIds(result.failedIds);
+      })
+      .catch((requestError) => {
+        if (!active || isCanceled(requestError)) {
+          return;
+        }
+
+        setBooks([]);
+        setError(requestError);
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [key, enabled]);
+
+  return { books, missingIds, failedIds, loading, error };
+}
+
+export default useBooksByIds;

--- a/bookshelf-frontend/src/hooks/useBooksByIds.test.jsx
+++ b/bookshelf-frontend/src/hooks/useBooksByIds.test.jsx
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import * as bookService from '../services/bookService.js';
+import { useBooksByIds, isCanceled } from './useBooksByIds.js';
+
+/**
+ * The shared id-resolver behind the wishlist (#328) and the Recently Viewed
+ * strip (#336).
+ *
+ * Both used to do `books.filter(b => ids.includes(b.id))` against
+ * `src/data/books.js`, a hardcoded local snapshot of the catalogue. That is a
+ * silent drop in one direction and a phantom card in the other. The rules
+ * that replace it — ordering, deduplication of effects, 404 vs failure, abort
+ * on unmount — are all easy to get subtly wrong, which is why they live in
+ * one hook and are asserted here rather than twice over in two page tests.
+ */
+
+vi.mock('../services/bookService.js', async () => {
+  const actual = await vi.importActual('../services/bookService.js');
+  return { ...actual, getBooksByIds: vi.fn() };
+});
+
+const book = (id, title) => ({ id, title });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useBooksByIds', () => {
+  it('resolves ids to books', async () => {
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [book('b1', 'One'), book('b2', 'Two')],
+      missingIds: [],
+      failedIds: [],
+    });
+
+    const { result } = renderHook(() => useBooksByIds(['b1', 'b2']));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.books.map((b) => b.id)).toEqual(['b1', 'b2']);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('follows the order of the ids, not the order of the responses', async () => {
+    // The requests run concurrently, so the response order is whichever
+    // finished first. A list that reshuffles between loads is its own bug.
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [book('b3', 'Three'), book('b1', 'One'), book('b2', 'Two')],
+      missingIds: [],
+      failedIds: [],
+    });
+
+    const { result } = renderHook(() => useBooksByIds(['b1', 'b2', 'b3']));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.books.map((b) => b.id)).toEqual(['b1', 'b2', 'b3']);
+  });
+
+  it('separates a 404 from a request that did not complete', async () => {
+    // Saying "no longer in the catalogue" about a book that is merely
+    // unreachable is a lie told by a flaky network.
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [book('b1', 'One')],
+      missingIds: ['gone'],
+      failedIds: ['unreachable'],
+    });
+
+    const { result } = renderHook(() =>
+      useBooksByIds(['b1', 'gone', 'unreachable'])
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.missingIds).toEqual(['gone']);
+    expect(result.current.failedIds).toEqual(['unreachable']);
+  });
+
+  it('requests nothing for an empty list and settles immediately', async () => {
+    const { result } = renderHook(() => useBooksByIds([]));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.books).toEqual([]);
+    expect(bookService.getBooksByIds).not.toHaveBeenCalled();
+  });
+
+  it('treats a non-array as an empty list rather than throwing', async () => {
+    const { result } = renderHook(() => useBooksByIds(null));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.books).toEqual([]);
+  });
+
+  it('does not refetch when the caller passes a new array with the same ids', async () => {
+    // A caller holding the ids in state hands back a new identity on every
+    // render. Depending on the array itself would refetch forever.
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [book('b1', 'One')],
+      missingIds: [],
+      failedIds: [],
+    });
+
+    const { result, rerender } = renderHook(({ ids }) => useBooksByIds(ids), {
+      initialProps: { ids: ['b1'] },
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(bookService.getBooksByIds).toHaveBeenCalledTimes(1);
+
+    rerender({ ids: ['b1'] });
+    rerender({ ids: ['b1'] });
+
+    expect(bookService.getBooksByIds).toHaveBeenCalledTimes(1);
+  });
+
+  it('does refetch when the ids actually change', async () => {
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [],
+      missingIds: [],
+      failedIds: [],
+    });
+
+    const { rerender } = renderHook(({ ids }) => useBooksByIds(ids), {
+      initialProps: { ids: ['b1'] },
+    });
+
+    await waitFor(() => expect(bookService.getBooksByIds).toHaveBeenCalledTimes(1));
+
+    rerender({ ids: ['b1', 'b2'] });
+
+    await waitFor(() => expect(bookService.getBooksByIds).toHaveBeenCalledTimes(2));
+  });
+
+  it('reports a failure without leaving stale books on screen', async () => {
+    bookService.getBooksByIds.mockRejectedValue({
+      status: 500,
+      message: 'Internal server error.',
+    });
+
+    const { result } = renderHook(() => useBooksByIds(['b1']));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.books).toEqual([]);
+    expect(result.current.error).toMatchObject({ status: 500 });
+  });
+
+  it('never renders a cancellation as an error', async () => {
+    // A cancellation does not reach the API client's normalisation, so it
+    // keeps the Axios shape. A page that unmounted mid-request would flash
+    // "canceled" into its error slot.
+    bookService.getBooksByIds.mockRejectedValue({ code: 'ERR_CANCELED' });
+
+    const { result } = renderHook(() => useBooksByIds(['b1']));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeNull();
+  });
+
+  it('aborts the request when it unmounts', async () => {
+    let signal;
+    bookService.getBooksByIds.mockImplementation(async (ids, options) => {
+      signal = options?.signal;
+      return { books: [], missingIds: [], failedIds: [] };
+    });
+
+    const { unmount } = renderHook(() => useBooksByIds(['b1']));
+
+    await waitFor(() => expect(signal).toBeDefined());
+    expect(signal.aborted).toBe(false);
+
+    unmount();
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('does not apply a response that arrived after the ids changed', async () => {
+    const slow = { books: [book('old', 'Old')], missingIds: [], failedIds: [] };
+    const fast = { books: [book('new', 'New')], missingIds: [], failedIds: [] };
+
+    let resolveSlow;
+    bookService.getBooksByIds
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveSlow = resolve; }))
+      .mockResolvedValueOnce(fast);
+
+    const { result, rerender } = renderHook(({ ids }) => useBooksByIds(ids), {
+      initialProps: { ids: ['old'] },
+    });
+
+    rerender({ ids: ['new'] });
+    await waitFor(() => expect(result.current.books.map((b) => b.id)).toEqual(['new']));
+
+    // The first request finishes last. It must not paint over the current one.
+    resolveSlow(slow);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(result.current.books.map((b) => b.id)).toEqual(['new']);
+  });
+
+  describe('enabled: false', () => {
+    it('requests nothing and stays loading', async () => {
+      const { result } = renderHook(() => useBooksByIds(['b1'], { enabled: false }));
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(bookService.getBooksByIds).not.toHaveBeenCalled();
+      expect(result.current.loading).toBe(true);
+    });
+
+    it('fetches as soon as it is enabled', async () => {
+      bookService.getBooksByIds.mockResolvedValue({
+        books: [book('b1', 'One')],
+        missingIds: [],
+        failedIds: [],
+      });
+
+      const { result, rerender } = renderHook(
+        ({ enabled }) => useBooksByIds(['b1'], { enabled }),
+        { initialProps: { enabled: false } }
+      );
+
+      expect(bookService.getBooksByIds).not.toHaveBeenCalled();
+
+      rerender({ enabled: true });
+
+      await waitFor(() => expect(result.current.books).toHaveLength(1));
+    });
+  });
+});
+
+describe('isCanceled', () => {
+  it('recognises every shape a cancellation arrives in', () => {
+    expect(isCanceled({ name: 'CanceledError' })).toBe(true);
+    expect(isCanceled({ code: 'ERR_CANCELED' })).toBe(true);
+    expect(isCanceled({ original: { code: 'ERR_CANCELED' } })).toBe(true);
+  });
+
+  it('does not swallow a real failure', () => {
+    expect(isCanceled({ status: 500, code: 'SERVER_ERROR' })).toBe(false);
+    expect(isCanceled(null)).toBe(false);
+    expect(isCanceled(undefined)).toBe(false);
+    expect(isCanceled(new Error('boom'))).toBe(false);
+  });
+});

--- a/bookshelf-frontend/src/hooks/useRecentlyViewedBooks.js
+++ b/bookshelf-frontend/src/hooks/useRecentlyViewedBooks.js
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useBooksByIds } from './useBooksByIds.js';
+import {
+  forgetBookViews,
+  readRecentlyViewedExcept,
+} from '../utils/recentlyViewed.js';
+
+/**
+ * The reader's recent history, as books rather than as ids.
+ *
+ * The strip used to resolve its ids against `src/data/books.js`:
+ *
+ *     ids.map((id) => books.find((book) => String(book.id) === id))
+ *        .filter(Boolean)
+ *
+ * That file is the deprecated local snapshot of the catalogue, and says so in
+ * its own header — no `inventory` field, prices that go stale the moment the
+ * catalogue is edited, and no record at all for a book added to the backend.
+ * All three showed up on screen (#336):
+ *
+ *   - A price edited in the backend updated in the grid and did not update in
+ *     the strip below it, on the same page.
+ *   - A book added to the backend produced `undefined` from `find`, which
+ *     `.filter(Boolean)` dropped silently. Viewed, and then simply absent.
+ *   - `isInStock()` treats a missing `inventory` as available, so a sold-out
+ *     book kept an enabled "Add to cart" in the strip while the identical
+ *     card above it read "Out of stock".
+ *
+ * It reads the API now, through the same `useBooksByIds` the wishlist uses.
+ *
+ * The ids themselves are re-read on every navigation rather than held in
+ * state: `recordBookView` writes to localStorage from a different effect in
+ * the same component, so state seeded once at mount would be one navigation
+ * behind.
+ *
+ * @param {{ excludeId?: string, locationKey?: string, enabled?: boolean }} options
+ *   `excludeId` is the book the page is already showing. `locationKey` is
+ *   React Router's `location.key`, which changes on every navigation and is
+ *   what makes the stored list re-read. `enabled: false` reads nothing and
+ *   requests nothing — the strip is hidden on most routes, and hooks cannot
+ *   be called conditionally, so the caller says so here instead.
+ */
+export function useRecentlyViewedBooks({
+  excludeId,
+  locationKey,
+  enabled = true,
+} = {}) {
+  const [ids, setIds] = useState(() =>
+    enabled ? readRecentlyViewedExcept(excludeId) : []
+  );
+
+  useEffect(() => {
+    setIds(enabled ? readRecentlyViewedExcept(excludeId) : []);
+  }, [excludeId, locationKey, enabled]);
+
+  const { books, missingIds, failedIds, loading, error } = useBooksByIds(ids, {
+    enabled,
+  });
+
+  /*
+   * Ids the catalogue answered 404 for are dropped from storage.
+   *
+   * A delisted book is not coming back, and leaving it in the list means
+   * asking the API about it on every page load for as long as the browser
+   * keeps the value. `failedIds` is deliberately not touched — those books
+   * probably still exist, and forgetting a reader's history because their
+   * connection dropped would be worse than the bug being fixed.
+   */
+  const missingKey = missingIds.join(',');
+
+  useEffect(() => {
+    if (missingKey === '') {
+      return;
+    }
+
+    forgetBookViews(missingKey.split(','));
+  }, [missingKey]);
+
+  const refresh = useCallback(() => {
+    setIds(enabled ? readRecentlyViewedExcept(excludeId) : []);
+  }, [excludeId, enabled]);
+
+  return useMemo(
+    () => ({ books, missingIds, failedIds, loading, error, refresh }),
+    [books, missingIds, failedIds, loading, error, refresh]
+  );
+}
+
+export default useRecentlyViewedBooks;

--- a/bookshelf-frontend/src/hooks/useRecentlyViewedBooks.test.jsx
+++ b/bookshelf-frontend/src/hooks/useRecentlyViewedBooks.test.jsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import * as bookService from '../services/bookService.js';
+import { STORAGE_KEY, readRecentlyViewed } from '../utils/recentlyViewed.js';
+import { useRecentlyViewedBooks } from './useRecentlyViewedBooks.js';
+
+/**
+ * The reader's history, resolved against the catalogue.
+ *
+ * Split out from the component so the parts that are easy to get wrong — when
+ * the stored list is re-read, which ids get pruned, what `enabled` suppresses
+ * — can be asserted without rendering a router and a book card. See #336.
+ */
+
+vi.mock('../services/bookService.js', async () => {
+  const actual = await vi.importActual('../services/bookService.js');
+  return { ...actual, getBooksByIds: vi.fn() };
+});
+
+const CATALOGUE = {
+  b1: { id: 'b1', title: 'One' },
+  b2: { id: 'b2', title: 'Two' },
+  b3: { id: 'b3', title: 'Three' },
+};
+
+function serveCatalogue() {
+  bookService.getBooksByIds.mockImplementation(async (ids) => {
+    const books = [];
+    const missingIds = [];
+
+    for (const id of ids) {
+      if (CATALOGUE[id]) {
+        books.push(CATALOGUE[id]);
+      } else {
+        missingIds.push(id);
+      }
+    }
+
+    return { books, missingIds, failedIds: [] };
+  });
+}
+
+const store = (...ids) =>
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.clearAllMocks();
+  serveCatalogue();
+});
+
+describe('useRecentlyViewedBooks', () => {
+  it('resolves the stored ids against the API', async () => {
+    store('b1', 'b2');
+
+    const { result } = renderHook(() => useRecentlyViewedBooks());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.books.map((b) => b.id)).toEqual(['b1', 'b2']);
+  });
+
+  it('excludes the book the page is already showing', async () => {
+    store('b1', 'b2', 'b3');
+
+    const { result } = renderHook(() =>
+      useRecentlyViewedBooks({ excludeId: 'b2' })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.books.map((b) => b.id)).toEqual(['b1', 'b3']);
+    expect(bookService.getBooksByIds.mock.calls[0][0]).not.toContain('b2');
+  });
+
+  it('re-reads storage when the location key changes', async () => {
+    // recordBookView writes from a sibling effect in the same component, so a
+    // list read once at mount would be one navigation behind.
+    store('b1');
+
+    const { result, rerender } = renderHook(
+      ({ locationKey }) => useRecentlyViewedBooks({ locationKey }),
+      { initialProps: { locationKey: 'first' } }
+    );
+
+    await waitFor(() => expect(result.current.books).toHaveLength(1));
+
+    store('b2', 'b1');
+    rerender({ locationKey: 'second' });
+
+    await waitFor(() =>
+      expect(result.current.books.map((b) => b.id)).toEqual(['b2', 'b1'])
+    );
+  });
+
+  it('prunes an id the catalogue answered 404 for', async () => {
+    store('b1', 'delisted', 'b2');
+
+    const { result } = renderHook(() => useRecentlyViewedBooks());
+
+    await waitFor(() => expect(result.current.missingIds).toEqual(['delisted']));
+    await waitFor(() => expect(readRecentlyViewed()).toEqual(['b1', 'b2']));
+  });
+
+  it('keeps an id whose request only failed', async () => {
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [CATALOGUE.b1],
+      missingIds: [],
+      failedIds: ['b2'],
+    });
+
+    store('b1', 'b2');
+
+    const { result } = renderHook(() => useRecentlyViewedBooks());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.failedIds).toEqual(['b2']);
+    expect(readRecentlyViewed()).toEqual(['b1', 'b2']);
+  });
+
+  it('does not prune on every render once it has pruned', async () => {
+    store('b1', 'delisted');
+
+    const { rerender } = renderHook(() => useRecentlyViewedBooks());
+
+    await waitFor(() => expect(readRecentlyViewed()).toEqual(['b1']));
+
+    const callsAfterPrune = bookService.getBooksByIds.mock.calls.length;
+    rerender();
+    rerender();
+
+    expect(bookService.getBooksByIds.mock.calls.length).toBe(callsAfterPrune);
+  });
+
+  it('requests nothing when nothing has been viewed', async () => {
+    const { result } = renderHook(() => useRecentlyViewedBooks());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(bookService.getBooksByIds).not.toHaveBeenCalled();
+  });
+
+  it('reads and requests nothing when disabled', async () => {
+    store('b1', 'b2');
+
+    const { result } = renderHook(() =>
+      useRecentlyViewedBooks({ enabled: false })
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(bookService.getBooksByIds).not.toHaveBeenCalled();
+    expect(result.current.books).toEqual([]);
+  });
+
+  it('starts working the moment it is enabled', async () => {
+    store('b1');
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useRecentlyViewedBooks({ enabled }),
+      { initialProps: { enabled: false } }
+    );
+
+    expect(bookService.getBooksByIds).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    await waitFor(() => expect(result.current.books).toHaveLength(1));
+  });
+
+  it('surfaces a failure rather than hanging', async () => {
+    bookService.getBooksByIds.mockRejectedValue({ status: 500 });
+    store('b1');
+
+    const { result } = renderHook(() => useRecentlyViewedBooks());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toMatchObject({ status: 500 });
+    expect(result.current.books).toEqual([]);
+  });
+
+  it('re-reads on demand through refresh()', async () => {
+    store('b1');
+
+    const { result } = renderHook(() => useRecentlyViewedBooks());
+
+    await waitFor(() => expect(result.current.books).toHaveLength(1));
+
+    store('b1', 'b2');
+    result.current.refresh();
+
+    await waitFor(() => expect(result.current.books).toHaveLength(2));
+  });
+});

--- a/bookshelf-frontend/src/hooks/useWishlistBooks.js
+++ b/bookshelf-frontend/src/hooks/useWishlistBooks.js
@@ -1,38 +1,27 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 
-import { getBooksByIds } from '../services/bookService.js';
+import { useBooksByIds } from './useBooksByIds.js';
 import { useWishlist } from './useWishlist.js';
-
-/**
- * A request this hook deliberately dropped on unmount.
- *
- * A cancellation never reaches the API client's error normalisation, so it
- * keeps the Axios shape. It is not a failure and must never be rendered — a
- * page that unmounted mid-request would otherwise flash "canceled" into its
- * error slot.
- */
-function isCanceled(error) {
-  return (
-    error?.name === 'CanceledError' ||
-    error?.code === 'ERR_CANCELED' ||
-    error?.original?.code === 'ERR_CANCELED'
-  );
-}
 
 /**
  * The wishlist, as books rather than as ids.
  *
  * The wishlist page used to resolve its ids against `src/data/books.js` — a
  * hardcoded copy of the catalogue that says in its own header it is a local
- * draft, and which has drifted: it holds 16 books (`s1`–`s8`, `b1`–`b8`)
- * where the API serves 8 (`b1`–`b8`).
+ * draft, and which had drifted: it held 16 books (`s1`-`s8`, `b1`-`b8`)
+ * where the API serves 8 (`b1`-`b8`).
  *
- * `books.filter(b => wishlist.includes(b.id))` is wrong in both directions
- * and silent in both. A wishlisted book the local file does not have produces
- * no card and no message, while the heart stays filled on the catalogue; and
- * the eight `s*` ids that exist *only* in the local file render cards for
+ * `books.filter(b => wishlist.includes(b.id))` was wrong in both directions
+ * and silent in both. A wishlisted book the local file did not have produced
+ * no card and no message, while the heart stayed filled on the catalogue; and
+ * the eight `s*` ids that existed *only* in the local file rendered cards for
  * books the API has never heard of, which 404 the moment they are clicked.
  * See #328.
+ *
+ * The fetching half now lives in `useBooksByIds`, because the Recently Viewed
+ * strip turned out to have exactly the same bug and exactly the same needs.
+ * See #336. What is left here is the wishlist-specific part: waiting for the
+ * wishlist itself to settle before resolving anything.
  *
  * `missingIds` is the ids the catalogue answered 404 for — delisted books,
  * which the customer should be told about rather than have quietly vanish.
@@ -43,88 +32,24 @@ function isCanceled(error) {
 export function useWishlistBooks() {
   const { wishlist, loading: wishlistLoading } = useWishlist();
 
-  const [books, setBooks] = useState([]);
-  const [missingIds, setMissingIds] = useState([]);
-  const [failedIds, setFailedIds] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  /*
+   * The provider hands back a new array identity on every render. Memoising
+   * on the joined ids keeps `useBooksByIds` from seeing a new array — and so
+   * a new effect dependency — on every render of the page.
+   */
+  const key = Array.isArray(wishlist) ? wishlist.join(',') : '';
+  const ids = useMemo(() => (key === '' ? [] : key.split(',')), [key]);
 
   /*
-   * The provider hands back a new array identity on every render, so the
-   * effect has to key on the ids themselves. Without this it refetches the
-   * whole wishlist on every render of the page.
+   * Nothing to resolve until the wishlist itself has settled — for a
+   * signed-in user that is a round trip of its own, and resolving the empty
+   * interim list would flash "your wishlist is empty".
    */
-  const key = useMemo(() => (Array.isArray(wishlist) ? wishlist.join(',') : ''), [wishlist]);
-
-  // Read inside the effect so `wishlist` itself is not a dependency.
-  const wishlistRef = useRef(wishlist);
-  wishlistRef.current = wishlist;
-
-  useEffect(() => {
-    // Nothing to resolve until the wishlist itself has settled — for a
-    // signed-in user that is a round trip of its own, and resolving the
-    // empty interim list would flash "your wishlist is empty".
-    if (wishlistLoading) {
-      return undefined;
-    }
-
-    const ids = Array.isArray(wishlistRef.current) ? wishlistRef.current : [];
-
-    if (ids.length === 0) {
-      setBooks([]);
-      setMissingIds([]);
-      setFailedIds([]);
-      setError(null);
-      setLoading(false);
-      return undefined;
-    }
-
-    const controller = new AbortController();
-    let active = true;
-
-    setLoading(true);
-    setError(null);
-
-    getBooksByIds(ids, { signal: controller.signal })
-      .then((result) => {
-        if (!active) {
-          return;
-        }
-
-        // Follow the wishlist's own order rather than whichever response
-        // came back first, so the list does not reshuffle between loads.
-        const byId = new Map(result.books.map((book) => [book.id, book]));
-        setBooks(ids.map((id) => byId.get(id)).filter(Boolean));
-
-        setMissingIds(result.missingIds);
-        setFailedIds(result.failedIds);
-      })
-      .catch((requestError) => {
-        if (!active || isCanceled(requestError)) {
-          return;
-        }
-
-        setBooks([]);
-        setError(requestError);
-      })
-      .finally(() => {
-        if (active) {
-          setLoading(false);
-        }
-      });
-
-    return () => {
-      active = false;
-      controller.abort();
-    };
-  }, [key, wishlistLoading]);
+  const result = useBooksByIds(ids, { enabled: !wishlistLoading });
 
   return {
-    books,
-    missingIds,
-    failedIds,
-    loading: loading || wishlistLoading,
-    error,
+    ...result,
+    loading: result.loading || wishlistLoading,
   };
 }
 

--- a/bookshelf-frontend/src/utils/recentlyViewed.js
+++ b/bookshelf-frontend/src/utils/recentlyViewed.js
@@ -143,6 +143,42 @@ export function readRecentlyViewedExcept(excludeId) {
   return readRecentlyViewed().filter((id) => id !== excluded);
 }
 
+/**
+ * Drop ids from the list.
+ *
+ * Used for the ids the catalogue answered 404 for. A book that has been
+ * delisted is not coming back, and leaving its id in storage means asking the
+ * API about it on every page load for as long as the browser keeps the value
+ * — eight ids, one request each, forever.
+ *
+ * Only a 404 should reach this. An id whose request merely *failed* must stay:
+ * that book probably still exists, and forgetting a reader's history because
+ * their connection dropped is a worse bug than the one this fixes.
+ *
+ * Returns the new list.
+ */
+export function forgetBookViews(ids) {
+  const doomed = new Set(
+    (Array.isArray(ids) ? ids : [ids])
+      .filter((id) => typeof id === 'string' || typeof id === 'number')
+      .map((id) => String(id))
+  );
+
+  if (doomed.size === 0) {
+    return readRecentlyViewed();
+  }
+
+  const next = readRecentlyViewed().filter((id) => !doomed.has(id));
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch (error) {
+    console.error('[recentlyViewed] could not save to storage:', error);
+  }
+
+  return next;
+}
+
 export function clearRecentlyViewed() {
   try {
     window.localStorage.removeItem(STORAGE_KEY);
@@ -157,5 +193,6 @@ export default {
   readRecentlyViewed,
   readRecentlyViewedExcept,
   recordBookView,
+  forgetBookViews,
   clearRecentlyViewed,
 };

--- a/bookshelf-frontend/src/utils/recentlyViewed.test.js
+++ b/bookshelf-frontend/src/utils/recentlyViewed.test.js
@@ -3,6 +3,7 @@ import {
   MAX_ENTRIES,
   STORAGE_KEY,
   clearRecentlyViewed,
+  forgetBookViews,
   readRecentlyViewed,
   readRecentlyViewedExcept,
   recordBookView,
@@ -151,5 +152,75 @@ describe('recentlyViewed', () => {
       clearRecentlyViewed();
       expect(readRecentlyViewed()).toEqual([]);
     });
+  });
+});
+
+describe('forgetBookViews', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  /**
+   * Added with #336. Ids the catalogue answers 404 for are dropped, so a
+   * delisted book is not re-requested on every page load for as long as the
+   * browser keeps the value. Ids whose request merely *failed* are not
+   * touched — see the tests in RecentlyViewed.test.jsx for that half.
+   */
+
+  it('drops the ids it is given and keeps the rest', () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(['b1', 'b2', 'b3']));
+
+    expect(forgetBookViews(['b2'])).toEqual(['b1', 'b3']);
+    expect(readRecentlyViewed()).toEqual(['b1', 'b3']);
+  });
+
+  it('accepts a single id as well as a list', () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(['b1', 'b2']));
+
+    expect(forgetBookViews('b1')).toEqual(['b2']);
+  });
+
+  it('coerces a numeric id, because the app compares with String() on both sides', () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(['1', '2']));
+
+    expect(forgetBookViews([1])).toEqual(['2']);
+  });
+
+  it('is a no-op for an empty list rather than clearing everything', () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(['b1', 'b2']));
+
+    expect(forgetBookViews([])).toEqual(['b1', 'b2']);
+    expect(forgetBookViews(null)).toEqual(['b1', 'b2']);
+    expect(readRecentlyViewed()).toEqual(['b1', 'b2']);
+  });
+
+  it('ignores ids that are not there', () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(['b1']));
+
+    expect(forgetBookViews(['nope', 'also-nope'])).toEqual(['b1']);
+  });
+
+  it('drops every id when every id is gone', () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(['b1', 'b2']));
+
+    expect(forgetBookViews(['b1', 'b2'])).toEqual([]);
+    expect(readRecentlyViewed()).toEqual([]);
+  });
+
+  it('does not throw when storage refuses the write', () => {
+    // Safari private browsing throws on every setItem. Losing the pruning is
+    // not a reason to take the page down.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(['b1', 'b2']));
+
+    const setItem = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+
+    expect(() => forgetBookViews(['b1'])).not.toThrow();
+
+    setItem.mockRestore();
   });
 });


### PR DESCRIPTION
Closes #336.

The Recently Viewed strip resolved its stored ids against `src/data/books.js`:

```js
ids.map((id) => books.find((book) => String(book.id) === id)).filter(Boolean)
```

That file's own header calls itself deprecated and lists exactly what is wrong with it — no `inventory` field, prices that go stale the moment the catalogue is edited, and no record at all for a book added to the backend. All three showed up on screen:

- **Stale prices.** Edit a price in `books.json` and the catalogue grid updates while the strip below it keeps showing the old number for the same book, on the same page. Clicking "Add to cart" there took the book at the stale price.
- **New books silently dropped.** `find` returns `undefined` and `.filter(Boolean)` swallows it. The reader viewed the book; it is simply absent from the history they just made — no card, no message, no error.
- **Wrong stock state.** The snapshot has no `inventory` field, and `isInStock()` treats a missing one as available. A sold-out book kept an enabled "Add to cart" in the strip while the identical card above it read "Out of stock".

## The shape of the fix

The wishlist had this exact bug and it was fixed in #328. Rather than write a second copy of that hook, the fetching half of `useWishlistBooks` is extracted as **`useBooksByIds`** and both callers share it.

Everything that made the wishlist version careful applies identically here, and none of it is obvious enough to want written twice:

- results follow the order of `ids`, not the order the concurrent responses happened to arrive in, so a list does not reshuffle between loads;
- the effect keys on the joined ids rather than the array, because a caller holding the ids in state hands back a new identity every render and would refetch forever;
- requests abort on unmount and on a change of ids;
- a cancellation is swallowed rather than rendered — it never reaches the API client's normalisation, so it keeps the Axios shape and would otherwise flash "canceled" into an error slot;
- `missingIds` (the catalogue answered 404) stays separate from `failedIds` (the request did not complete). Saying "no longer in the catalogue" about a book that is merely unreachable is a lie told by a flaky network.

`useWishlistBooks` keeps only the part that is actually about the wishlist: waiting for the wishlist itself to settle before resolving anything, so the empty interim list does not flash "your wishlist is empty".

## Two things specific to a browsing history

**The ids are re-read on every navigation.** `recordBookView` writes to localStorage from a sibling effect in the same component, so a list read once at mount is one navigation behind. `location.key` is what drives the re-read.

**Ids the catalogue 404s are dropped from storage.** A delisted book is not coming back, and leaving its id there means asking the API about it on every page load for as long as the browser keeps the value. `forgetBookViews()` handles that — and deliberately does *not* touch `failedIds`: those books probably still exist, and forgetting a reader's history because their connection dropped would be a worse bug than the one being fixed.

## `enabled`

The strip is hidden on all but two routes, and hooks cannot be called conditionally. `enabled: false` is how the visibility rule reaches the hook — without it the checkout page fetches a strip it never renders, once per navigation. There is a test asserting `getBooksByIds` is not called on `/login`, `/checkout`, `/privacy` or an unmatched route.

The strip also renders nothing while loading, and nothing when the request fails. The lookup used to be synchronous so the strip appeared fully formed; it is a request now, and a heading over a row about to gain an unknown number of cards would push the footer around as the response lands. A failed request is silent for the same reason — this is a nicety at the bottom of a page the reader came for something else. The wishlist page, where the list *is* the page, reports its failures; this does not.

## Removing the snapshot

With the last consumer gone, `src/data/books.js` drops its `books` and `genres` exports. Every page that needed them has moved to the API — Home in #274, book detail in #317, the wishlist in #328, and this strip. `genres` is served by `GET /api/books/genres` with counts.

`spines` stays. It has no API behind it: colours and heights for the decorative shelf strip in `Hero.jsx`, genuinely local data rather than a catalogue.

## Testing

- **`useBooksByIds.test.jsx`** — 15 new tests. Ordering independent of response order, 404 vs failure, the stable-key rule (a new array with the same ids does not refetch; changed ids do), abort on unmount, the out-of-order-response race, `enabled`, and `isCanceled` across all three shapes a cancellation arrives in.
- **`useRecentlyViewedBooks.test.jsx`** — 11 new tests. Re-reading on navigation, excluding the current book from its own strip *and* from the request, pruning a 404 while keeping a failure, and not re-pruning on every render.
- **`RecentlyViewed.test.jsx`** — rewritten against a mocked API, now 27 tests. It asserts the three symptoms directly: a price the API changed reaches the strip, `inventory` is carried through so a sold-out book is not sellable there, and a book that exists only in the API renders. The earlier coverage from #318 and #327 (recording, route visibility, current-book exclusion, corrupted storage) is all still there.
- **`recentlyViewed.test.js`** — 7 new tests for `forgetBookViews`, including the no-op-on-empty case, since a bug there would clear a reader's whole history.
- `WishlistPage.test.jsx` passes unchanged against the refactored hook, which is the point of it.

Frontend **487 passing** (was 445). ESLint reports the same 43 errors / 51 warnings as `main`; every file touched here is clean. Backend untouched.
