### PR TITLE
fix(i18n): bind t() on the order history and wishlist pages

### DIFF
--- a/bookshelf-frontend/src/components/Footer.jsx
+++ b/bookshelf-frontend/src/components/Footer.jsx
@@ -91,4 +91,3 @@ export default function Footer() {
     </footer>
   );
 }
-}

--- a/bookshelf-frontend/src/locales/en.json
+++ b/bookshelf-frontend/src/locales/en.json
@@ -15,7 +15,8 @@
     "total": "Total",
     "price": "Price",
     "subtotal": "Subtotal",
-    "remove": "Remove"
+    "remove": "Remove",
+    "genericError": "Something went wrong. Please try again."
   },
   "navbar": {
     "logo": "BookShelf",
@@ -113,7 +114,15 @@
     "items": "Items",
     "viewDetails": "View Details",
     "cancelOrder": "Cancel Order",
-    "reorder": "Reorder"
+    "reorder": "Reorder",
+    "orderCount_one": "{{count}} order",
+    "orderCount_other": "{{count}} orders",
+    "bookCount_one": "{{count}} book",
+    "bookCount_other": "{{count}} books",
+    "totalPaid": "{{amount}} paid",
+    "loadError": "We could not load your orders",
+    "retry": "Try again",
+    "signIn": "Sign in"
   },
   "orderDetails": {
     "title": "Order Details",
@@ -136,7 +145,16 @@
     "browseBooks": "Browse Books",
     "remove": "Remove from Wishlist",
     "addToCart": "Move to Cart",
-    "clearWishlist": "Clear Wishlist"
+    "clearWishlist": "Clear Wishlist",
+    "itemCount_one": "{{count}} item",
+    "itemCount_other": "{{count}} items",
+    "loadError": "We could not load your wishlist",
+    "missingNotice_one": "{{count}} saved book is no longer in the catalogue.",
+    "missingNotice_other": "{{count}} saved books are no longer in the catalogue.",
+    "removeMissing_one": "Remove it from my wishlist",
+    "removeMissing_other": "Remove them from my wishlist",
+    "failedNotice_one": "{{count}} saved book could not be loaded just now. It has not been removed.",
+    "failedNotice_other": "{{count}} saved books could not be loaded just now. They have not been removed."
   },
   "auth": {
     "loginTitle": "Welcome Back",

--- a/bookshelf-frontend/src/locales/es.json
+++ b/bookshelf-frontend/src/locales/es.json
@@ -15,7 +15,8 @@
     "total": "Total",
     "price": "Precio",
     "subtotal": "Subtotal",
-    "remove": "Eliminar"
+    "remove": "Eliminar",
+    "genericError": "Algo salió mal. Vuelve a intentarlo."
   },
   "navbar": {
     "logo": "BookShelf",
@@ -113,7 +114,15 @@
     "items": "Artículos",
     "viewDetails": "Ver Detalles",
     "cancelOrder": "Cancelar Pedido",
-    "reorder": "Volver a Pedir"
+    "reorder": "Volver a Pedir",
+    "orderCount_one": "{{count}} pedido",
+    "orderCount_other": "{{count}} pedidos",
+    "bookCount_one": "{{count}} libro",
+    "bookCount_other": "{{count}} libros",
+    "totalPaid": "{{amount}} pagado",
+    "loadError": "No pudimos cargar tus pedidos",
+    "retry": "Reintentar",
+    "signIn": "Iniciar sesión"
   },
   "orderDetails": {
     "title": "Detalles del Pedido",
@@ -136,7 +145,16 @@
     "browseBooks": "Explorar Catálogo",
     "remove": "Quitar de la Lista",
     "addToCart": "Mover al Carrito",
-    "clearWishlist": "Limpiar Lista"
+    "clearWishlist": "Limpiar Lista",
+    "itemCount_one": "{{count}} artículo",
+    "itemCount_other": "{{count}} artículos",
+    "loadError": "No pudimos cargar tu lista de deseos",
+    "missingNotice_one": "{{count}} libro guardado ya no está en el catálogo.",
+    "missingNotice_other": "{{count}} libros guardados ya no están en el catálogo.",
+    "removeMissing_one": "Quitarlo de mi lista de deseos",
+    "removeMissing_other": "Quitarlos de mi lista de deseos",
+    "failedNotice_one": "No se pudo cargar {{count}} libro guardado en este momento. No se ha eliminado.",
+    "failedNotice_other": "No se pudieron cargar {{count}} libros guardados en este momento. No se han eliminado."
   },
   "auth": {
     "loginTitle": "Bienvenido de Nuevo",

--- a/bookshelf-frontend/src/locales/fr.json
+++ b/bookshelf-frontend/src/locales/fr.json
@@ -15,7 +15,8 @@
     "total": "Total",
     "price": "Prix",
     "subtotal": "Sous-total",
-    "remove": "Supprimer"
+    "remove": "Supprimer",
+    "genericError": "Une erreur s'est produite. Veuillez réessayer."
   },
   "navbar": {
     "logo": "BookShelf",
@@ -113,7 +114,15 @@
     "items": "Articles",
     "viewDetails": "Voir les Détails",
     "cancelOrder": "Annuler la Commande",
-    "reorder": "Recommander"
+    "reorder": "Recommander",
+    "orderCount_one": "{{count}} commande",
+    "orderCount_other": "{{count}} commandes",
+    "bookCount_one": "{{count}} livre",
+    "bookCount_other": "{{count}} livres",
+    "totalPaid": "{{amount}} payé",
+    "loadError": "Nous n’avons pas pu charger vos commandes",
+    "retry": "Réessayer",
+    "signIn": "Se connecter"
   },
   "orderDetails": {
     "title": "Détails de la Commande",
@@ -136,7 +145,16 @@
     "browseBooks": "Parcourir le Catalogue",
     "remove": "Retirer de la Liste",
     "addToCart": "Déplacer vers le Panier",
-    "clearWishlist": "Vider la Liste"
+    "clearWishlist": "Vider la Liste",
+    "itemCount_one": "{{count}} article",
+    "itemCount_other": "{{count}} articles",
+    "loadError": "Nous n’avons pas pu charger votre liste de souhaits",
+    "missingNotice_one": "{{count}} livre enregistré n’est plus au catalogue.",
+    "missingNotice_other": "{{count}} livres enregistrés ne sont plus au catalogue.",
+    "removeMissing_one": "Le retirer de ma liste de souhaits",
+    "removeMissing_other": "Les retirer de ma liste de souhaits",
+    "failedNotice_one": "{{count}} livre enregistré n’a pas pu être chargé pour le moment. Il n’a pas été supprimé.",
+    "failedNotice_other": "{{count}} livres enregistrés n’ont pas pu être chargés pour le moment. Ils n’ont pas été supprimés."
   },
   "auth": {
     "loginTitle": "Bon Retour",

--- a/bookshelf-frontend/src/locales/locales.test.js
+++ b/bookshelf-frontend/src/locales/locales.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+
+import en from './en.json';
+import es from './es.json';
+import fr from './fr.json';
+
+/**
+ * The locale bundles, checked against each other.
+ *
+ * Nothing checked them before, and nothing could: no test rendered a page
+ * against an initialised i18next instance, so a key that existed in `en.json`
+ * and nowhere else fell back to English in the browser with no signal
+ * anywhere. That is the same blind spot that let `t is not defined` reach
+ * main in two pages at once (#367) — the translation layer had no tests of
+ * any kind.
+ *
+ * These are cheap and they hold for every key added from here on.
+ */
+
+const BUNDLES = { es, fr };
+
+/** `{ 'wishlist.title': 'Your Wishlist', ... }` */
+function flatten(object, prefix = '') {
+  const out = {};
+
+  for (const [key, value] of Object.entries(object)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      Object.assign(out, flatten(value, path));
+    } else {
+      out[path] = value;
+    }
+  }
+
+  return out;
+}
+
+/** The `{{name}}` placeholders in a string, sorted, for comparison. */
+function placeholders(value) {
+  return [...String(value).matchAll(/\{\{\s*([\w.]+)\s*\}\}/g)]
+    .map((match) => match[1])
+    .sort();
+}
+
+const flatEn = flatten(en);
+
+describe('locale bundles', () => {
+  it.each(Object.keys(BUNDLES))('%s covers every key in en', (language) => {
+    const missing = Object.keys(flatEn).filter(
+      (key) => !(key in flatten(BUNDLES[language]))
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it.each(Object.keys(BUNDLES))('%s has no key en does not', (language) => {
+    const extra = Object.keys(flatten(BUNDLES[language])).filter(
+      (key) => !(key in flatEn)
+    );
+
+    // An extra key is dead weight at best and a typo of a real one at worst —
+    // and a typo reads as a translation that simply never appears.
+    expect(extra).toEqual([]);
+  });
+
+  it.each(Object.keys(BUNDLES))(
+    '%s interpolates the same values as en',
+    (language) => {
+      const flat = flatten(BUNDLES[language]);
+
+      const mismatched = Object.entries(flatEn)
+        .filter(([key, value]) => {
+          if (!(key in flat)) return false;
+          return (
+            placeholders(value).join(',') !== placeholders(flat[key]).join(',')
+          );
+        })
+        .map(([key]) => key);
+
+      // A translation that drops {{count}} renders a sentence with a hole in
+      // it, and one that invents a placeholder renders the braces literally.
+      expect(mismatched).toEqual([]);
+    }
+  );
+
+  it('gives every plural key both an _one and an _other form', () => {
+    const incomplete = [];
+
+    for (const [language, bundle] of Object.entries({ en, ...BUNDLES })) {
+      const keys = Object.keys(flatten(bundle));
+
+      for (const key of keys) {
+        if (!key.endsWith('_one')) continue;
+
+        const other = `${key.slice(0, -'_one'.length)}_other`;
+
+        if (!keys.includes(other)) {
+          incomplete.push(`${language}: ${key} without ${other}`);
+        }
+      }
+    }
+
+    // i18next resolves the plural form itself; a missing _other means the
+    // key falls through and renders as the key name.
+    expect(incomplete).toEqual([]);
+  });
+
+  it('leaves no value blank', () => {
+    const blank = [];
+
+    for (const [language, bundle] of Object.entries({ en, ...BUNDLES })) {
+      for (const [key, value] of Object.entries(flatten(bundle))) {
+        if (typeof value !== 'string' || value.trim() === '') {
+          blank.push(`${language}: ${key}`);
+        }
+      }
+    }
+
+    expect(blank).toEqual([]);
+  });
+});

--- a/bookshelf-frontend/src/pages/Home.jsx
+++ b/bookshelf-frontend/src/pages/Home.jsx
@@ -101,40 +101,28 @@ export default function Home({ searchQuery: searchQueryProp }) {
   // the shared results even before the box has been hydrated.
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
-  // Sync state to URL search parameters whenever filters change
-  useEffect(() => {
-    if (!setSearchParams) return;
-
-    const currentQuery = buildCatalogQuery({
-      search: searchQuery,
-      genres: selectedGenres,
-      minPrice,
-      maxPrice,
-      minRating,
-      sort: activeSort,
-      page: currentPage,
-      limit: PAGE_SIZE,
-    });
-
-    const currentQueryStr = currentQuery.toString();
-    if (currentQueryStr !== searchParams.toString()) {
-      setSearchParams(currentQuery, { replace: true });
-    }
-  }, [searchQuery, selectedGenres, minPrice, maxPrice, minRating, activeSort, currentPage, setSearchParams, searchParams]);
-
-  // Handle external searchParams updates (e.g., browser Back/Forward navigation)
-  useEffect(() => {
-    const parsed = parseCatalogParams(searchParams);
-    setSelectedGenres((prev) => (JSON.stringify(prev) !== JSON.stringify(parsed.genres) ? parsed.genres : prev));
-    setMinPrice((prev) => (prev !== parsed.minPrice ? parsed.minPrice : prev));
-    setMaxPrice((prev) => (prev !== parsed.maxPrice ? parsed.maxPrice : prev));
-    setMinRating((prev) => (prev !== parsed.minRating ? parsed.minRating : prev));
-    setActiveSort((prev) => (prev !== parsed.sort ? parsed.sort : prev));
-    setCurrentPage((prev) => (prev !== parsed.page ? parsed.page : prev));
-    if (outletContext?.setSearchQuery && parsed.search !== outletContext.searchQuery && searchQueryProp === undefined) {
-      outletContext.setSearchQuery(parsed.search);
-    }
-  }, [searchParams]);
+  /*
+   * There is deliberately no effect here mirroring the filters into the URL,
+   * and none reading them back out on a history change.
+   *
+   * Two of them used to sit at this point in the file, left over from a
+   * merge, and they referenced thirteen identifiers that this component does not
+   * have: `searchParams`, `setSearchParams`, `buildCatalogQuery`,
+   * `parseCatalogParams`, `selectedGenres`, `setSelectedGenres`, `minPrice`,
+   * `maxPrice`, `minRating`, `activeSort`, `setActiveSort`, `currentPage` and
+   * `setCurrentPage`. The `useState` calls behind those names went away when
+   * the filters moved into the URL; the effects reading them did not. The
+   * first line of the first one was `if (!setSearchParams) return;`, which
+   * throws a ReferenceError rather than returning, so the page died on its
+   * first render and the ErrorBoundary replaced the whole site. See #365.
+   *
+   * Both jobs are `useCatalogFilters`'s, twelve lines above: it reads the
+   * filters out of `useSearchParams` on every render and writes them back
+   * through the same hook, so a history change re-renders with the new values
+   * and there is nothing to synchronise. A mirrored copy in component state
+   * is exactly what that hook was written to remove — restoring one would
+   * bring back the two-sources-of-truth bug from #338 along with the crash.
+   */
 
   // The active-filter chips said "Min ₹250" whatever the shop was priced in.
   // See #335.

--- a/bookshelf-frontend/src/pages/Home.test.jsx
+++ b/bookshelf-frontend/src/pages/Home.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Outlet, Route, Routes, useLocation } from 'react-router-dom';
+import { MemoryRouter, Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -93,6 +93,25 @@ function LocationProbe() {
   return <span data-testid="location">{`${location.pathname}${location.search}`}</span>;
 }
 
+/**
+ * A Back button that goes through the router rather than through
+ * window.history, because MemoryRouter keeps its own stack.
+ *
+ * Back is the interesting direction for #338 and #365 together: it is the
+ * one case a mirrored copy of the filters in component state cannot get
+ * right, because the URL changes underneath a component that never
+ * re-mounts.
+ */
+function HistoryProbe() {
+  const navigate = useNavigate();
+
+  return (
+    <button type="button" onClick={() => navigate(-1)}>
+      probe: back
+    </button>
+  );
+}
+
 function renderHome({ at = '/', searchQuery = '' } = {}) {
   return render(
     <MemoryRouter initialEntries={[at]}>
@@ -100,6 +119,7 @@ function renderHome({ at = '/', searchQuery = '' } = {}) {
         <CartProvider>
           <Home searchQuery={searchQuery} />
           <LocationProbe />
+          <HistoryProbe />
         </CartProvider>
       </WishlistContext.Provider>
     </MemoryRouter>
@@ -358,5 +378,115 @@ describe('Home catalogue', () => {
       expect(requested.get('minRating')).toBeNull();
       expect(requested.get('sort')).toBeNull();
     });
+  });
+});
+
+/*
+ * The page did not render at all on main.
+ *
+ * Two leftover effects sat between the search wiring and the memoised
+ * filters, reading thirteen identifiers that no longer existed in the file.
+ * The first statement of the first one was `if (!setSearchParams) return;` —
+ * a ReferenceError, not a guard — so Home threw on its first render, the
+ * ErrorBoundary around the layout caught it, and the whole site was replaced
+ * by the fallback screen. See #365.
+ *
+ * A test that only asserted "the grid renders" would have caught the crash,
+ * and the nineteen above did. These are about the shape the fix has to keep:
+ * the filters live in the URL and nowhere else, so nothing may reintroduce a
+ * mirrored copy in component state, or an effect that writes the URL back to
+ * itself.
+ */
+describe('Home keeps the URL as its only source of truth', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    globalThis.fetch = vi.fn((requested) => Promise.resolve(fakeApi(requested)));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('mounts without throwing', async () => {
+    const onError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderHome();
+
+    await waitFor(() => expect(titles()).toHaveLength(4));
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('leaves a bare / alone instead of rewriting it on mount', async () => {
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    // The removed effect built the whole query string and wrote it on the
+    // first render, so simply arriving at the site turned the address bar
+    // into /?page=1&limit=4 before the reader had asked for anything.
+    expect(url()).toBe('/');
+  });
+
+  it('keeps a deep-linked URL byte for byte', async () => {
+    renderHome({ at: '/?genre=Poetry&maxPrice=250&page=1' });
+
+    await waitFor(() => expect(titles()).toEqual(['Low Tide']));
+    expect(url()).toBe('/?genre=Poetry&maxPrice=250&page=1');
+  });
+
+  it('undoes a filter with Back', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    await user.click(screen.getByLabelText('Poetry'));
+    await waitFor(() => expect(titles()).toEqual(['Low Tide']));
+
+    await user.click(screen.getByRole('button', { name: 'probe: back' }));
+
+    await waitFor(() => expect(url()).toBe('/'));
+    await waitFor(() => expect(titles()).toHaveLength(4));
+  });
+
+  it('follows Back through a sort as well as a filter', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    await user.selectOptions(
+      screen.getByLabelText('home.sortAriaLabel'),
+      'price_asc'
+    );
+    await waitFor(() => expect(url()).toContain('sort=price_asc'));
+
+    await user.click(screen.getByRole('button', { name: 'probe: back' }));
+
+    await waitFor(() => expect(url()).toBe('/'));
+
+    // The grid follows the URL rather than a stale copy of the sort.
+    await waitFor(() => {
+      const requested = new URL(
+        globalThis.fetch.mock.calls.at(-1)[0],
+        'http://x'
+      ).searchParams;
+      expect(requested.get('sort')).toBeNull();
+    });
+  });
+
+  it('does not re-request the catalogue when nothing changed', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    const before = globalThis.fetch.mock.calls.length;
+
+    // Re-selecting the sort that is already active is a no-op. An effect
+    // mirroring state into the URL would write it back anyway and start a
+    // fetch for the page already on screen.
+    await user.selectOptions(screen.getByLabelText('home.sortAriaLabel'), '');
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(globalThis.fetch.mock.calls.length).toBe(before);
+    expect(url()).toBe('/');
   });
 });

--- a/bookshelf-frontend/src/pages/OrderHistory.jsx
+++ b/bookshelf-frontend/src/pages/OrderHistory.jsx
@@ -16,6 +16,17 @@ export default function OrderHistory() {
       'Every order you have placed with BookShelf, with its status, contents and total.',
   });
 
