### PR TITLE
fix(catalog): stop the home page throwing on its first render

### DIFF
--- a/bookshelf-frontend/src/components/Footer.jsx
+++ b/bookshelf-frontend/src/components/Footer.jsx
@@ -91,4 +91,3 @@ export default function Footer() {
     </footer>
   );
 }
-}

--- a/bookshelf-frontend/src/pages/Home.jsx
+++ b/bookshelf-frontend/src/pages/Home.jsx
@@ -101,40 +101,28 @@ export default function Home({ searchQuery: searchQueryProp }) {
   // the shared results even before the box has been hydrated.
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
-  // Sync state to URL search parameters whenever filters change
-  useEffect(() => {
-    if (!setSearchParams) return;
-
-    const currentQuery = buildCatalogQuery({
-      search: searchQuery,
-      genres: selectedGenres,
-      minPrice,
-      maxPrice,
-      minRating,
-      sort: activeSort,
-      page: currentPage,
-      limit: PAGE_SIZE,
-    });
-
-    const currentQueryStr = currentQuery.toString();
-    if (currentQueryStr !== searchParams.toString()) {
-      setSearchParams(currentQuery, { replace: true });
-    }
-  }, [searchQuery, selectedGenres, minPrice, maxPrice, minRating, activeSort, currentPage, setSearchParams, searchParams]);
-
-  // Handle external searchParams updates (e.g., browser Back/Forward navigation)
-  useEffect(() => {
-    const parsed = parseCatalogParams(searchParams);
-    setSelectedGenres((prev) => (JSON.stringify(prev) !== JSON.stringify(parsed.genres) ? parsed.genres : prev));
-    setMinPrice((prev) => (prev !== parsed.minPrice ? parsed.minPrice : prev));
-    setMaxPrice((prev) => (prev !== parsed.maxPrice ? parsed.maxPrice : prev));
-    setMinRating((prev) => (prev !== parsed.minRating ? parsed.minRating : prev));
-    setActiveSort((prev) => (prev !== parsed.sort ? parsed.sort : prev));
-    setCurrentPage((prev) => (prev !== parsed.page ? parsed.page : prev));
-    if (outletContext?.setSearchQuery && parsed.search !== outletContext.searchQuery && searchQueryProp === undefined) {
-      outletContext.setSearchQuery(parsed.search);
-    }
-  }, [searchParams]);
+  /*
+   * There is deliberately no effect here mirroring the filters into the URL,
+   * and none reading them back out on a history change.
+   *
+   * Two of them used to sit at this point in the file, left over from a
+   * merge, and they referenced thirteen identifiers that this component does not
+   * have: `searchParams`, `setSearchParams`, `buildCatalogQuery`,
+   * `parseCatalogParams`, `selectedGenres`, `setSelectedGenres`, `minPrice`,
+   * `maxPrice`, `minRating`, `activeSort`, `setActiveSort`, `currentPage` and
+   * `setCurrentPage`. The `useState` calls behind those names went away when
+   * the filters moved into the URL; the effects reading them did not. The
+   * first line of the first one was `if (!setSearchParams) return;`, which
+   * throws a ReferenceError rather than returning, so the page died on its
+   * first render and the ErrorBoundary replaced the whole site. See #365.
+   *
+   * Both jobs are `useCatalogFilters`'s, twelve lines above: it reads the
+   * filters out of `useSearchParams` on every render and writes them back
+   * through the same hook, so a history change re-renders with the new values
+   * and there is nothing to synchronise. A mirrored copy in component state
+   * is exactly what that hook was written to remove — restoring one would
+   * bring back the two-sources-of-truth bug from #338 along with the crash.
+   */
 
   // The active-filter chips said "Min ₹250" whatever the shop was priced in.
   // See #335.

--- a/bookshelf-frontend/src/pages/Home.test.jsx
+++ b/bookshelf-frontend/src/pages/Home.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Outlet, Route, Routes, useLocation } from 'react-router-dom';
+import { MemoryRouter, Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -93,6 +93,25 @@ function LocationProbe() {
   return <span data-testid="location">{`${location.pathname}${location.search}`}</span>;
 }
 
+/**
+ * A Back button that goes through the router rather than through
+ * window.history, because MemoryRouter keeps its own stack.
+ *
+ * Back is the interesting direction for #338 and #365 together: it is the
+ * one case a mirrored copy of the filters in component state cannot get
+ * right, because the URL changes underneath a component that never
+ * re-mounts.
+ */
+function HistoryProbe() {
+  const navigate = useNavigate();
+
+  return (
+    <button type="button" onClick={() => navigate(-1)}>
+      probe: back
+    </button>
+  );
+}
+
 function renderHome({ at = '/', searchQuery = '' } = {}) {
   return render(
     <MemoryRouter initialEntries={[at]}>
@@ -100,6 +119,7 @@ function renderHome({ at = '/', searchQuery = '' } = {}) {
         <CartProvider>
           <Home searchQuery={searchQuery} />
           <LocationProbe />
+          <HistoryProbe />
         </CartProvider>
       </WishlistContext.Provider>
     </MemoryRouter>
@@ -358,5 +378,115 @@ describe('Home catalogue', () => {
       expect(requested.get('minRating')).toBeNull();
       expect(requested.get('sort')).toBeNull();
     });
+  });
+});
+
+/*
+ * The page did not render at all on main.
+ *
+ * Two leftover effects sat between the search wiring and the memoised
+ * filters, reading thirteen identifiers that no longer existed in the file.
+ * The first statement of the first one was `if (!setSearchParams) return;` —
+ * a ReferenceError, not a guard — so Home threw on its first render, the
+ * ErrorBoundary around the layout caught it, and the whole site was replaced
+ * by the fallback screen. See #365.
+ *
+ * A test that only asserted "the grid renders" would have caught the crash,
+ * and the nineteen above did. These are about the shape the fix has to keep:
+ * the filters live in the URL and nowhere else, so nothing may reintroduce a
+ * mirrored copy in component state, or an effect that writes the URL back to
+ * itself.
+ */
+describe('Home keeps the URL as its only source of truth', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    globalThis.fetch = vi.fn((requested) => Promise.resolve(fakeApi(requested)));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('mounts without throwing', async () => {
+    const onError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderHome();
+
+    await waitFor(() => expect(titles()).toHaveLength(4));
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('leaves a bare / alone instead of rewriting it on mount', async () => {
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    // The removed effect built the whole query string and wrote it on the
+    // first render, so simply arriving at the site turned the address bar
+    // into /?page=1&limit=4 before the reader had asked for anything.
+    expect(url()).toBe('/');
+  });
+
+  it('keeps a deep-linked URL byte for byte', async () => {
+    renderHome({ at: '/?genre=Poetry&maxPrice=250&page=1' });
+
+    await waitFor(() => expect(titles()).toEqual(['Low Tide']));
+    expect(url()).toBe('/?genre=Poetry&maxPrice=250&page=1');
+  });
+
+  it('undoes a filter with Back', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    await user.click(screen.getByLabelText('Poetry'));
+    await waitFor(() => expect(titles()).toEqual(['Low Tide']));
+
+    await user.click(screen.getByRole('button', { name: 'probe: back' }));
+
+    await waitFor(() => expect(url()).toBe('/'));
+    await waitFor(() => expect(titles()).toHaveLength(4));
+  });
+
+  it('follows Back through a sort as well as a filter', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    await user.selectOptions(
+      screen.getByLabelText('home.sortAriaLabel'),
+      'price_asc'
+    );
+    await waitFor(() => expect(url()).toContain('sort=price_asc'));
+
+    await user.click(screen.getByRole('button', { name: 'probe: back' }));
+
+    await waitFor(() => expect(url()).toBe('/'));
+
+    // The grid follows the URL rather than a stale copy of the sort.
+    await waitFor(() => {
+      const requested = new URL(
+        globalThis.fetch.mock.calls.at(-1)[0],
+        'http://x'
+      ).searchParams;
+      expect(requested.get('sort')).toBeNull();
+    });
+  });
+
+  it('does not re-request the catalogue when nothing changed', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    const before = globalThis.fetch.mock.calls.length;
+
+    // Re-selecting the sort that is already active is a no-op. An effect
+    // mirroring state into the URL would write it back anyway and start a
+    // fetch for the page already on screen.
+    await user.selectOptions(screen.getByLabelText('home.sortAriaLabel'), '');
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(globalThis.fetch.mock.calls.length).toBe(before);
+    expect(url()).toBe('/');
   });
 });

