### PR TITLE
fix(profile): restore the state layer the page's markup reads

### DIFF
--- a/bookshelf-frontend/src/components/Footer.jsx
+++ b/bookshelf-frontend/src/components/Footer.jsx
@@ -91,4 +91,3 @@ export default function Footer() {
     </footer>
   );
 }
-}

--- a/bookshelf-frontend/src/pages/Profile.jsx
+++ b/bookshelf-frontend/src/pages/Profile.jsx
@@ -3,17 +3,169 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { useAuth } from '../hooks/useAuth.js';
-import './Auth.css';
+import { useWishlist } from '../hooks/useWishlist.js';
+import { useOrders } from '../hooks/useOrders.js';
 import { usePageMetadata } from '../hooks/usePageMetadata.js';
+import ReadingGoalRing from '../components/ReadingGoalRing.jsx';
+import ReadingStreak from '../components/ReadingStreak.jsx';
+import RecentlyViewed from '../components/RecentlyViewed.jsx';
+import FavoriteBooks from '../components/FavoriteBooks.jsx';
 
-const Profile = () => {
+/*
+ * Profile.css, not Auth.css.
+ *
+ * The stylesheet import was the quiet half of #366: a merge kept this page's
+ * 350 lines of reading-portal markup and took the top of the file from the
+ * version before the portal existed, when this was a plain account form
+ * styled by Auth.css. Every class the markup below uses — profile-page,
+ * profile-tabs, profile-stat-card and the rest — is defined here.
+ */
+import './Profile.css';
+
+const LOCAL_STORAGE_KEY = 'bookshelf_user_profile';
+const ALL_GENRES = ['Fiction', 'Non-Fiction', 'Mystery', 'Sci-Fi', 'Fantasy', 'Romance', 'Biography', 'History'];
+const AVATAR_OPTIONS = ['📖', '🦉', '🧙‍♂️', '📚', '✍️', '🌟', '🚀', '☕'];
+
+/**
+ * The reader's account page: overview, goals, favourites and settings.
+ *
+ * Everything below the banner reads state that this component owns. That is
+ * worth saying plainly, because the state layer was missing entirely on main
+ * — the JSX survived a merge and the twenty-odd declarations feeding it did
+ * not, so the page threw `ReferenceError: profileData is not defined` on its
+ * first render and every signed-in reader got the ErrorBoundary fallback
+ * instead of their account. See #366.
+ */
+export default function Profile() {
   usePageMetadata({
     title: 'Your profile',
-    description:
-      'Your BookShelf account details.',
+    description: 'Your BookShelf account details, reading goals and preferences.',
   });
 
-  const { user } = useAuth();
+  const { t } = useTranslation();
+  const { user, logout } = useAuth();
+  const { count: wishlistCount } = useWishlist();
+  const { orders = [] } = useOrders();
+  const navigate = useNavigate();
+
+  const [activeTab, setActiveTab] = useState('overview');
+
+  /*
+   * The customisation the reader has chosen, kept in localStorage.
+   *
+   * Read inside the initialiser rather than in an effect so the first paint
+   * already shows the saved avatar and bio instead of the defaults. The
+   * try/catch is not decoration: a hand-edited or half-written value would
+   * otherwise throw out of the initialiser, which React does not recover
+   * from.
+   */
+  const [profileData, setProfileData] = useState(() => {
+    try {
+      const saved = localStorage.getItem(LOCAL_STORAGE_KEY);
+      if (saved) return JSON.parse(saved);
+    } catch (err) {
+      console.error('Failed to parse profile data:', err);
+    }
+    return {
+      bio: 'A room without books is like a body without a soul.',
+      annualGoal: 24,
+      avatar: '📖',
+      preferredGenres: ['Fiction', 'Mystery', 'Sci-Fi'],
+    };
+  });
+
+  // Settings form, held separately from profileData so an unsaved edit can be
+  // abandoned by navigating away rather than being committed as it is typed.
+  const [formName, setFormName] = useState(user?.name || 'Reader');
+  const [formBio, setFormBio] = useState(profileData.bio);
+  const [formGoal, setFormGoal] = useState(profileData.annualGoal);
+  const [formAvatar, setFormAvatar] = useState(profileData.avatar);
+  const [formGenres, setFormGenres] = useState(profileData.preferredGenres);
+
+  // Security form.
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+
+  // Transient confirmations, cleared on a timer.
+  const [saveMessage, setSaveMessage] = useState(null);
+  const [securityMessage, setSecurityMessage] = useState(null);
+
+  /*
+   * The name box is seeded from `user`, which arrives asynchronously — the
+   * session is restored by a GET /api/auth/me after the first render, so the
+   * initialiser above usually runs while `user` is still null.
+   */
+  useEffect(() => {
+    if (user?.name) {
+      setFormName(user.name);
+    }
+  }, [user]);
+
+  const handleSaveProfile = (e) => {
+    e.preventDefault();
+
+    const updated = {
+      ...profileData,
+      bio: formBio,
+      annualGoal: Number(formGoal) || 20,
+      avatar: formAvatar,
+      preferredGenres: formGenres,
+    };
+
+    setProfileData(updated);
+
+    try {
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updated));
+    } catch (err) {
+      // A full or disabled store must not lose the edit from the screen.
+      console.error('Failed to save profile to localStorage:', err);
+    }
+
+    setSaveMessage(t('profile.updateSuccess', 'Profile updated successfully!'));
+    setTimeout(() => setSaveMessage(null), 4000);
+  };
+
+  const handleUpdatePassword = (e) => {
+    e.preventDefault();
+
+    if (!currentPassword || !newPassword) {
+      setSecurityMessage({ type: 'error', text: 'Please fill out both password fields.' });
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setSecurityMessage({ type: 'error', text: 'New password must be at least 8 characters long.' });
+      return;
+    }
+
+    setSecurityMessage({
+      type: 'success',
+      text: t('profile.security.passwordSuccess', 'Password updated successfully!'),
+    });
+    setCurrentPassword('');
+    setNewPassword('');
+    setTimeout(() => setSecurityMessage(null), 4000);
+  };
+
+  const toggleGenre = (genre) => {
+    if (formGenres.includes(genre)) {
+      setFormGenres(formGenres.filter((g) => g !== genre));
+    } else {
+      setFormGenres([...formGenres, genre]);
+    }
+  };
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/login');
+  };
+
+  // Placeholder reading stats. There is no endpoint behind these yet; they
+  // are constants so the overview tab has something to lay out.
+  const booksReadCount = 18;
+  const pagesReadCount = 5840;
+  const readingHoursCount = 96;
+
 
   return (
     <main className="profile-page">

--- a/bookshelf-frontend/src/pages/Profile.test.jsx
+++ b/bookshelf-frontend/src/pages/Profile.test.jsx
@@ -149,3 +149,159 @@ describe('Profile Page (Reading Portal)', () => {
     expect(navigate).toHaveBeenCalledWith('/login');
   });
 });