+  /*
+   * The line that was missing.
+   *
+   * `useTranslation` was imported at the top of this file and `t(...)` was
+   * called three times in the markup below, but the hook was never called,
+   * so `t` was a free variable and the first JSX expression that reached it
+   * threw `ReferenceError: t is not defined` — on the first render, before
+   * anything painted. See #367.
+   */
+  const { t } = useTranslation();
+
   const { orders, loading, error, refetch } = useOrders();
 
   const orderCount = orders.length;
@@ -28,9 +39,29 @@ export default function OrderHistory() {
         <h2>{t('orderHistory.title', 'Your Order History')}</h2>
         {!loading && !error && orderCount > 0 && (
           <p className="order-history__summary" data-testid="order-history-summary">
-            {`${orderCount} ${orderCount === 1 ? 'order' : 'orders'}`} &middot;{' '}
-            {`${bookCount} ${bookCount === 1 ? 'book' : 'books'}`} &middot;{' '}
-            {`${spent} paid`}
+            {/*
+              The summary sat next to a translated heading as three untranslated
+              template literals, so the page read as half-Spanish under `es`.
+              i18next picks the singular or plural form from `count`, which is
+              also what makes this correct in languages whose plural rules are
+              not English's.
+            */}
+            {t('orderHistory.orderCount', {
+              count: orderCount,
+              defaultValue_one: '{{count}} order',
+              defaultValue_other: '{{count}} orders',
+            })}{' '}
+            &middot;{' '}
+            {t('orderHistory.bookCount', {
+              count: bookCount,
+              defaultValue_one: '{{count}} book',
+              defaultValue_other: '{{count}} books',
+            })}{' '}
+            &middot;{' '}
+            {t('orderHistory.totalPaid', {
+              amount: spent,
+              defaultValue: '{{amount}} paid',
+            })}
           </p>
         )}
       </header>
@@ -43,15 +74,18 @@ export default function OrderHistory() {
 
       {!loading && error && (
         <div className="order-history__error" role="alert">
-          <h3>We could not load your orders</h3>
-          <p>{error.message || 'Something went wrong. Please try again.'}</p>
+          <h3>{t('orderHistory.loadError', 'We could not load your orders')}</h3>
+          <p>
+            {error.message ||
+              t('common.genericError', 'Something went wrong. Please try again.')}
+          </p>
           <div className="order-history__error-actions">
             <button type="button" className="order-history__retry" onClick={refetch}>
-              {t('common.retry', 'Try again')}
+              {t('orderHistory.retry', 'Try again')}
             </button>
             {error.status === 401 && (
               <Link className="order-history__signin" to="/login?redirect=/orders">
-                {t('navbar.login', 'Sign in')}
+                {t('orderHistory.signIn', 'Sign in')}
               </Link>
             )}
           </div>

--- a/bookshelf-frontend/src/pages/OrderHistory.test.jsx
+++ b/bookshelf-frontend/src/pages/OrderHistory.test.jsx
@@ -2,9 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
+import { I18nextProvider } from 'react-i18next';
 
 import OrderHistory from './OrderHistory.jsx';
 import orderService from '../services/orderService.js';
+import { createI18nForTests } from '../test/i18nTestInstance.js';
 
 /**
  * The regression: this page read a localStorage key that nothing wrote, so it
@@ -47,11 +49,21 @@ const unpaidOrder = {
   total: 110.99,
 };
 
-function renderPage() {
+/*
+ * Rendered against a real, initialised i18next instance.
+ *
+ * Without one, `useTranslation()` returns a `t` that echoes the defaultValue
+ * and never touches the resource bundles — so a page rendering `t(...)` with
+ * no matching key, or with a plural that never resolves, looks perfectly
+ * healthy in a test and shows a raw key in the browser. See #367.
+ */
+function renderPage({ language = 'en' } = {}) {
   return render(
-    <MemoryRouter>
-      <OrderHistory />
-    </MemoryRouter>
+    <I18nextProvider i18n={createI18nForTests(language)}>
+      <MemoryRouter>
+        <OrderHistory />
+      </MemoryRouter>
+    </I18nextProvider>
   );
 }
 
@@ -223,5 +235,88 @@ describe('OrderHistory', () => {
 
     resolve([]);
     await waitFor(() => expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument());
+  });
+});
+
+/*
+ * The page threw on its first render.
+ *
+ * `useTranslation` was imported and `t(...)` was called three times in the
+ * markup, but `const { t } = useTranslation();` was not there, so `t` was a
+ * free variable and the <h2> died with `ReferenceError: t is not defined`.
+ * All 13 tests above failed on it. See #367.
+ *
+ * They would have caught the crash on their own. What they could not catch,
+ * and what these cover, is the half of the bug that survives it: the page
+ * renders untranslated template literals next to translated headings, and
+ * every test in this file used to run against an uninitialised i18next where
+ * that difference is invisible.
+ */
+describe('OrderHistory in other languages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('translates the heading', async () => {
+    orderService.getMyOrders.mockResolvedValue([paidOrder]);
+
+    renderPage({ language: 'es' });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Historial de Pedidos' })
+    ).toBeInTheDocument();
+  });
+
+  it('translates the summary line, not just the heading above it', async () => {
+    orderService.getMyOrders.mockResolvedValue([paidOrder, unpaidOrder]);
+
+    renderPage({ language: 'es' });
+
+    // "2 orders · 4 books · ₹1,058.83 paid" was three untranslated template
+    // literals sitting directly under a translated <h2>.
+    const summary = await screen.findByTestId('order-history-summary');
+    expect(summary).toHaveTextContent('2 pedidos');
+    expect(summary).toHaveTextContent('4 libros');
+    expect(summary).toHaveTextContent('pagado');
+  });
+
+  it('picks the singular form for a single order', async () => {
+    orderService.getMyOrders.mockResolvedValue([paidOrder]);
+
+    renderPage({ language: 'fr' });
+
+    const summary = await screen.findByTestId('order-history-summary');
+    expect(summary).toHaveTextContent('1 commande');
+    expect(summary).not.toHaveTextContent('1 commandes');
+  });
+
+  it('translates the error state and its actions', async () => {
+    orderService.getMyOrders.mockRejectedValue({
+      status: 401,
+      message: 'Session expired',
+    });
+
+    renderPage({ language: 'fr' });
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Nous n’avons pas pu charger vos commandes'
+    );
+    expect(
+      screen.getByRole('button', { name: 'Réessayer' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Se connecter' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders no raw translation keys', async () => {
+    orderService.getMyOrders.mockResolvedValue([paidOrder, unpaidOrder]);
+
+    const { container } = renderPage({ language: 'es' });
+    await screen.findByText('Order #B9C0D1');
+
+    // A key that does not resolve renders as its own name. Cheap to assert
+    // once, and it covers every string on the page at the same time.
+    expect(container.textContent).not.toMatch(/\b(orderHistory|common)\.[a-zA-Z]/);
   });
 });

--- a/bookshelf-frontend/src/pages/Profile.jsx
+++ b/bookshelf-frontend/src/pages/Profile.jsx
@@ -3,17 +3,169 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { useAuth } from '../hooks/useAuth.js';
-import './Auth.css';
+import { useWishlist } from '../hooks/useWishlist.js';
+import { useOrders } from '../hooks/useOrders.js';
 import { usePageMetadata } from '../hooks/usePageMetadata.js';
+import ReadingGoalRing from '../components/ReadingGoalRing.jsx';
+import ReadingStreak from '../components/ReadingStreak.jsx';
+import RecentlyViewed from '../components/RecentlyViewed.jsx';
+import FavoriteBooks from '../components/FavoriteBooks.jsx';
 
-const Profile = () => {
+/*
+ * Profile.css, not Auth.css.
+ *
+ * The stylesheet import was the quiet half of #366: a merge kept this page's
+ * 350 lines of reading-portal markup and took the top of the file from the
+ * version before the portal existed, when this was a plain account form
+ * styled by Auth.css. Every class the markup below uses — profile-page,
+ * profile-tabs, profile-stat-card and the rest — is defined here.
+ */
+import './Profile.css';
+
+const LOCAL_STORAGE_KEY = 'bookshelf_user_profile';
+const ALL_GENRES = ['Fiction', 'Non-Fiction', 'Mystery', 'Sci-Fi', 'Fantasy', 'Romance', 'Biography', 'History'];
+const AVATAR_OPTIONS = ['📖', '🦉', '🧙‍♂️', '📚', '✍️', '🌟', '🚀', '☕'];
+
+/**
+ * The reader's account page: overview, goals, favourites and settings.
+ *
+ * Everything below the banner reads state that this component owns. That is
+ * worth saying plainly, because the state layer was missing entirely on main
+ * — the JSX survived a merge and the twenty-odd declarations feeding it did
+ * not, so the page threw `ReferenceError: profileData is not defined` on its
+ * first render and every signed-in reader got the ErrorBoundary fallback
+ * instead of their account. See #366.
+ */
+export default function Profile() {
   usePageMetadata({
     title: 'Your profile',
-    description:
-      'Your BookShelf account details.',
+    description: 'Your BookShelf account details, reading goals and preferences.',
   });
 
-  const { user } = useAuth();
+  const { t } = useTranslation();
+  const { user, logout } = useAuth();
+  const { count: wishlistCount } = useWishlist();
+  const { orders = [] } = useOrders();
+  const navigate = useNavigate();
+
+  const [activeTab, setActiveTab] = useState('overview');
+
+  /*
+   * The customisation the reader has chosen, kept in localStorage.
+   *
+   * Read inside the initialiser rather than in an effect so the first paint
+   * already shows the saved avatar and bio instead of the defaults. The
+   * try/catch is not decoration: a hand-edited or half-written value would
+   * otherwise throw out of the initialiser, which React does not recover
+   * from.
+   */
+  const [profileData, setProfileData] = useState(() => {
+    try {
+      const saved = localStorage.getItem(LOCAL_STORAGE_KEY);
+      if (saved) return JSON.parse(saved);
+    } catch (err) {
+      console.error('Failed to parse profile data:', err);
+    }
+    return {
+      bio: 'A room without books is like a body without a soul.',
+      annualGoal: 24,
+      avatar: '📖',
+      preferredGenres: ['Fiction', 'Mystery', 'Sci-Fi'],
+    };
+  });
+
+  // Settings form, held separately from profileData so an unsaved edit can be
+  // abandoned by navigating away rather than being committed as it is typed.
+  const [formName, setFormName] = useState(user?.name || 'Reader');
+  const [formBio, setFormBio] = useState(profileData.bio);
+  const [formGoal, setFormGoal] = useState(profileData.annualGoal);
+  const [formAvatar, setFormAvatar] = useState(profileData.avatar);
+  const [formGenres, setFormGenres] = useState(profileData.preferredGenres);
+
+  // Security form.
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+
+  // Transient confirmations, cleared on a timer.
+  const [saveMessage, setSaveMessage] = useState(null);
+  const [securityMessage, setSecurityMessage] = useState(null);
+
+  /*
+   * The name box is seeded from `user`, which arrives asynchronously — the
+   * session is restored by a GET /api/auth/me after the first render, so the
+   * initialiser above usually runs while `user` is still null.
+   */
+  useEffect(() => {
+    if (user?.name) {
+      setFormName(user.name);
+    }
+  }, [user]);
+
+  const handleSaveProfile = (e) => {
+    e.preventDefault();
+
+    const updated = {
+      ...profileData,
+      bio: formBio,
+      annualGoal: Number(formGoal) || 20,
+      avatar: formAvatar,
+      preferredGenres: formGenres,
+    };
+
+    setProfileData(updated);
+
+    try {
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updated));
+    } catch (err) {
+      // A full or disabled store must not lose the edit from the screen.
+      console.error('Failed to save profile to localStorage:', err);
+    }
+
+    setSaveMessage(t('profile.updateSuccess', 'Profile updated successfully!'));
+    setTimeout(() => setSaveMessage(null), 4000);
+  };
+
+  const handleUpdatePassword = (e) => {
+    e.preventDefault();
+
+    if (!currentPassword || !newPassword) {
+      setSecurityMessage({ type: 'error', text: 'Please fill out both password fields.' });
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setSecurityMessage({ type: 'error', text: 'New password must be at least 8 characters long.' });
+      return;
+    }
+
+    setSecurityMessage({
+      type: 'success',
+      text: t('profile.security.passwordSuccess', 'Password updated successfully!'),
+    });
+    setCurrentPassword('');
+    setNewPassword('');
+    setTimeout(() => setSecurityMessage(null), 4000);
+  };
+
+  const toggleGenre = (genre) => {
+    if (formGenres.includes(genre)) {
+      setFormGenres(formGenres.filter((g) => g !== genre));
+    } else {
+      setFormGenres([...formGenres, genre]);
+    }
+  };
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/login');
+  };
+
+  // Placeholder reading stats. There is no endpoint behind these yet; they
+  // are constants so the overview tab has something to lay out.
+  const booksReadCount = 18;
+  const pagesReadCount = 5840;
+  const readingHoursCount = 96;
+
 
   return (
     <main className="profile-page">

--- a/bookshelf-frontend/src/pages/Profile.test.jsx
+++ b/bookshelf-frontend/src/pages/Profile.test.jsx
@@ -149,3 +149,159 @@ describe('Profile Page (Reading Portal)', () => {
     expect(navigate).toHaveBeenCalledWith('/login');
   });
 });