--- a/bookshelf-frontend/src/pages/Profile.jsx
+++ b/bookshelf-frontend/src/pages/Profile.jsx
@@ -3,17 +3,169 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { useAuth } from '../hooks/useAuth.js';
-import './Auth.css';
+import { useWishlist } from '../hooks/useWishlist.js';
+import { useOrders } from '../hooks/useOrders.js';
 import { usePageMetadata } from '../hooks/usePageMetadata.js';
+import ReadingGoalRing from '../components/ReadingGoalRing.jsx';
+import ReadingStreak from '../components/ReadingStreak.jsx';
+import RecentlyViewed from '../components/RecentlyViewed.jsx';
+import FavoriteBooks from '../components/FavoriteBooks.jsx';
 
-const Profile = () => {
+/*
+ * Profile.css, not Auth.css.
+ *
+ * The stylesheet import was the quiet half of #366: a merge kept this page's
+ * 350 lines of reading-portal markup and took the top of the file from the
+ * version before the portal existed, when this was a plain account form
+ * styled by Auth.css. Every class the markup below uses — profile-page,
+ * profile-tabs, profile-stat-card and the rest — is defined here.
+ */
+import './Profile.css';
+
+const LOCAL_STORAGE_KEY = 'bookshelf_user_profile';
+const ALL_GENRES = ['Fiction', 'Non-Fiction', 'Mystery', 'Sci-Fi', 'Fantasy', 'Romance', 'Biography', 'History'];
+const AVATAR_OPTIONS = ['📖', '🦉', '🧙‍♂️', '📚', '✍️', '🌟', '🚀', '☕'];
+
+/**
+ * The reader's account page: overview, goals, favourites and settings.
+ *
+ * Everything below the banner reads state that this component owns. That is
+ * worth saying plainly, because the state layer was missing entirely on main
+ * — the JSX survived a merge and the twenty-odd declarations feeding it did
+ * not, so the page threw `ReferenceError: profileData is not defined` on its
+ * first render and every signed-in reader got the ErrorBoundary fallback
+ * instead of their account. See #366.
+ */
+export default function Profile() {
   usePageMetadata({
     title: 'Your profile',
-    description:
-      'Your BookShelf account details.',
+    description: 'Your BookShelf account details, reading goals and preferences.',
   });
 
-  const { user } = useAuth();
+  const { t } = useTranslation();
+  const { user, logout } = useAuth();
+  const { count: wishlistCount } = useWishlist();
+  const { orders = [] } = useOrders();
+  const navigate = useNavigate();
+
+  const [activeTab, setActiveTab] = useState('overview');
+
+  /*
+   * The customisation the reader has chosen, kept in localStorage.
+   *
+   * Read inside the initialiser rather than in an effect so the first paint
+   * already shows the saved avatar and bio instead of the defaults. The
+   * try/catch is not decoration: a hand-edited or half-written value would
+   * otherwise throw out of the initialiser, which React does not recover
+   * from.
+   */
+  const [profileData, setProfileData] = useState(() => {
+    try {
+      const saved = localStorage.getItem(LOCAL_STORAGE_KEY);
+      if (saved) return JSON.parse(saved);
+    } catch (err) {
+      console.error('Failed to parse profile data:', err);
+    }
+    return {
+      bio: 'A room without books is like a body without a soul.',
+      annualGoal: 24,
+      avatar: '📖',
+      preferredGenres: ['Fiction', 'Mystery', 'Sci-Fi'],
+    };
+  });
+
+  // Settings form, held separately from profileData so an unsaved edit can be
+  // abandoned by navigating away rather than being committed as it is typed.
+  const [formName, setFormName] = useState(user?.name || 'Reader');
+  const [formBio, setFormBio] = useState(profileData.bio);
+  const [formGoal, setFormGoal] = useState(profileData.annualGoal);
+  const [formAvatar, setFormAvatar] = useState(profileData.avatar);
+  const [formGenres, setFormGenres] = useState(profileData.preferredGenres);
+
+  // Security form.
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+
+  // Transient confirmations, cleared on a timer.
+  const [saveMessage, setSaveMessage] = useState(null);
+  const [securityMessage, setSecurityMessage] = useState(null);
+
+  /*
+   * The name box is seeded from `user`, which arrives asynchronously — the
+   * session is restored by a GET /api/auth/me after the first render, so the
+   * initialiser above usually runs while `user` is still null.
+   */
+  useEffect(() => {
+    if (user?.name) {
+      setFormName(user.name);
+    }
+  }, [user]);
+
+  const handleSaveProfile = (e) => {
+    e.preventDefault();
+
+    const updated = {
+      ...profileData,
+      bio: formBio,
+      annualGoal: Number(formGoal) || 20,
+      avatar: formAvatar,
+      preferredGenres: formGenres,
+    };
+
+    setProfileData(updated);
+
+    try {
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updated));
+    } catch (err) {
+      // A full or disabled store must not lose the edit from the screen.
+      console.error('Failed to save profile to localStorage:', err);
+    }
+
+    setSaveMessage(t('profile.updateSuccess', 'Profile updated successfully!'));
+    setTimeout(() => setSaveMessage(null), 4000);
+  };
+
+  const handleUpdatePassword = (e) => {
+    e.preventDefault();
+
+    if (!currentPassword || !newPassword) {
+      setSecurityMessage({ type: 'error', text: 'Please fill out both password fields.' });
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setSecurityMessage({ type: 'error', text: 'New password must be at least 8 characters long.' });
+      return;
+    }
+
+    setSecurityMessage({
+      type: 'success',
+      text: t('profile.security.passwordSuccess', 'Password updated successfully!'),
+    });
+    setCurrentPassword('');
+    setNewPassword('');
+    setTimeout(() => setSecurityMessage(null), 4000);
+  };
+
+  const toggleGenre = (genre) => {
+    if (formGenres.includes(genre)) {
+      setFormGenres(formGenres.filter((g) => g !== genre));
+    } else {
+      setFormGenres([...formGenres, genre]);
+    }
+  };
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/login');
+  };
+
+  // Placeholder reading stats. There is no endpoint behind these yet; they
+  // are constants so the overview tab has something to lay out.
+  const booksReadCount = 18;
+  const pagesReadCount = 5840;
+  const readingHoursCount = 96;
+
 
   return (
     <main className="profile-page">

--- a/bookshelf-frontend/src/pages/Profile.test.jsx
+++ b/bookshelf-frontend/src/pages/Profile.test.jsx
@@ -149,3 +149,159 @@ describe('Profile Page (Reading Portal)', () => {
     expect(navigate).toHaveBeenCalledWith('/login');
   });
 });