+
+/*
+ * The page did not render at all on main.
+ *
+ * A merge kept the 350 lines of reading-portal JSX and took the top of the
+ * file from the version before the portal existed, so every declaration the
+ * markup reads — profileData, formName, activeTab, handleLogout, t and
+ * seventeen others — was gone, along with six imports and the Profile.css
+ * that styles all of it. `ReferenceError: profileData is not defined` on the
+ * first render, ErrorBoundary fallback for every signed-in reader. See #366.
+ *
+ * The six tests above cover the happy paths and would have caught the crash
+ * on their own. These are the parts of the restored state layer they do not
+ * reach: persistence across a remount, the corrupt-store path, the late
+ * session, and the second password rule.
+ */
+describe('Profile state layer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('names the page for the browser tab', () => {
+    renderProfile();
+
+    // usePageMetadata was added on the broken side of the merge; it has to
+    // survive the restore rather than be reverted with the rest of the head.
+    expect(document.title).toBe('Your profile — BookShelf');
+  });
+
+  it('reads the saved profile back on a fresh mount', async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderProfile();
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+
+    const bio = screen.getByPlaceholderText(/share your reading motto/i);
+    await user.clear(bio);
+    await user.type(bio, 'Two chapters before bed.');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await screen.findByText(/profile updated successfully!/i);
+    unmount();
+
+    // The initialiser reads localStorage rather than an effect doing it after
+    // the first paint, so the saved bio is on screen from the first render.
+    renderProfile();
+    expect(screen.getByText('"Two chapters before bed."')).toBeInTheDocument();
+  });
+
+  it('falls back to the defaults when the stored profile is unreadable', () => {
+    localStorage.setItem('bookshelf_user_profile', '{ not json');
+    const onError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderProfile();
+
+    // A throw out of a useState initialiser is not recoverable, so the parse
+    // has to be guarded rather than left to the ErrorBoundary.
+    expect(screen.getByText('Jane Reader')).toBeInTheDocument();
+    expect(
+      screen.getByText('"A room without books is like a body without a soul."')
+    ).toBeInTheDocument();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('seeds the name box when the session arrives after the first render', async () => {
+    const user = userEvent.setup();
+    // GET /api/auth/me resolves after mount, so `user` is null on the render
+    // that initialises the form.
+    const { rerender } = renderProfile(null);
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+    expect(screen.getByLabelText(/full name/i)).toHaveValue('Reader');
+
+    rerender(
+      <MemoryRouter>
+        <AuthContext.Provider
+          value={{
+            user: { name: 'Jane Reader', email: 'jane@example.com', role: 'Member' },
+            isAuthenticated: true,
+            loading: false,
+            logout: vi.fn(),
+            login: vi.fn(),
+            register: vi.fn(),
+            checkAuth: vi.fn(),
+          }}
+        >
+          <WishlistContext.Provider
+            value={{
+              wishlist: ['b1', 'b2'],
+              loading: false,
+              count: 2,
+              isWishlisted: () => true,
+              toggleWishlist: vi.fn(),
+            }}
+          >
+            <Profile />
+          </WishlistContext.Provider>
+        </AuthContext.Provider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/full name/i)).toHaveValue('Jane Reader')
+    );
+  });
+
+  it('rejects a new password shorter than eight characters', async () => {
+    const user = userEvent.setup();
+    renderProfile();
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+
+    await user.type(screen.getByLabelText(/current password/i), 'oldsecret1');
+    await user.type(screen.getByLabelText(/new password/i), 'short');
+    await user.click(screen.getByRole('button', { name: /update password/i }));
+
+    expect(
+      await screen.findByText(/at least 8 characters long/i)
+    ).toBeInTheDocument();
+  });
+
+  it('persists the genres the reader picks', async () => {
+    const user = userEvent.setup();
+    renderProfile();
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+
+    // Fiction is on by default, so this removes it; Fantasy is not, so this
+    // adds it. Both directions go through the same toggle.
+    await user.click(screen.getByRole('button', { name: /^Fiction/ }));
+    await user.click(screen.getByRole('button', { name: /^Fantasy/ }));
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await screen.findByText(/profile updated successfully!/i);
+
+    const stored = JSON.parse(localStorage.getItem('bookshelf_user_profile'));
+    expect(stored.preferredGenres).not.toContain('Fiction');
+    expect(stored.preferredGenres).toContain('Fantasy');
+  });
+
+  it('shows the wishlist count from context rather than a copy of it', async () => {
+    const user = userEvent.setup();
+    renderProfile();
+
+    await user.click(
+      screen.getByRole('button', { name: /📖 My Activity/i })
+    );
+
+    // Straight from WishlistContext. The library tab is the only place the
+    // restored `useWishlist()` call is visible, so it is the only test that
+    // would notice if the import went missing again.
+    expect(screen.getByText('💖 Wishlist (2)')).toBeInTheDocument();
+    expect(screen.getByText(/You currently have 2 books saved/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #366.

## The bug

`/profile` crashed for every signed-in reader. React unmounted the tree and the `ErrorBoundary` fallback took the page.

```
ReferenceError: profileData is not defined
    at Profile (src/pages/Profile.jsx:23)
```

A merge kept the 350 lines of reading-portal JSX and took the top of the file from the version before the portal existed. What was left is a component that renders a goal ring, a reading streak, four tabs and three forms over a body that declares none of it.

Missing: `profileData`, `formName`, `formBio`, `formGoal`, `formAvatar`, `formGenres`, `currentPassword`, `newPassword`, `saveMessage`, `securityMessage`, `activeTab`, `setActiveTab`, `handleSaveProfile`, `handleUpdatePassword`, `handleLogout`, `toggleGenre`, `wishlistCount`, `orders`, `booksReadCount`, `pagesReadCount`, `readingHoursCount`, `t`, `ALL_GENRES` and `AVATAR_OPTIONS` — plus six imports.

The 6 tests in `Profile.test.jsx` all failed with `Element type is invalid: ... got: undefined`, which is the missing `ReadingGoalRing` import surfacing a moment before the `ReferenceError` would have.

## The fix

The state layer is restored as it was written, so this is a repair rather than a redesign — no behaviour changes for anything that worked:

- the six imports: `useWishlist`, `useOrders`, `ReadingGoalRing`, `ReadingStreak`, `RecentlyViewed`, `FavoriteBooks`
- `useTranslation()`, so `t` is bound
- `activeTab`, the `localStorage`-backed `profileData`, the five settings fields, the two password fields, the two message banners
- `handleSaveProfile`, `handleUpdatePassword`, `toggleGenre`, `handleLogout`
- the effect that seeds the name box once the session resolves

Two deliberate departures from a plain revert:

| | why |
| --- | --- |
| `./Profile.css`, not `./Auth.css` | `Auth.css` styles the login-style form this page stopped being. None of the `profile-*` classes the markup uses are defined in it, so the page would have rendered unstyled even once it stopped throwing. |
| `usePageMetadata` stays | It was added on the broken side of the merge. Naming the browser tab is not something to lose while fixing a crash, so it is kept and covered by a test. |

## Tests

6 failed → 13 passed. The seven new ones cover the parts of the restored state layer the existing tests do not reach:

- the browser tab is named `Your profile — BookShelf`
- a save and remount round trip: the bio comes back from `localStorage` on the first paint, because the read is in the `useState` initialiser rather than in an effect
- an unparseable stored value falls back to the defaults instead of throwing — a throw out of a `useState` initialiser is not something the ErrorBoundary can recover from
- the name box catches up when `GET /api/auth/me` resolves after the first render
- the eight-character rule on a new password
- genre toggling in both directions, persisted
- the wishlist count comes from `WishlistContext`

## Verification

```
$ cd bookshelf-frontend && npm test -- src/pages/Profile.test.jsx
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Manually: sign in, open `/profile`, switch all four tabs, save a bio, reload, save a goal, toggle genres, try a six-character password.

---

## Where this sits

`main` is broken in four independent places and does not build at all, so these five PRs are a **stack** and have to land in order. This is the base of it.

| order | PR | what it owns |
| --- | --- | --- |
| **1** | **#371 (this one)** | `Profile.jsx` — and, as the two commits that unblock everything else, the stray `}` in `Footer.jsx` and the missing `export default` on Profile, without which nothing in `bookshelf-frontend` bundles |
| 2 | #370 | `Home.jsx` |
| 3 | #372 | `OrderHistory.jsx`, `WishlistPage.jsx`, the locale bundles |
| 4 | #373 | `Pagination.jsx` |
| 5 | #374 | the lint script, `.eslintrc.cjs`, the CI workflow |

Each PR from here carries the ones before it, so they merge in order with no conflicts. I checked every pair with `git merge-tree --write-tree`; there are none, in either direction.

**Its CI:** the build is green (Netlify preview builds for the first time in a while). `npm test` still reports 41 failures — 19 in `Home.test.jsx`, 13 in `OrderHistory.test.jsx`, 9 in `WishlistPage.test.jsx`. None of those are this PR's; they are the crashes #370 and #372 fix, and they go green at step 3 of the stack. The six `Profile.test.jsx` tests this PR is about pass, and so do the seven new ones.