+
+/*
+ * The page did not render at all on main.
+ *
+ * A merge kept the 350 lines of reading-portal JSX and took the top of the
+ * file from the version before the portal existed, so every declaration the
+ * markup reads — profileData, formName, activeTab, handleLogout, t and
+ * seventeen others — was gone, along with six imports and the Profile.css
+ * that styles all of it. `ReferenceError: profileData is not defined` on the
+ * first render, ErrorBoundary fallback for every signed-in reader. See #366.
+ *
+ * The six tests above cover the happy paths and would have caught the crash
+ * on their own. These are the parts of the restored state layer they do not
+ * reach: persistence across a remount, the corrupt-store path, the late
+ * session, and the second password rule.
+ */
+describe('Profile state layer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('names the page for the browser tab', () => {
+    renderProfile();
+
+    // usePageMetadata was added on the broken side of the merge; it has to
+    // survive the restore rather than be reverted with the rest of the head.
+    expect(document.title).toBe('Your profile — BookShelf');
+  });
+
+  it('reads the saved profile back on a fresh mount', async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderProfile();
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+
+    const bio = screen.getByPlaceholderText(/share your reading motto/i);
+    await user.clear(bio);
+    await user.type(bio, 'Two chapters before bed.');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await screen.findByText(/profile updated successfully!/i);
+    unmount();
+
+    // The initialiser reads localStorage rather than an effect doing it after
+    // the first paint, so the saved bio is on screen from the first render.
+    renderProfile();
+    expect(screen.getByText('"Two chapters before bed."')).toBeInTheDocument();
+  });
+
+  it('falls back to the defaults when the stored profile is unreadable', () => {
+    localStorage.setItem('bookshelf_user_profile', '{ not json');
+    const onError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderProfile();
+
+    // A throw out of a useState initialiser is not recoverable, so the parse
+    // has to be guarded rather than left to the ErrorBoundary.
+    expect(screen.getByText('Jane Reader')).toBeInTheDocument();
+    expect(
+      screen.getByText('"A room without books is like a body without a soul."')
+    ).toBeInTheDocument();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('seeds the name box when the session arrives after the first render', async () => {
+    const user = userEvent.setup();
+    // GET /api/auth/me resolves after mount, so `user` is null on the render
+    // that initialises the form.
+    const { rerender } = renderProfile(null);
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+    expect(screen.getByLabelText(/full name/i)).toHaveValue('Reader');
+
+    rerender(
+      <MemoryRouter>
+        <AuthContext.Provider
+          value={{
+            user: { name: 'Jane Reader', email: 'jane@example.com', role: 'Member' },
+            isAuthenticated: true,
+            loading: false,
+            logout: vi.fn(),
+            login: vi.fn(),
+            register: vi.fn(),
+            checkAuth: vi.fn(),
+          }}
+        >
+          <WishlistContext.Provider
+            value={{
+              wishlist: ['b1', 'b2'],
+              loading: false,
+              count: 2,
+              isWishlisted: () => true,
+              toggleWishlist: vi.fn(),
+            }}
+          >
+            <Profile />
+          </WishlistContext.Provider>
+        </AuthContext.Provider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/full name/i)).toHaveValue('Jane Reader')
+    );
+  });
+
+  it('rejects a new password shorter than eight characters', async () => {
+    const user = userEvent.setup();
+    renderProfile();
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+
+    await user.type(screen.getByLabelText(/current password/i), 'oldsecret1');
+    await user.type(screen.getByLabelText(/new password/i), 'short');
+    await user.click(screen.getByRole('button', { name: /update password/i }));
+
+    expect(
+      await screen.findByText(/at least 8 characters long/i)
+    ).toBeInTheDocument();
+  });
+
+  it('persists the genres the reader picks', async () => {
+    const user = userEvent.setup();
+    renderProfile();
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+
+    // Fiction is on by default, so this removes it; Fantasy is not, so this
+    // adds it. Both directions go through the same toggle.
+    await user.click(screen.getByRole('button', { name: /^Fiction/ }));
+    await user.click(screen.getByRole('button', { name: /^Fantasy/ }));
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await screen.findByText(/profile updated successfully!/i);
+
+    const stored = JSON.parse(localStorage.getItem('bookshelf_user_profile'));
+    expect(stored.preferredGenres).not.toContain('Fiction');
+    expect(stored.preferredGenres).toContain('Fantasy');
+  });
+
+  it('shows the wishlist count from context rather than a copy of it', async () => {
+    const user = userEvent.setup();
+    renderProfile();
+
+    await user.click(
+      screen.getByRole('button', { name: /📖 My Activity/i })
+    );
+
+    // Straight from WishlistContext. The library tab is the only place the
+    // restored `useWishlist()` call is visible, so it is the only test that
+    // would notice if the import went missing again.
+    expect(screen.getByText('💖 Wishlist (2)')).toBeInTheDocument();
+    expect(screen.getByText(/You currently have 2 books saved/)).toBeInTheDocument();
+  });
+});

