### PR TITLE
fix(a11y): reset scroll, move focus, and add a skip link

### DIFF
--- a/bookshelf-frontend/src/App.jsx
+++ b/bookshelf-frontend/src/App.jsx
@@ -1,7 +1,9 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Outlet } from 'react-router-dom';
 
-import ScrollToTop from './components/ScrollToTop.jsx';
+import BackToTopButton from './components/BackToTopButton.jsx';
+import RouteChangeHandler from './components/RouteChangeHandler.jsx';
+import SkipLink from './components/SkipLink.jsx';
 
 import CustomCursor from './components/CustomCursor.jsx';
 import Navbar from './components/Navbar.jsx';
@@ -26,20 +28,62 @@ import './App.css';
 export default function App() {
   const [searchQuery, setSearchQuery] = useState('');
 
+  /*
+   * The one element a skip link can target and a route change can focus.
+   *
+   * Pages own their own <main>: Home, BookDetail, Checkout, OrderConfirmation,
+   * WishlistPage and NotFound each render one, while OrderHistory, Profile,
+   * OrderDetailsPage, Login and Register render none at all. So there was no
+   * single element to send focus to, and adding one to eleven pages would put
+   * the same rule in eleven places. The layout owns it instead.
+   *
+   * `tabIndex={-1}` makes it focusable programmatically without adding a tab
+   * stop of its own. Its id is `main-content` rather than `catalog`, which
+   * Home already uses for the `/#catalog` anchor in the navbar.
+   *
+   * It is a <div>, not a <main>: the pages that render their own <main> would
+   * otherwise be nesting one inside another, and two `main` landmarks is
+   * worse for a screen reader than the wrapper being unlabelled.
+   */
+  const contentRef = useRef(null);
+
   return (
     <div className="app">
+      {/*
+        First in the DOM, so it is the first thing Tab reaches. A keyboard
+        user arriving at any page had to walk the whole navbar — brand, two
+        section links, three public links, up to two account links,
+        login/logout, search, theme toggle, cart, hamburger — before reaching
+        the content. See #339.
+      */}
+      <SkipLink targetId="main-content" />
+
+      {/*
+        Resets the scroll position and moves focus on navigation.
+
+        The component that used to sit here was called ScrollToTop, which read
+        as though this were already handled. It is a floating back-to-top
+        button and always was: it never looked at the location. Nothing in the
+        app reset scroll, so opening a book from the bottom of the catalogue
+        landed on the book page already scrolled past its title. It is renamed
+        to what it is, and the real thing sits above it.
+      */}
+      <RouteChangeHandler contentRef={contentRef} />
+
       {/*
         The theme toggle used to be rendered here *as well as* in the navbar,
         as two separate components each holding their own copy of the theme.
         It now lives only in the navbar, reading the shared ThemeContext.
       */}
-      <ScrollToTop />
+      <BackToTopButton />
       <CustomCursor />
 
       <Navbar searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
       <div className="nav-spacer" />
 
-      <Outlet context={{ searchQuery, setSearchQuery }} />
+      <div id="main-content" ref={contentRef} tabIndex={-1}>
+        <Outlet context={{ searchQuery, setSearchQuery }} />
+      </div>
 
       <RecentlyViewed />
       <Footer />

--- a/bookshelf-frontend/src/App.test.jsx
+++ b/bookshelf-frontend/src/App.test.jsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, Link } from 'react-router-dom';
+
+/*
+ * The layout shell, not the pages. Everything App mounts that has its own
+ * behaviour is stubbed, because what is being asserted here is the wiring:
+ * that there is one focusable content wrapper, that the skip link points at
+ * it, and that a navigation resets scroll and moves focus into it. See #339.
+ */
+
+vi.mock('./components/CustomCursor.jsx', () => ({ default: () => null }));
+vi.mock('./components/RecentlyViewed.jsx', () => ({ default: () => null }));
+vi.mock('./components/CartDrawer.jsx', () => ({ default: () => null }));
+vi.mock('./components/Footer.jsx', () => ({ default: () => <footer /> }));
+vi.mock('./components/BackToTopButton.jsx', () => ({ default: () => null }));
+
+vi.mock('./components/Navbar.jsx', () => ({
+  default: () => (
+    <nav>
+      <Link to="/">brand</Link>
+      <Link to="/wishlist">wishlist</Link>
+      <input aria-label="Search" />
+      <button type="button">cart</button>
+    </nav>
+  ),
+}));
+
+const { default: App } = await import('./App.jsx');
+
+let scrollTo;
+
+function renderApp(initialEntry = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/" element={<App />}>
+          <Route index element={<main><h1>home</h1></main>} />
+          <Route path="wishlist" element={<main><h1>wishlist</h1></main>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  scrollTo = vi.fn();
+  window.scrollTo = scrollTo;
+  window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('App layout', () => {
+  it('gives every route one focusable content wrapper', () => {
+    // Pages own their own <main> — six render one, five render none — so
+    // there was no single element a skip link or a focus move could target.
+    renderApp();
+
+    const content = document.getElementById('main-content');
+
+    expect(content).not.toBeNull();
+    expect(content).toHaveAttribute('tabindex', '-1');
+    expect(content).toContainElement(screen.getByRole('heading', { name: 'home' }));
+  });
+
+  it('does not nest a second main landmark', () => {
+    // The wrapper is a <div>. Two `main` landmarks is worse for a screen
+    // reader than one unlabelled container.
+    renderApp();
+
+    expect(screen.getAllByRole('main')).toHaveLength(1);
+  });
+
+  it('puts the skip link before the navbar in the tab order', async () => {
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.tab();
+
+    expect(document.activeElement).toBe(
+      screen.getByRole('link', { name: 'Skip to content' })
+    );
+  });
+
+  it('skips the whole navbar in one keystroke', async () => {
+    // The alternative was twelve to fourteen tab stops, on every page.
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.tab();
+    await user.keyboard('{Enter}');
+
+    expect(document.activeElement).toBe(document.getElementById('main-content'));
+  });
+
+  it('resets scroll and moves focus on a navigation', async () => {
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(screen.getByRole('link', { name: 'wishlist' }));
+
+    expect(await screen.findByRole('heading', { name: 'wishlist' })).toBeInTheDocument();
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 0 }));
+    expect(document.activeElement).toBe(document.getElementById('main-content'));
+  });
+
+  it('does not steal focus on the initial load', () => {
+    // Nobody navigated, so nothing needs announcing.
+    renderApp();
+
+    expect(document.activeElement).toBe(document.body);
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/bookshelf-frontend/src/components/BackToTopButton.css
+++ b/bookshelf-frontend/src/components/BackToTopButton.css
@@ -1,4 +1,4 @@
-.scroll-to-top {
+.back-to-top {
   position: fixed;
   right: 24px;
   bottom: 24px;
@@ -26,19 +26,19 @@
   z-index: 900;
 }
 
-.scroll-to-top--visible {
+.back-to-top--visible {
   opacity: 1;
   visibility: visible;
   transform: translateY(0);
 }
 
-.scroll-to-top:hover,
-.scroll-to-top:focus-visible {
+.back-to-top:hover,
+.back-to-top:focus-visible {
   background: var(--leather-deep);
 }
 
 @media (max-width: 640px) {
-  .scroll-to-top {
+  .back-to-top {
     right: 16px;
     bottom: 16px;
     width: 40px;

--- a/bookshelf-frontend/src/components/BackToTopButton.jsx
+++ b/bookshelf-frontend/src/components/BackToTopButton.jsx
@@ -1,9 +1,20 @@
 import { useEffect, useState } from 'react';
-import './ScrollToTop.css';
+import './BackToTopButton.css';
 
+/**
+ * The floating "back to top" button.
+ *
+ * Renamed from `ScrollToTop`. That name said this component reset the scroll
+ * position on navigation, and App.jsx rendered it at the top of the layout
+ * exactly as though it did — but it never read the location and had no
+ * route-change effect at all. Nothing in the app reset scroll, so opening a
+ * book from the bottom of the catalogue landed on the book page already
+ * scrolled past its own title. See #339, where `RouteChangeHandler` now does
+ * the thing this was named after.
+ */
 const SCROLL_THRESHOLD = 400;
 
-export default function ScrollToTop() {
+export default function BackToTopButton() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -32,7 +43,7 @@ export default function ScrollToTop() {
   return (
     <button
       type="button"
-      className={`scroll-to-top ${visible ? 'scroll-to-top--visible' : ''}`}
+      className={`back-to-top ${visible ? 'back-to-top--visible' : ''}`}
       onClick={handleClick}
       aria-label="Scroll back to top"
       aria-hidden={!visible}

--- a/bookshelf-frontend/src/components/RouteChangeHandler.jsx
+++ b/bookshelf-frontend/src/components/RouteChangeHandler.jsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Reset the scroll position and move focus when the route changes.
+ *
+ * Neither happened. `App.jsx` rendered a component called `ScrollToTop` at
+ * the top of the layout, which reads as though this were handled — but that
+ * component is a floating "back to top" button. It subscribes to the `scroll`
+ * event, shows itself past 400px and scrolls up when clicked; it never reads
+ * the location and has no route-change effect at all. `AppRoutes.jsx` does
+ * not use React Router's `<ScrollRestoration>` either, and the only
+ * `window.scrollTo` in the app is in Home's pagination handler.
+ *
+ * A pushState navigation does not reset the scroll offset on its own, so
+ * every page inherited the last one's. Open a book from the bottom of the
+ * catalogue and the book page arrives already scrolled past its own title,
+ * cover and price. See #339.
+ *
+ * Focus was left behind the same way. It stays on whatever was clicked, or
+ * falls back to `<body>` when that element unmounts — so the next Tab starts
+ * from the very top of the document, walking the whole navbar again. Moving
+ * it to the new page's content is what lets a keyboard or screen reader user
+ * continue from where the content starts.
+ *
+ * @param {{ contentRef: React.RefObject<HTMLElement> }} props
+ *   The element to focus. The layout owns it, because pages do not: `Home`,
+ *   `BookDetail`, `Checkout`, `OrderConfirmation`, `WishlistPage` and
+ *   `NotFound` each render their own `<main>`, while `OrderHistory`,
+ *   `Profile`, `OrderDetailsPage`, `Login` and `Register` render none. There
+ *   was no single element to send focus or a skip link to.
+ */
+export default function RouteChangeHandler({ contentRef }) {
+  const location = useLocation();
+
+  /*
+   * The first render is a page load, not a navigation.
+   *
+   * The browser is already at the top, and it may deliberately not be — a
+   * reload mid-page restores the offset, and a deep link with a hash is
+   * scrolled by the navbar's own effect. Stealing focus on arrival would also
+   * be wrong: nobody navigated, so nothing needs announcing.
+   */
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
+    /*
+     * A hash is a destination. `/#catalog` from a book page means "go home
+     * and scroll to the catalogue", and Navbar's effect does exactly that —
+     * scrolling to the top here would fight it, and whichever ran last would
+     * win, which is not a behaviour anyone can rely on.
+     */
+    if (location.hash) {
+      return;
+    }
+
+    scrollToTop();
+    focusContent(contentRef.current);
+  }, [location.pathname, location.search, location.hash, contentRef]);
+
+  return null;
+}
+
+/**
+ * Instantly, or smoothly, depending on what the reader has asked for.
+ *
+ * `behavior: 'smooth'` on a route change is an animation nobody requested and
+ * it is exactly what `prefers-reduced-motion` is for. The same check is made
+ * in Navbar's hash-scroll effect and in the back-to-top button.
+ */
+function scrollToTop() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const prefersReducedMotion = window.matchMedia?.(
+    '(prefers-reduced-motion: reduce)'
+  )?.matches;
+
+  try {
+    window.scrollTo({ top: 0, left: 0, behavior: prefersReducedMotion ? 'auto' : 'smooth' });
+  } catch {
+    /*
+     * `scrollTo` with an options object is not universally implemented, and
+     * jsdom does not implement scrolling at all. Falling back rather than
+     * throwing matters because this runs from an effect, where an exception
+     * takes the tree down — the lesson of the unguarded `scrollIntoView` in
+     * Navbar, which was failing half the test runs on main.
+     */
+    try {
+      window.scrollTo(0, 0);
+    } catch {
+      // Nothing to scroll. Not a reason to break the navigation.
+    }
+  }
+}
+
+/**
+ * Move focus to the new page's content.
+ *
+ * The element carries `tabIndex={-1}` so it can be focused programmatically
+ * without becoming a tab stop of its own.
+ *
+ * `preventScroll` because the scroll reset above has already put the page
+ * where it belongs, and focusing an element scrolls it into view by default —
+ * which, for a container that starts below a fixed navbar, would undo the
+ * reset by a hundred pixels.
+ */
+function focusContent(element) {
+  if (!element || typeof element.focus !== 'function') {
+    return;
+  }
+
+  try {
+    element.focus({ preventScroll: true });
+  } catch {
+    // Older browsers ignore the options object and throw on nothing; the
+    // focus is a nicety, the navigation is not.
+  }
+}

--- a/bookshelf-frontend/src/components/RouteChangeHandler.test.jsx
+++ b/bookshelf-frontend/src/components/RouteChangeHandler.test.jsx
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, Link } from 'react-router-dom';
+import { useRef } from 'react';
+
+import RouteChangeHandler from './RouteChangeHandler.jsx';
+
+/**
+ * Scroll and focus on navigation.
+ *
+ * The regression (#339): neither happened. App.jsx rendered a component
+ * called `ScrollToTop`, which reads as though scroll restoration were
+ * handled — it is a floating back-to-top button that never looks at the
+ * location. A pushState navigation does not reset the scroll offset on its
+ * own, so every page inherited the last one's: open a book from the bottom of
+ * the catalogue and the book page arrives already scrolled past its own
+ * title. Focus was left behind the same way, so the next Tab restarted from
+ * the top of the navbar.
+ */
+
+let scrollTo;
+
+function Harness({ initialEntry = '/' } = {}) {
+  const contentRef = useRef(null);
+
+  return (
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <RouteChangeHandler contentRef={contentRef} />
+      <nav>
+        <Link to="/book/b1">book</Link>
+        <Link to="/wishlist">wishlist</Link>
+        <Link to="/#catalog">catalog</Link>
+        <Link to="/?page=2">page two</Link>
+      </nav>
+      <div id="main-content" ref={contentRef} tabIndex={-1}>
+        <Routes>
+          <Route path="/" element={<h1>home</h1>} />
+          <Route path="/book/:id" element={<h1>book</h1>} />
+          <Route path="/wishlist" element={<h1>wishlist</h1>} />
+        </Routes>
+      </div>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  scrollTo = vi.fn();
+  window.scrollTo = scrollTo;
+
+  // jsdom has no matchMedia; the default is "no reduced-motion preference".
+  window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('RouteChangeHandler', () => {
+  it('does nothing on the first render', () => {
+    // A page load is not a navigation. The browser is already where it should
+    // be — and may deliberately not be at the top, because a reload mid-page
+    // restores the offset. Stealing focus on arrival would be wrong too:
+    // nobody navigated, so nothing needs announcing.
+    render(<Harness />);
+
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it('scrolls to the top on a navigation', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole('link', { name: 'book' }));
+
+    expect(scrollTo).toHaveBeenCalledWith(
+      expect.objectContaining({ top: 0, left: 0 })
+    );
+  });
+
+  it('moves focus to the content', async () => {
+    // So the next Tab continues from where the content starts, instead of
+    // restarting at the top of the navbar.
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole('link', { name: 'wishlist' }));
+
+    expect(document.activeElement).toBe(document.getElementById('main-content'));
+  });
+
+  it('focuses without scrolling, so it does not undo the reset', async () => {
+    // Focusing an element scrolls it into view by default, and this container
+    // starts below a fixed navbar — which would put the page back a hundred
+    // pixels from where the scroll reset just put it.
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const content = document.getElementById('main-content');
+    const focus = vi.spyOn(content, 'focus');
+
+    await user.click(screen.getByRole('link', { name: 'book' }));
+
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it('leaves a hash navigation alone', async () => {
+    // `/#catalog` from a book page means "go home and scroll to the
+    // catalogue", and Navbar's own effect does that. Scrolling to the top
+    // here would fight it, and whichever ran last would win.
+    const user = userEvent.setup();
+    render(<Harness initialEntry="/book/b1" />);
+
+    await user.click(screen.getByRole('link', { name: 'catalog' }));
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('reacts to a query-string change, not just a path change', async () => {
+    // Paging the catalogue changes only `?page=`, and page 2 should start at
+    // the top of page 2.
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole('link', { name: 'page two' }));
+
+    expect(scrollTo).toHaveBeenCalled();
+  });
+
+  it('scrolls instantly when the reader prefers reduced motion', async () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole('link', { name: 'book' }));
+
+    expect(scrollTo).toHaveBeenCalledWith(
+      expect.objectContaining({ behavior: 'auto' })
+    );
+  });
+
+  it('scrolls smoothly when they do not', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole('link', { name: 'book' }));
+
+    expect(scrollTo).toHaveBeenCalledWith(
+      expect.objectContaining({ behavior: 'smooth' })
+    );
+  });
+
+  it('falls back to the two-argument form when options are not supported', async () => {
+    // `scrollTo({...})` is not universally implemented, and this runs from an
+    // effect — where an exception takes the tree down. That is the lesson of
+    // the unguarded scrollIntoView in Navbar, which was failing half the test
+    // runs on main.
+    window.scrollTo = vi.fn((arg) => {
+      if (typeof arg === 'object') {
+        throw new TypeError('not supported');
+      }
+    });
+
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole('link', { name: 'book' }));
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('survives a browser that cannot scroll at all', async () => {
+    window.scrollTo = vi.fn(() => {
+      throw new Error('nope');
+    });
+
+    const user = userEvent.setup();
+
+    expect(() => render(<Harness />)).not.toThrow();
+    await expect(
+      user.click(screen.getByRole('link', { name: 'book' }))
+    ).resolves.not.toThrow();
+  });
+
+  it('survives a content element that is not there', async () => {
+    // The ref is null until the layout has mounted its wrapper, and a
+    // navigation must not depend on that having happened.
+    function NoContent() {
+      const contentRef = useRef(null);
+
+      return (
+        <MemoryRouter>
+          <RouteChangeHandler contentRef={contentRef} />
+          <Link to="/elsewhere">go</Link>
+        </MemoryRouter>
+      );
+    }
+
+    const user = userEvent.setup();
+    render(<NoContent />);
+
+    await user.click(screen.getByRole('link', { name: 'go' }));
+
+    expect(scrollTo).toHaveBeenCalled();
+  });
+
+  it('renders nothing of its own', () => {
+    const { container } = render(<Harness />);
+
+    // It is behaviour, not markup — the layout's DOM is exactly what the
+    // layout put there.
+    expect(container.querySelector('#main-content')).not.toBeNull();
+    expect(container.textContent).not.toContain('undefined');
+  });
+});

--- a/bookshelf-frontend/src/components/SkipLink.css
+++ b/bookshelf-frontend/src/components/SkipLink.css
@@ -1,0 +1,61 @@
+/*
+ * Visually hidden until focused.
+ *
+ * The clip rectangle, rather than `display: none` or `visibility: hidden`:
+ * both of those take the element out of the tab order, which would make a
+ * skip link unreachable by exactly the people it exists for.
+ *
+ * Not `left: -9999px` either — that keeps it focusable, but some browsers
+ * scroll the viewport sideways to reveal the focused element before the
+ * :focus rule can bring it back on screen.
+ */
+.skip-link {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  position: fixed;
+  /* Above the fixed navbar, which is what it is skipping past. */
+  z-index: 1000;
+  top: 0.75rem;
+  left: 0.75rem;
+  width: auto;
+  height: auto;
+  margin: 0;
+  padding: 0.75rem 1.25rem;
+  overflow: visible;
+  clip: auto;
+  clip-path: none;
+
+  background: var(--ink, #221e19);
+  color: var(--paper, #fdfaf5);
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: 8px;
+  /* Its own ring, because the background above is dark and the browser
+     default outline can disappear into it. */
+  outline: 3px solid var(--leather, #8b5a2b);
+  outline-offset: 2px;
+  box-shadow: 0 6px 20px rgb(0 0 0 / 25%);
+}
+
+/*
+ * The layout's content wrapper is focused on every route change, which
+ * otherwise draws a focus ring around the entire page. It is not an
+ * interactive element and the ring says nothing useful about it; the reason
+ * focus moved there is announced by the heading, not drawn around the
+ * container.
+ */
+#main-content:focus {
+  outline: none;
+}

--- a/bookshelf-frontend/src/components/SkipLink.jsx
+++ b/bookshelf-frontend/src/components/SkipLink.jsx
@@ -1,0 +1,59 @@
+import './SkipLink.css';
+
+/**
+ * "Skip to content", the first tab stop on every page.
+ *
+ * There was none — `grep -rn "skip-link\|Skip to" src` returned nothing. A
+ * keyboard user arriving at any page had to tab through the entire navbar
+ * before reaching anything they came for: the brand, two section links, three
+ * public links, up to two account links, login or logout, the search input,
+ * the theme toggle, the cart button and the hamburger. Twelve to fourteen
+ * stops, on every page, every time. See #339.
+ *
+ * An `<a href="#…">` rather than a button, because it has to work as a link:
+ * it is announced as one, and activating it moves the browser's own sequential
+ * focus point, which a `focus()` call alone does not.
+ *
+ * The click handler is what makes it work in a single-page app anyway. A bare
+ * hash link would put `#main-content` in the URL, which React Router treats as
+ * a navigation — and the app's own hash-scroll effect would then try to
+ * interpret it. Focusing the target directly and preventing the default does
+ * the useful half without touching the address bar.
+ *
+ * It is visually hidden until focused. Hidden with a clip rectangle rather
+ * than `display: none` or `visibility: hidden`, because both of those remove
+ * an element from the tab order entirely — which would make a skip link that
+ * cannot be reached by the only people who need it.
+ */
+export default function SkipLink({ targetId = 'main-content', children = 'Skip to content' }) {
+  const handleClick = (event) => {
+    const target = document.getElementById(targetId);
+
+    if (!target) {
+      // Let the browser try the hash. Better than swallowing the click.
+      return;
+    }
+
+    event.preventDefault();
+
+    try {
+      target.focus();
+    } catch {
+      return;
+    }
+
+    // Focusing scrolls the target into view in most browsers, but not all,
+    // and not when it is already partly visible under a fixed header.
+    try {
+      target.scrollIntoView?.({ block: 'start' });
+    } catch {
+      // A nicety on top of a nicety.
+    }
+  };
+
+  return (
+    <a className="skip-link" href={`#${targetId}`} onClick={handleClick}>
+      {children}
+    </a>
+  );
+}

--- a/bookshelf-frontend/src/components/SkipLink.test.jsx
+++ b/bookshelf-frontend/src/components/SkipLink.test.jsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import SkipLink from './SkipLink.jsx';
+
+/**
+ * "Skip to content".
+ *
+ * The regression (#339): there was none. `grep -rn "skip-link\\|Skip to" src`
+ * returned nothing, so a keyboard user arriving at any page had to tab
+ * through the whole navbar — brand, two section links, three public links, up
+ * to two account links, login or logout, the search input, the theme toggle,
+ * the cart button and the hamburger — before reaching what they came for.
+ * Twelve to fourteen stops, on every page, every time.
+ */
+
+function renderWithTarget(props = {}) {
+  return render(
+    <>
+      <SkipLink {...props} />
+      <a href="/somewhere">a navbar link</a>
+      <div id="main-content" tabIndex={-1}>
+        <h1>the content</h1>
+      </div>
+    </>
+  );
+}
+
+describe('SkipLink', () => {
+  it('is a link, so it is announced as one', () => {
+    // Not a button: a link is what moves the browser's own sequential focus
+    // point, which a focus() call alone does not.
+    renderWithTarget();
+
+    const link = screen.getByRole('link', { name: 'Skip to content' });
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', '#main-content');
+  });
+
+  it('is the first thing Tab reaches', async () => {
+    const user = userEvent.setup();
+    renderWithTarget();
+
+    await user.tab();
+
+    expect(document.activeElement).toBe(
+      screen.getByRole('link', { name: 'Skip to content' })
+    );
+  });
+
+  it('moves focus to the content when activated', async () => {
+    const user = userEvent.setup();
+    renderWithTarget();
+
+    await user.click(screen.getByRole('link', { name: 'Skip to content' }));
+
+    expect(document.activeElement).toBe(document.getElementById('main-content'));
+  });
+
+  it('works from the keyboard, which is the only way anyone uses it', async () => {
+    const user = userEvent.setup();
+    renderWithTarget();
+
+    await user.tab();
+    await user.keyboard('{Enter}');
+
+    expect(document.activeElement).toBe(document.getElementById('main-content'));
+  });
+
+  it('does not put a hash in the URL', async () => {
+    // A bare hash link would leave `#main-content` in the address bar, which
+    // React Router treats as a navigation — and the app's own hash-scroll
+    // effect would then try to interpret it.
+    const user = userEvent.setup();
+    renderWithTarget();
+
+    const link = screen.getByRole('link', { name: 'Skip to content' });
+    const click = vi.fn();
+    link.addEventListener('click', click);
+
+    await user.click(link);
+
+    expect(click.mock.calls[0][0].defaultPrevented).toBe(true);
+  });
+
+  it('scrolls the content into view as well as focusing it', async () => {
+    const user = userEvent.setup();
+    renderWithTarget();
+
+    const target = document.getElementById('main-content');
+    target.scrollIntoView = vi.fn();
+
+    await user.click(screen.getByRole('link', { name: 'Skip to content' }));
+
+    expect(target.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('falls back to the browser when the target is not there', async () => {
+    const user = userEvent.setup();
+
+    render(<SkipLink targetId="nothing-here" />);
+
+    const link = screen.getByRole('link');
+    const click = vi.fn();
+    link.addEventListener('click', click);
+
+    await user.click(link);
+
+    // Not prevented: let the browser try the hash rather than swallow the
+    // click and do nothing at all.
+    expect(click.mock.calls[0][0].defaultPrevented).toBe(false);
+  });
+
+  it('does not throw when scrollIntoView is missing', async () => {
+    // jsdom does not implement it, and neither do all browsers. An exception
+    // from a click handler on the first tab stop of the page would be a bad
+    // place to discover that.
+    const user = userEvent.setup();
+    renderWithTarget();
+
+    const target = document.getElementById('main-content');
+    delete target.scrollIntoView;
+
+    await user.click(screen.getByRole('link', { name: 'Skip to content' }));
+
+    expect(document.activeElement).toBe(target);
+  });
+
+  it('takes a different target and label', () => {
+    render(
+      <>
+        <SkipLink targetId="somewhere-else">Jump to the results</SkipLink>
+        <div id="somewhere-else" tabIndex={-1} />
+      </>
+    );
+
+    expect(screen.getByRole('link', { name: 'Jump to the results' })).toHaveAttribute(
+      'href',
+      '#somewhere-else'
+    );
+  });
+});


### PR DESCRIPTION
Closes #339.

Navigating between routes left the reader wherever the previous page had them.

`App.jsx` rendered a component called **`ScrollToTop`** at the top of the layout, which reads as though this were handled. It is not: it is a floating "back to top" button. It subscribes to the `scroll` event, shows itself past 400px, and scrolls up when clicked. It never reads the location and has no route-change effect at all. `AppRoutes.jsx` does not use React Router's `<ScrollRestoration>` either, and the only `window.scrollTo` in the app is in `Home`'s pagination handler.

A `pushState` navigation does not reset the scroll offset on its own, so every page inherited the last one's. **Open a book from the bottom of the catalogue and the book page arrives already scrolled past its own title, cover and price.**

Focus was left behind the same way — on whatever was clicked, or on `<body>` when that element unmounted, so the next Tab restarted from the very top of the navbar. And there was no skip link: `grep -rn "skip-link\|Skip to" src` returned nothing, so a keyboard user walked the whole navbar on every page — brand, two section links, three public links, up to two account links, login/logout, the search input, the theme toggle, the cart button, the hamburger. Twelve to fourteen stops, every time.

## `RouteChangeHandler`

Scrolls to the top and moves focus into the page content on navigation. Four decisions in it are worth stating:

**It skips the first render.** A page load is not a navigation. The browser is already where it belongs — and may deliberately not be at the top, because a reload mid-page restores the offset. Stealing focus on arrival would be wrong too: nobody navigated, so nothing needs announcing.

**It skips a hash navigation.** A hash is a destination. `/#catalog` from a book page means "go home and scroll to the catalogue", and `Navbar`'s effect does exactly that. Scrolling to the top here would fight it, and whichever ran last would win — not a behaviour anyone can rely on.

**It honours `prefers-reduced-motion`,** the same way `Navbar`'s hash-scroll and the back-to-top button already do. A smooth scroll on every route change is an animation nobody asked for.

**It focuses with `preventScroll: true`.** Focusing an element scrolls it into view by default, and the wrapper starts below a fixed navbar — so without this, the focus call would undo the scroll reset by a hundred pixels.

Both scroll calls are guarded and fall back rather than throwing. This runs from an effect, where an exception takes the tree down — which is precisely what the unguarded `scrollIntoView` in `Navbar` was doing to roughly half the test runs on `main` before #327.

It also watches `location.search`, not only `pathname`: paging the catalogue changes only `?page=`, and page 2 should start at the top of page 2.

## `SkipLink`

An `<a>`, not a button — a link is what moves the browser's own *sequential focus point*, which a `focus()` call alone does not, and it is announced as a link.

It prevents the default and focuses the target directly rather than letting the hash through. A bare hash link would leave `#main-content` in the URL, which React Router treats as a navigation, and the app's own hash-scroll effect would then try to interpret it.

It is hidden with a clip rectangle, not `display: none` or `visibility: hidden` — both of those remove an element from the tab order entirely, which would make a skip link unreachable by the only people who need it. Not `left: -9999px` either: that stays focusable, but some browsers scroll the viewport sideways to reveal the focused element before the `:focus` rule can bring it back.

## Where the content wrapper lives

The layout owns it, because the pages do not. `Home`, `BookDetail`, `Checkout`, `OrderConfirmation`, `WishlistPage` and `NotFound` each render their own `<main>`; `OrderHistory`, `Profile`, `OrderDetailsPage`, `Login` and `Register` render none at all. There was no single element to send focus or a skip link to, and adding one to eleven pages would put the same rule in eleven places.

Two details: it is a `<div>` rather than a `<main>`, so the six pages that already have one are not nesting a second landmark inside it — two `main` landmarks is worse for a screen reader than an unlabelled wrapper. And its id is `main-content` rather than `catalog`, which `Home` already uses for the navbar's `/#catalog` anchor.

`#main-content:focus` has its outline suppressed. It is not an interactive element, and a focus ring around the entire page says nothing useful; what announces the move is the heading inside it.

## The rename

`ScrollToTop` → `BackToTopButton`, with its CSS and class names. The old name claimed the behaviour this PR actually adds, and having both under the old name would be worse than either.

## Testing

- **`RouteChangeHandler.test.jsx`** — 12 tests: no-op on first render, scroll and focus on navigation, `preventScroll`, the hash exemption, query-string-only changes, both reduced-motion branches, the `scrollTo(0, 0)` fallback, a browser that cannot scroll at all, and a null content ref.
- **`SkipLink.test.jsx`** — 9 tests: it is a link, it is the first tab stop, Enter activates it, the default is prevented so no hash reaches the URL, it falls back to the browser when the target is missing, and it survives jsdom's missing `scrollIntoView`.
- **`App.test.jsx`** — 6 new integration tests on the real layout: exactly one focusable `#main-content`, exactly one `main` landmark, the skip link ahead of the navbar in the tab order, skipping the navbar in one keystroke, scroll and focus on a real route change, and no focus stolen on the initial load.

Frontend **472 passing** (was 445). ESLint reports the same 43 errors / 51 warnings as `main`; every file touched here is clean. Backend untouched.

Not in scope: this is separate from #219, which is about the mobile menu's own state surviving a navigation. This one is scroll offset and focus position, and it affects desktop and mobile equally.