+
+/*
+ * The page did not render at all on main.
+ *
+ * A merge kept the 350 lines of reading-portal JSX and took the top of the
+ * file from the version before the portal existed, so every declaration the
+ * markup reads — profileData, formName, activeTab, handleLogout, t and
+ * seventeen others — was gone, along with six imports and the Profile.css
+ * that styles all of it. `ReferenceError: profileData is not defined` on the
+ * first render, ErrorBoundary fallback for every signed-in reader. See #366.
+ *
+ * The six tests above cover the happy paths and would have caught the crash
+ * on their own. These are the parts of the restored state layer they do not
+ * reach: persistence across a remount, the corrupt-store path, the late
+ * session, and the second password rule.
+ */
+describe('Profile state layer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('names the page for the browser tab', () => {
+    renderProfile();
+
+    // usePageMetadata was added on the broken side of the merge; it has to
+    // survive the restore rather than be reverted with the rest of the head.
+    expect(document.title).toBe('Your profile — BookShelf');
+  });
+
+  it('reads the saved profile back on a fresh mount', async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderProfile();
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+
+    const bio = screen.getByPlaceholderText(/share your reading motto/i);
+    await user.clear(bio);
+    await user.type(bio, 'Two chapters before bed.');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await screen.findByText(/profile updated successfully!/i);
+    unmount();
+
+    // The initialiser reads localStorage rather than an effect doing it after
+    // the first paint, so the saved bio is on screen from the first render.
+    renderProfile();
+    expect(screen.getByText('"Two chapters before bed."')).toBeInTheDocument();
+  });
+
+  it('falls back to the defaults when the stored profile is unreadable', () => {
+    localStorage.setItem('bookshelf_user_profile', '{ not json');
+    const onError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderProfile();
+
+    // A throw out of a useState initialiser is not recoverable, so the parse
+    // has to be guarded rather than left to the ErrorBoundary.
+    expect(screen.getByText('Jane Reader')).toBeInTheDocument();
+    expect(
+      screen.getByText('"A room without books is like a body without a soul."')
+    ).toBeInTheDocument();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('seeds the name box when the session arrives after the first render', async () => {
+    const user = userEvent.setup();
+    // GET /api/auth/me resolves after mount, so `user` is null on the render
+    // that initialises the form.
+    const { rerender } = renderProfile(null);
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+    expect(screen.getByLabelText(/full name/i)).toHaveValue('Reader');
+
+    rerender(
+      <MemoryRouter>
+        <AuthContext.Provider
+          value={{
+            user: { name: 'Jane Reader', email: 'jane@example.com', role: 'Member' },
+            isAuthenticated: true,
+            loading: false,
+            logout: vi.fn(),
+            login: vi.fn(),
+            register: vi.fn(),
+            checkAuth: vi.fn(),
+          }}
+        >
+          <WishlistContext.Provider
+            value={{
+              wishlist: ['b1', 'b2'],
+              loading: false,
+              count: 2,
+              isWishlisted: () => true,
+              toggleWishlist: vi.fn(),
+            }}
+          >
+            <Profile />
+          </WishlistContext.Provider>
+        </AuthContext.Provider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/full name/i)).toHaveValue('Jane Reader')
+    );
+  });
+
+  it('rejects a new password shorter than eight characters', async () => {
+    const user = userEvent.setup();
+    renderProfile();
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+
+    await user.type(screen.getByLabelText(/current password/i), 'oldsecret1');
+    await user.type(screen.getByLabelText(/new password/i), 'short');
+    await user.click(screen.getByRole('button', { name: /update password/i }));
+
+    expect(
+      await screen.findByText(/at least 8 characters long/i)
+    ).toBeInTheDocument();
+  });
+
+  it('persists the genres the reader picks', async () => {
+    const user = userEvent.setup();
+    renderProfile();
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+
+    // Fiction is on by default, so this removes it; Fantasy is not, so this
+    // adds it. Both directions go through the same toggle.
+    await user.click(screen.getByRole('button', { name: /^Fiction/ }));
+    await user.click(screen.getByRole('button', { name: /^Fantasy/ }));
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await screen.findByText(/profile updated successfully!/i);
+
+    const stored = JSON.parse(localStorage.getItem('bookshelf_user_profile'));
+    expect(stored.preferredGenres).not.toContain('Fiction');
+    expect(stored.preferredGenres).toContain('Fantasy');
+  });
+
+  it('shows the wishlist count from context rather than a copy of it', async () => {
+    const user = userEvent.setup();
+    renderProfile();
+
+    await user.click(
+      screen.getByRole('button', { name: /📖 My Activity/i })
+    );
+
+    // Straight from WishlistContext. The library tab is the only place the
+    // restored `useWishlist()` call is visible, so it is the only test that
+    // would notice if the import went missing again.
+    expect(screen.getByText('💖 Wishlist (2)')).toBeInTheDocument();
+    expect(screen.getByText(/You currently have 2 books saved/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #365.

## The bug

`/` did not render. `Home` threw before its first paint, the `ErrorBoundary` that wraps the layout route caught it, and the fallback screen replaced the entire site — navbar, footer and cart drawer included.

```
ReferenceError: selectedGenres is not defined
    at Home (src/pages/Home.jsx:110)
```

Two `useEffect` blocks sat between the search wiring and the memoised filters, left behind by a merge. Between them they read thirteen identifiers that do not exist in the file:

| identifier | why it is missing |
| --- | --- |
| `searchParams`, `setSearchParams` | `useSearchParams` is not imported or destructured here |
| `buildCatalogQuery`, `parseCatalogParams` | never imported |
| `selectedGenres`, `setSelectedGenres`, `minPrice`, `maxPrice`, `minRating`, `activeSort`, `setActiveSort`, `currentPage`, `setCurrentPage` | the `useState` declarations went away when the filters moved into the URL in #338 |

The first statement of the first effect was `if (!setSearchParams) return;`. That reads like a guard and is a `ReferenceError`, which is why the failure was total rather than partial.

## The fix

Both effects are deleted rather than repaired.

Everything they were trying to do — read the filters out of the URL on mount, write them back on change, follow Back and Forward — is already done by `useCatalogFilters()`, which the same component calls twelve lines above them. That hook holds the filters in `useSearchParams` and keeps no copy in state, which is what makes history navigation work with nothing to synchronise. Giving the effects their `useState` back would reintroduce the two-sources-of-truth bug #338 removed, on top of fixing the crash.

A comment stays at the same spot in the file saying what used to be there and why nothing belongs there, so the next merge does not put it back.

## Tests

The 19 existing `Home` tests go from 19 failed to 19 passed. Six more cover the shape the fix has to hold, not just the absence of the throw:

- the page mounts with no `console.error`
- a bare `/` is left alone rather than rewritten to `/?page=1&limit=4` on mount — the deleted effect wrote the full query string on first render
- a deep-linked `/?genre=Poetry&maxPrice=250&page=1` survives byte for byte
- Back undoes a filter, and Back undoes a sort, with the grid following the URL rather than a stale copy
- re-selecting the sort already in effect starts no fetch

`HistoryProbe` navigates through the router rather than `window.history`, because `MemoryRouter` keeps its own stack.

## Verification

```
$ cd bookshelf-frontend && npm test -- src/pages/Home.test.jsx
 Test Files  1 passed (1)
      Tests  25 passed (25)
```

## Note for a follow-up

`utils/catalogQuery.js` still exports `parseCatalogParams`, which now has no caller — it duplicates `readCatalogParams` in `utils/catalogUrl.js`. Its own unit tests still pass, so it is left alone here rather than widening this PR; worth collapsing the two into one in a separate change.

---

## Where this sits

`main` is broken in four independent places and does not build at all, so these five PRs are a **stack** and land in order. This is **step 2**, on top of #371.

| order | PR | what it owns |
| --- | --- | --- |
| 1 | #371 | `Profile.jsx`, plus the two commits that unblock the build for everything else — the stray `}` in `Footer.jsx` and the missing `export default` on Profile |
| 2 | #370 | `Home.jsx` |
| 3 | #372 | `OrderHistory.jsx`, `WishlistPage.jsx`, the locale bundles |
| 4 | #373 | `Pagination.jsx` |
| 5 | #374 | the lint script, `.eslintrc.cjs`, the CI workflow |

Each PR carries the ones before it, so they merge in order with no conflicts. I checked every pair with `git merge-tree --write-tree`; there are none, in either direction. Review the files listed against this PR — the rest of the diff is the PRs below it.

**Its CI:** the build is green. `npm test` still reports 22 failures — 13 in `OrderHistory.test.jsx`, 9 in `WishlistPage.test.jsx`. Neither is this PR's; both are the crash #372 fixes, and the suite goes fully green at step 3. All 25 `Home.test.jsx` tests pass.