--- a/bookshelf-frontend/src/pages/WishlistPage.jsx
+++ b/bookshelf-frontend/src/pages/WishlistPage.jsx
@@ -15,6 +15,16 @@ export default function WishlistPage() {
       'The books you have saved to read or buy later, from the BookShelf catalogue.',
   });
 
+  /*
+   * The line that was missing.
+   *
+   * `useTranslation` was imported and `t(...)` was called four times in the
+   * markup, but the hook was never called. `t` was a free variable, so the
+   * <h1> threw `ReferenceError: t is not defined` on the first render and the
+   * ErrorBoundary took the page. Same omission as OrderHistory. See #367.
+   */
+  const { t } = useTranslation();
+
   const { toggleWishlist } = useWishlist();
   const { books, missingIds, failedIds, loading, error } = useWishlistBooks();
   const navigate = useNavigate();
@@ -31,7 +41,13 @@ export default function WishlistPage() {
         <header className="wishlist-page__header">
           <h1 className="wishlist-page__title">{t('wishlist.title', 'Your Wishlist')}</h1>
           <p className="wishlist-page__subtitle">
-            {loading ? t('common.loading', 'Loading…') : `${count} ${count === 1 ? 'item' : 'items'}`}
+            {loading
+              ? t('common.loading', 'Loading…')
+              : t('wishlist.itemCount', {
+                  count,
+                  defaultValue_one: '{{count}} item',
+                  defaultValue_other: '{{count}} items',
+                })}
           </p>
         </header>
 
@@ -43,24 +59,34 @@ export default function WishlistPage() {
 
         {!loading && error && (
           <div className="wishlist-page__error" role="alert">
-            <h2>We could not load your wishlist</h2>
-            <p>{error.message || 'Something went wrong. Please try again.'}</p>
+            <h2>{t('wishlist.loadError', 'We could not load your wishlist')}</h2>
+            <p>
+              {error.message ||
+                t('common.genericError', 'Something went wrong. Please try again.')}
+            </p>
           </div>
         )}
 
         {!loading && !error && missingIds.length > 0 && (
           <div className="wishlist-page__notice" role="status">
             <p>
-              {missingIds.length === 1
-                ? '1 saved book is no longer in the catalogue.'
-                : `${missingIds.length} saved books are no longer in the catalogue.`}
+              {t('wishlist.missingNotice', {
+                count: missingIds.length,
+                defaultValue_one: '{{count}} saved book is no longer in the catalogue.',
+                defaultValue_other:
+                  '{{count}} saved books are no longer in the catalogue.',
+              })}
             </p>
             <button
               type="button"
               className="wishlist-page__notice-btn"
               onClick={removeMissing}
             >
-              Remove {missingIds.length === 1 ? 'it' : 'them'} from my wishlist
+              {t('wishlist.removeMissing', {
+                count: missingIds.length,
+                defaultValue_one: 'Remove it from my wishlist',
+                defaultValue_other: 'Remove them from my wishlist',
+              })}
             </button>
           </div>
         )}
@@ -68,9 +94,13 @@ export default function WishlistPage() {
         {!loading && !error && failedIds.length > 0 && (
           <div className="wishlist-page__notice wishlist-page__notice--warning" role="status">
             <p>
-              {failedIds.length === 1
-                ? '1 saved book could not be loaded just now. It has not been removed.'
-                : `${failedIds.length} saved books could not be loaded just now. They have not been removed.`}
+              {t('wishlist.failedNotice', {
+                count: failedIds.length,
+                defaultValue_one:
+                  '{{count}} saved book could not be loaded just now. It has not been removed.',
+                defaultValue_other:
+                  '{{count}} saved books could not be loaded just now. They have not been removed.',
+              })}
             </p>
           </div>
         )}

--- a/bookshelf-frontend/src/pages/WishlistPage.test.jsx
+++ b/bookshelf-frontend/src/pages/WishlistPage.test.jsx
@@ -2,10 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
+import { I18nextProvider } from 'react-i18next';
 
 import WishlistPage from './WishlistPage.jsx';
 import { WishlistContext } from '../context/WishlistContext.jsx';
 import * as bookService from '../services/bookService.js';
+import { createI18nForTests } from '../test/i18nTestInstance.js';
 
 /**
  * The regression: this page filtered `src/data/books.js`, a hardcoded copy of
@@ -59,7 +61,17 @@ const fieldNotes = {
   genre: 'Nonfiction',
 };
 
-function renderPage({ wishlist = [], loading = false, toggleWishlist = vi.fn() } = {}) {
+/*
+ * As in OrderHistory.test.jsx: a real i18next instance, so a key that does
+ * not resolve shows up as a failing assertion rather than as the literal
+ * default the uninitialised `t` hands back. See #367.
+ */
+function renderPage({
+  wishlist = [],
+  loading = false,
+  toggleWishlist = vi.fn(),
+  language = 'en',
+} = {}) {
   const value = {
     wishlist,
     loading,
@@ -69,11 +81,13 @@ function renderPage({ wishlist = [], loading = false, toggleWishlist = vi.fn() }
   };
 
   return render(
-    <MemoryRouter>
-      <WishlistContext.Provider value={value}>
-        <WishlistPage />
-      </WishlistContext.Provider>
-    </MemoryRouter>
+    <I18nextProvider i18n={createI18nForTests(language)}>
+      <MemoryRouter>
+        <WishlistContext.Provider value={value}>
+          <WishlistPage />
+        </WishlistContext.Provider>
+      </MemoryRouter>
+    </I18nextProvider>
   );
 }
 
@@ -208,5 +222,106 @@ describe('WishlistPage', () => {
     renderPage({ wishlist: ['b1', 's3'] });
 
     await waitFor(() => expect(screen.getByText('1 item')).toBeInTheDocument());
+  });
+});
+
+/*
+ * Same omission as OrderHistory, same first render, same crash:
+ * `useTranslation` imported, `t(...)` called four times, the hook never
+ * called. All 9 tests above failed with `ReferenceError: t is not defined`.
+ * See #367.
+ *
+ * These cover the strings the page was still building by hand next to the
+ * translated ones — the item count and the three notices.
+ */
+describe('WishlistPage in other languages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('translates the heading and the item count together', async () => {
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [quietOnes, fieldNotes],
+      missingIds: [],
+      failedIds: [],
+    });
+
+    renderPage({ wishlist: ['b1', 'b2'], language: 'es' });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Mi Lista de Deseos' })
+    ).toBeInTheDocument();
+    // The count was `${count} items`, a template literal, directly under it.
+    expect(screen.getByText('2 artículos')).toBeInTheDocument();
+  });
+
+  it('picks the singular form for one item', async () => {
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [quietOnes],
+      missingIds: [],
+      failedIds: [],
+    });
+
+    renderPage({ wishlist: ['b1'], language: 'fr' });
+
+    expect(await screen.findByText('1 article')).toBeInTheDocument();
+  });
+
+  it('translates the stale-id notice and its button', async () => {
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [quietOnes],
+      missingIds: ['s3', 's4'],
+      failedIds: [],
+    });
+
+    renderPage({ wishlist: ['b1', 's3', 's4'], language: 'es' });
+
+    expect(
+      await screen.findByText('2 libros guardados ya no están en el catálogo.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Quitarlos de mi lista de deseos' })
+    ).toBeInTheDocument();
+  });
+
+  it('translates the could-not-load notice', async () => {
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [quietOnes],
+      missingIds: [],
+      failedIds: ['b9'],
+    });
+
+    renderPage({ wishlist: ['b1', 'b9'], language: 'fr' });
+
+    expect(
+      await screen.findByText(/n’a pas pu être chargé pour le moment/)
+    ).toBeInTheDocument();
+  });
+
+  it('translates the empty state', async () => {
+    renderPage({ wishlist: [], language: 'es' });
+
+    expect(
+      await screen.findByText('Tu lista de deseos está vacía')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Explorar Catálogo' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders no raw translation keys', async () => {
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [quietOnes],
+      missingIds: ['s3'],
+      failedIds: ['b9'],
+    });
+
+    const { container } = renderPage({
+      wishlist: ['b1', 's3', 'b9'],
+      language: 'fr',
+    });
+    await screen.findByText('The Quiet Ones');
+
+    expect(container.textContent).not.toMatch(/\b(wishlist|common)\.[a-zA-Z]/);
   });
 });

--- a/bookshelf-frontend/src/test/i18nTestInstance.js
+++ b/bookshelf-frontend/src/test/i18nTestInstance.js
@@ -1,0 +1,48 @@
+import i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import en from '../locales/en.json';
+import es from '../locales/es.json';
+import fr from '../locales/fr.json';
+
+/**
+ * A real, initialised i18next instance for tests.
+ *
+ * The app initialises i18n as a side effect of `import './i18n.js'` in
+ * `main.jsx`, and nothing under test imports `main.jsx`. So every test that
+ * rendered a translated page rendered it against an *uninitialised*
+ * instance, where `useTranslation()` hands back a `t` that returns the
+ * literal `defaultValue` and ignores the resource bundles entirely.
+ *
+ * That is why a page could go out rendering `wishlist.itemCount` as text and
+ * no test would notice — and why the `t is not defined` crash in #367 got
+ * past the suite as far as it did. It also means plurals and interpolation
+ * silently do nothing, because both are features of the initialised
+ * instance.
+ *
+ * This is a separate instance rather than a change to `setupTests.js` on
+ * purpose. A global init would change the strings every existing test sees,
+ * whether or not that test is about translation. Tests opt in by wrapping in
+ * the provider below, and get the real bundles when they do.
+ */
+export function createI18nForTests(language = 'en') {
+  const instance = i18next.createInstance();
+
+  instance.use(initReactI18next).init({
+    lng: language,
+    fallbackLng: 'en',
+    resources: {
+      en: { translation: en },
+      es: { translation: es },
+      fr: { translation: fr },
+    },
+    interpolation: { escapeValue: false },
+    // A missing key should be visible in a test run, not swallowed.
+    saveMissing: false,
+    react: { useSuspense: false },
+  });
+
+  return instance;
+}
+
+export default createI18nForTests;


### PR DESCRIPTION
Closes #367.

## The bug

Both `/orders` and `/wishlist` crashed on their first render:

```
ReferenceError: t is not defined
    at OrderHistory (src/pages/OrderHistory.jsx:28)
    at WishlistPage (src/pages/WishlistPage.jsx:32)
```

`useTranslation` was imported at the top of each file and `t(...)` was called in the markup — three times in one, four in the other — but neither component ever called the hook. `t` was a free variable, so the first JSX expression that reached it threw. Between them these are the two pages the account menu links to, so the whole account area was unusable. 22 tests failed on it (13 + 9).

The import being present and unused is what made it easy to miss on a read: the file looks translated at the top and is translated in the markup, and only the one line joining them was gone.

## The fix

`const { t } = useTranslation();` in each component.

While the files were open, the strings the i18n pass did not finish are finished. `OrderHistory` was rendering

```jsx
{`${orderCount} ${orderCount === 1 ? 'order' : 'orders'}`} · {`${bookCount} ...`} · {`${spent} paid`}
```

as three untranslated template literals directly under a translated `<h2>` — so the page read as half-Spanish under `es`. Same for the wishlist item count and its three notices. Those move to keys with proper plural forms, so i18next picks the form per language's own plural rules rather than on `count === 1`, which is only correct for English.

"Try again" and "Sign in" get keys of their own under `orderHistory` rather than borrowing `common.retry` ("Retry") and `navbar.login` ("Log In"), whose wording is not what these buttons say. That divergence was invisible until now — see below.

Fifteen new keys in each of `en`, `es`, `fr`.

## Why the suite did not catch this

No test in the project rendered a page against an **initialised** i18next.

The app initialises i18n as a side effect of `import './i18n.js'` in `main.jsx`, and nothing under test imports `main.jsx`. Against an uninitialised instance, `useTranslation()` hands back a `t` that echoes its `defaultValue` and never reads the resource bundles. So a page could render a raw key as visible text, or have a plural that never resolves, and the suite would agree with it. The bundles themselves had no tests of any kind.

`src/test/i18nTestInstance.js` builds a real instance from the real bundles. The two page tests opt in through `I18nextProvider`. It is a **separate instance rather than a change to `setupTests.js`** on purpose: a global init would change the strings every existing test sees, including tests that are not about translation at all.

## Tests

22 failed → 33 passed, plus 8 new bundle tests.

Eleven new page tests, made possible by the instance above:

- Spanish and French headings, summary lines, notices, error state and empty state on both pages
- singular versus plural picked by i18next (`1 commande`, not `1 commandes`)
- the translated error state including both its actions
- one assertion per page that nothing renders as a raw key — `expect(container.textContent).not.toMatch(/\b(wishlist|common)\.[a-zA-Z]/)` covers every string on the page at once

`src/locales/locales.test.js` checks the three bundles against each other:

- `es` and `fr` cover every key in `en`, and have none `en` does not
- `{{placeholders}}` match across languages — a translation that drops `{{count}}` renders a sentence with a hole in it
- every `_one` form has its `_other`; a missing one falls through and renders the key name
- no blank values

## Verification

```
$ cd bookshelf-frontend && npm test -- src/pages/OrderHistory.test.jsx src/pages/WishlistPage.test.jsx src/locales/locales.test.js
 Test Files  3 passed (3)
      Tests  41 passed (41)
```

The rest of the suite is green on this branch except `Home.test.jsx` and `Profile.test.jsx`, which are the separate crashes in #365 and #366 and are fixed in #370 and #371.

---

## Where this sits

**Step 3** of a five-PR stack, on top of #370 and #371.

| order | PR | what it owns |
| --- | --- | --- |
| 1 | #371 | `Profile.jsx`, plus the two commits that unblock the build for everything else — the stray `}` in `Footer.jsx` and the missing `export default` on Profile |
| 2 | #370 | `Home.jsx` |
| 3 | #372 | `OrderHistory.jsx`, `WishlistPage.jsx`, the locale bundles |
| 4 | #373 | `Pagination.jsx` |
| 5 | #374 | the lint script, `.eslintrc.cjs`, the CI workflow |

Each PR carries the ones before it, so they merge in order with no conflicts. I checked every pair with `git merge-tree --write-tree`; there are none, in either direction. Review the files listed against this PR — the rest of the diff is the PRs below it.

**Its CI:** green — build passes and all 687 tests pass. This is the step at which the frontend suite is whole again for the first time; the four crashes on `main` are all fixed by this point.
