### PR TITLE
chore(lint): fix the build, lint the .jsx files, and run lint in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -56,5 +56,15 @@ jobs:
         cache-dependency-path: ${{ matrix.workspace }}/package-lock.json
 
     - run: npm ci
+
+    # Before the build, because it is the cheaper of the two and it is the
+    # check that catches the class of bug the build does not. `vite build`
+    # will happily bundle a component whose body reads an identifier that
+    # does not exist — that is valid JavaScript to a bundler, and it fails
+    # only when the page renders. `no-undef` catches it here.
+    #
+    # --if-present because bookshelf-backend has no lint script yet.
+    - run: npm run lint --if-present
+
     - run: npm run build --if-present
     - run: npm test

--- a/bookshelf-frontend/.eslintrc.cjs
+++ b/bookshelf-frontend/.eslintrc.cjs
@@ -1,3 +1,17 @@
+/*
+ * ESLint for the frontend.
+ *
+ * The rules here were already right; what was wrong was what they ran on.
+ * `npm run lint` was `eslint .`, and on ESLint 8 with an .eslintrc config a
+ * bare directory only picks up `.js` files. So the run covered the 50 files
+ * under hooks, utils, services and config, and not one `.jsx` — every
+ * component and every page in the project was invisible to it.
+ *
+ * `eslint:recommended` turns on `no-undef`, which is the rule that would have
+ * stopped four pages shipping with a ReferenceError on their first render
+ * (#365, #366, #367). The script carries `--ext .js,.jsx` now, and CI runs
+ * it. See #368.
+ */
 module.exports = {
   env: {
     browser: true,
@@ -19,7 +33,28 @@ module.exports = {
   plugins: ['react'],
   rules: {
     'react/prop-types': 'off',
+
+    /*
+     * A warning, not an error, so it does not gate CI.
+     *
+     * There are 57 of them today, mostly unused imports left by earlier
+     * refactors. They are worth clearing, but clearing them is a change of
+     * its own — turning them into errors now would mean either a large
+     * unrelated diff or a suppression, and neither is what this gate is for.
+     */
     'no-unused-vars': 'warn',
+
+    /*
+     * Off, deliberately.
+     *
+     * It fires 45 times across the three policy pages, every one of them on a
+     * literal " or ' inside a paragraph of prose. React renders those
+     * correctly; the rule exists for JSX written by hand where a stray quote
+     * might have been meant as a delimiter, which is not what a terms-of-
+     * service page is. Escaping them all would make the source of that prose
+     * unreadable to keep a linter quiet.
+     */
+    'react/no-unescaped-entities': 'off',
   },
   settings: {
     react: {

--- a/bookshelf-frontend/package.json
+++ b/bookshelf-frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint .",
+    "lint": "eslint . --ext .js,.jsx",
     "format": "prettier --write .",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/bookshelf-frontend/src/Bookstartent.jsx
+++ b/bookshelf-frontend/src/Bookstartent.jsx
@@ -1,5 +1,10 @@
 import React from "react";
-import "./FavoriteCategories.css";
+// The stylesheet is Bookstartent.css — this file and its CSS were renamed
+// together and the import was not. Its own header comment still says
+// "FavoriteCategories.css", and every rule in it is a .favorite-categories
+// one, so this is the right file under the wrong name rather than a missing
+// one. See #368.
+import "./Bookstartent.css";
 
 export default function FavoriteCategories({
   categories = [],

--- a/bookshelf-frontend/src/components/BookCarousel.jsx
+++ b/bookshelf-frontend/src/components/BookCarousel.jsx
@@ -1,6 +1,13 @@
 import './BookCarousel.css';
 import { useRef } from 'react';
-import BookCard from '../BookCard/BookCard';
+/*
+ * Was `../BookCard/BookCard`. There is no src/components/BookCard/
+ * directory and never has been — the card is src/components/BookCard.jsx,
+ * a sibling of this file. Nothing imports BookCarousel yet, so the bundler
+ * never had to resolve the specifier and the build stayed green over a
+ * module that could not load. See #368.
+ */
+import BookCard from './BookCard.jsx';
 
 export default function BookCarousel({
   books = [],

--- a/bookshelf-frontend/src/components/Footer.jsx
+++ b/bookshelf-frontend/src/components/Footer.jsx
@@ -91,4 +91,3 @@ export default function Footer() {
     </footer>
   );
 }
-}

--- a/bookshelf-frontend/src/components/Pagination.css
+++ b/bookshelf-frontend/src/components/Pagination.css
@@ -55,3 +55,54 @@
     font-size: 13px;
   }
 }
+
+/*
+ * The skipped-run marker. Sized to match a page button so the row does not
+ * jog as the window moves and an ellipsis appears or disappears.
+ */
+.pagination__ellipsis {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 38px;
+  padding: 10px 6px;
+  color: var(--ink-soft, #6b7280);
+  font-size: 14px;
+  font-weight: 600;
+  user-select: none;
+}
+
+/*
+ * "Page 5 of 50", for assistive technology only. The numbers above say the
+ * same thing on screen, so showing it as well would be noise.
+ *
+ * Not `display: none` and not `visibility: hidden` — both remove the element
+ * from the accessibility tree, which is the one thing it is here for.
+ */
+.pagination__status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.pagination__page[aria-current='page'] {
+  /* Not colour alone: the active page also carries a heavier outline, so it
+     is still distinguishable in a high-contrast or forced-colours mode where
+     the background swap is dropped. */
+  outline: 2px solid var(--ink, #222);
+  outline-offset: 2px;
+}
+
+@media (max-width: 600px) {
+  .pagination__ellipsis {
+    min-width: 30px;
+    padding: 8px 4px;
+    font-size: 13px;
+  }
+}

--- a/bookshelf-frontend/src/components/Pagination.jsx
+++ b/bookshelf-frontend/src/components/Pagination.jsx
@@ -1,46 +1,131 @@
 import './Pagination.css';
 
+import { ELLIPSIS, clampPage, pageWindow } from '../utils/pagination.js';
+
+/**
+ * The catalogue pager.
+ *
+ * Two problems it had, and both of them get worse as the catalogue grows —
+ * which, since the admin CRUD endpoints landed in #364, it can:
+ *
+ * **It rendered one button per page.** A `for` loop from 1 to `totalPages`.
+ * Fine at four pages; at fifty it is a wrapped block of numbers taller than
+ * the grid it belongs to, and every one of them re-renders on every change.
+ * The list is windowed now — `pageWindow()` in utils/pagination.js decides
+ * what to show, so the arithmetic is testable without a DOM.
+ *
+ * **It told a screen reader almost nothing.** The current page was marked
+ * only by a background colour, the buttons were named by a bare digit, the
+ * arrows were read out as words, and swapping the grid announced nothing at
+ * all. See #369.
+ */
 export default function Pagination({
   currentPage = 1,
   totalPages = 1,
   onPageChange = () => {},
+  siblings,
+  label = 'Pagination',
 }) {
   if (totalPages <= 1) return null;
 
-  const pages = [];
-  for (let i = 1; i <= totalPages; i++) pages.push(i);
+  /*
+   * Clamp before anything reads it.
+   *
+   * `?page=7` on a three-page result set is a URL a reader can type, and the
+   * API answers a page past the end with an empty slice rather than an error.
+   * Without this, the pager renders with nothing marked current and Next
+   * still enabled above an empty grid.
+   */
+  const page = clampPage(currentPage, totalPages);
+  const pages = pageWindow({ currentPage: page, totalPages, siblings });
+
+  /*
+   * One place that decides whether a click does anything.
+   *
+   * `disabled` on the arrows is not enough on its own: the current page's own
+   * button used to fire `onPageChange` with the page already showing, and in
+   * `Home` that also runs `window.scrollTo`, so the page jumped for nothing.
+   */
+  const goTo = (next) => {
+    const target = clampPage(next, totalPages);
+
+    if (target === page) return;
+
+    onPageChange(target);
+  };
 
   return (
-    <nav className="pagination" aria-label="Pagination">
+    <nav className="pagination" aria-label={label}>
       <button
+        type="button"
         className="pagination__button"
-        onClick={() => onPageChange(currentPage - 1)}
-        disabled={currentPage === 1}
+        onClick={() => goTo(page - 1)}
+        disabled={page === 1}
       >
-        ← Prev
+        {/* Decoration. Without aria-hidden this is announced as "left arrow". */}
+        <span aria-hidden="true">←</span> Prev
       </button>
 
       <div className="pagination__pages">
-        {pages.map((page) => (
-          <button
-            key={page}
-            className={`pagination__page ${
-              currentPage === page ? 'pagination__page--active' : ''
-            }`}
-            onClick={() => onPageChange(page)}
-          >
-            {page}
-          </button>
-        ))}
+        {pages.map((entry, index) =>
+          entry === ELLIPSIS ? (
+            /*
+             * Not a button and not focusable: there is nothing here to
+             * activate. `aria-hidden` keeps "horizontal ellipsis" out of the
+             * announcement — the gap is already implied by the numbers
+             * either side of it.
+             */
+            <span
+              // Two ellipses can appear at once, and neither has a page
+              // number to key on, so the position is the only stable key.
+              key={`gap-${index}`}
+              className="pagination__ellipsis"
+              aria-hidden="true"
+            >
+              …
+            </span>
+          ) : (
+            <button
+              type="button"
+              key={entry}
+              className={`pagination__page ${
+                page === entry ? 'pagination__page--active' : ''
+              }`}
+              onClick={() => goTo(entry)}
+              /*
+               * The one attribute that says which page is showing. The active
+               * class is a colour change, which is nothing to a screen reader
+               * and not much to a reader who cannot tell the two shades
+               * apart.
+               */
+              aria-current={page === entry ? 'page' : undefined}
+              // "3, button" out of context does not say what it does.
+              aria-label={`Go to page ${entry}`}
+            >
+              {entry}
+            </button>
+          )
+        )}
       </div>
 
       <button
+        type="button"
         className="pagination__button"
-        onClick={() => onPageChange(currentPage + 1)}
-        disabled={currentPage === totalPages}
+        onClick={() => goTo(page + 1)}
+        disabled={page === totalPages}
       >
-        Next →
+        Next <span aria-hidden="true">→</span>
       </button>
+
+      {/*
+        The grid swaps its contents with no other signal that anything
+        happened. This is the confirmation — polite, so it waits for a gap
+        rather than interrupting, and visually hidden because the numbers
+        above already say it on screen.
+      */}
+      <p className="pagination__status" role="status" aria-live="polite">
+        Page {page} of {totalPages}
+      </p>
     </nav>
   );
 }

--- a/bookshelf-frontend/src/components/Pagination.test.jsx
+++ b/bookshelf-frontend/src/components/Pagination.test.jsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Pagination from './Pagination.jsx';
+
+/**
+ * The component had no test file at all.
+ *
+ * These are about the two things #369 was about: how many buttons a long
+ * result set produces, and what the control tells someone who is not looking
+ * at it.
+ */
+
+function renderPager({ currentPage = 1, totalPages = 1, onPageChange = vi.fn(), ...rest } = {}) {
+  const result = render(
+    <Pagination
+      currentPage={currentPage}
+      totalPages={totalPages}
+      onPageChange={onPageChange}
+      {...rest}
+    />
+  );
+
+  return { ...result, onPageChange };
+}
+
+const pageButtons = () =>
+  screen
+    .queryAllByRole('button', { name: /^Go to page/ })
+    .map((button) => button.textContent);
+
+describe('Pagination', () => {
+  it('renders nothing for a single page', () => {
+    const { container } = renderPager({ totalPages: 1 });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows every page while they fit', () => {
+    renderPager({ currentPage: 2, totalPages: 4 });
+
+    expect(pageButtons()).toEqual(['1', '2', '3', '4']);
+  });
+
+  it('windows a long range instead of rendering fifty buttons', () => {
+    renderPager({ currentPage: 25, totalPages: 50 });
+
+    // The reported symptom: a for-loop from 1 to totalPages put a block of
+    // fifty numbers under the grid.
+    expect(pageButtons()).toEqual(['1', '24', '25', '26', '50']);
+    expect(screen.getAllByText('…')).toHaveLength(2);
+  });
+
+  it('keeps the first and last page one click away', () => {
+    renderPager({ currentPage: 25, totalPages: 50 });
+
+    expect(screen.getByRole('button', { name: 'Go to page 1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to page 50' })).toBeInTheDocument();
+  });
+
+  describe('accessibility', () => {
+    it('marks the current page with aria-current, not just a class', () => {
+      renderPager({ currentPage: 3, totalPages: 10 });
+
+      const current = screen.getByRole('button', { name: 'Go to page 3' });
+
+      expect(current).toHaveAttribute('aria-current', 'page');
+      // Every other page must not claim to be current.
+      expect(
+        screen.getAllByRole('button', { name: /^Go to page/ })
+          .filter((button) => button.getAttribute('aria-current') === 'page')
+      ).toHaveLength(1);
+    });
+
+    it('names the page buttons rather than leaving them a bare digit', () => {
+      renderPager({ currentPage: 1, totalPages: 10 });
+
+      // "3, button" out of context says nothing about what it does.
+      expect(screen.getByRole('button', { name: 'Go to page 2' })).toHaveTextContent('2');
+    });
+
+    it('keeps the arrow glyphs out of the accessible name', () => {
+      renderPager({ currentPage: 2, totalPages: 10 });
+
+      // Not "left arrow Prev".
+      expect(screen.getByRole('button', { name: 'Prev' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    });
+
+    it('hides the ellipsis from assistive technology', () => {
+      renderPager({ currentPage: 25, totalPages: 50 });
+
+      screen.getAllByText('…').forEach((gap) => {
+        expect(gap).toHaveAttribute('aria-hidden', 'true');
+        // Nothing to activate, so it must not be a tab stop either.
+        expect(gap.tagName).toBe('SPAN');
+      });
+    });
+
+    it('announces which page is showing', () => {
+      renderPager({ currentPage: 5, totalPages: 50 });
+
+      const status = screen.getByRole('status');
+
+      expect(status).toHaveTextContent('Page 5 of 50');
+      expect(status).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('labels the landmark, so two pagers on a page are distinguishable', () => {
+      renderPager({ totalPages: 4, label: 'Search results pages' });
+
+      expect(
+        screen.getByRole('navigation', { name: 'Search results pages' })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('what a click does', () => {
+    it('moves to the page clicked', async () => {
+      const user = userEvent.setup();
+      const { onPageChange } = renderPager({ currentPage: 1, totalPages: 10 });
+
+      await user.click(screen.getByRole('button', { name: 'Go to page 3' }));
+
+      expect(onPageChange).toHaveBeenCalledWith(3);
+    });
+
+    it('does nothing when the current page is clicked', async () => {
+      const user = userEvent.setup();
+      const { onPageChange } = renderPager({ currentPage: 3, totalPages: 10 });
+
+      await user.click(screen.getByRole('button', { name: 'Go to page 3' }));
+
+      // It used to fire, and Home answers onPageChange with a smooth
+      // window.scrollTo — so clicking the page you are on jumped the page
+      // for nothing.
+      expect(onPageChange).not.toHaveBeenCalled();
+    });
+
+    it('steps with Prev and Next', async () => {
+      const user = userEvent.setup();
+      const { onPageChange } = renderPager({ currentPage: 5, totalPages: 10 });
+
+      await user.click(screen.getByRole('button', { name: 'Next' }));
+      expect(onPageChange).toHaveBeenLastCalledWith(6);
+
+      await user.click(screen.getByRole('button', { name: 'Prev' }));
+      expect(onPageChange).toHaveBeenLastCalledWith(4);
+    });
+
+    it('disables Prev on the first page and Next on the last', () => {
+      const { unmount } = renderPager({ currentPage: 1, totalPages: 10 });
+      expect(screen.getByRole('button', { name: 'Prev' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled();
+      unmount();
+
+      renderPager({ currentPage: 10, totalPages: 10 });
+      expect(screen.getByRole('button', { name: 'Prev' })).toBeEnabled();
+      expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+    });
+
+    it('cannot be walked past the end from a page outside the range', async () => {
+      const user = userEvent.setup();
+      // What a hand-typed ?page=7 produces on a three-page result set. The
+      // API answers a page past the end with an empty slice rather than an
+      // error, so nothing upstream catches it.
+      const { onPageChange } = renderPager({ currentPage: 7, totalPages: 3 });
+
+      expect(screen.getByRole('button', { name: 'Go to page 3' })).toHaveAttribute(
+        'aria-current',
+        'page'
+      );
+      expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+
+      await user.click(screen.getByRole('button', { name: 'Go to page 1' }));
+      expect(onPageChange).toHaveBeenCalledWith(1);
+    });
+
+    it('is reachable by keyboard in reading order', async () => {
+      const user = userEvent.setup();
+      renderPager({ currentPage: 2, totalPages: 4 });
+
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'Prev' })).toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'Go to page 1' })).toHaveFocus();
+    });
+  });
+});

--- a/bookshelf-frontend/src/locales/en.json
+++ b/bookshelf-frontend/src/locales/en.json
@@ -15,7 +15,8 @@
     "total": "Total",
     "price": "Price",
     "subtotal": "Subtotal",
-    "remove": "Remove"
+    "remove": "Remove",
+    "genericError": "Something went wrong. Please try again."
   },
   "navbar": {
     "logo": "BookShelf",
@@ -113,7 +114,15 @@
     "items": "Items",
     "viewDetails": "View Details",
     "cancelOrder": "Cancel Order",
-    "reorder": "Reorder"
+    "reorder": "Reorder",
+    "orderCount_one": "{{count}} order",
+    "orderCount_other": "{{count}} orders",
+    "bookCount_one": "{{count}} book",
+    "bookCount_other": "{{count}} books",
+    "totalPaid": "{{amount}} paid",
+    "loadError": "We could not load your orders",
+    "retry": "Try again",
+    "signIn": "Sign in"
   },
   "orderDetails": {
     "title": "Order Details",
@@ -136,7 +145,16 @@
     "browseBooks": "Browse Books",
     "remove": "Remove from Wishlist",
     "addToCart": "Move to Cart",
-    "clearWishlist": "Clear Wishlist"
+    "clearWishlist": "Clear Wishlist",
+    "itemCount_one": "{{count}} item",
+    "itemCount_other": "{{count}} items",
+    "loadError": "We could not load your wishlist",
+    "missingNotice_one": "{{count}} saved book is no longer in the catalogue.",
+    "missingNotice_other": "{{count}} saved books are no longer in the catalogue.",
+    "removeMissing_one": "Remove it from my wishlist",
+    "removeMissing_other": "Remove them from my wishlist",
+    "failedNotice_one": "{{count}} saved book could not be loaded just now. It has not been removed.",
+    "failedNotice_other": "{{count}} saved books could not be loaded just now. They have not been removed."
   },
   "auth": {
     "loginTitle": "Welcome Back",

--- a/bookshelf-frontend/src/locales/es.json
+++ b/bookshelf-frontend/src/locales/es.json
@@ -15,7 +15,8 @@
     "total": "Total",
     "price": "Precio",
     "subtotal": "Subtotal",
-    "remove": "Eliminar"
+    "remove": "Eliminar",
+    "genericError": "Algo salió mal. Vuelve a intentarlo."
   },
   "navbar": {
     "logo": "BookShelf",
@@ -113,7 +114,15 @@
     "items": "Artículos",
     "viewDetails": "Ver Detalles",
     "cancelOrder": "Cancelar Pedido",
-    "reorder": "Volver a Pedir"
+    "reorder": "Volver a Pedir",
+    "orderCount_one": "{{count}} pedido",
+    "orderCount_other": "{{count}} pedidos",
+    "bookCount_one": "{{count}} libro",
+    "bookCount_other": "{{count}} libros",
+    "totalPaid": "{{amount}} pagado",
+    "loadError": "No pudimos cargar tus pedidos",
+    "retry": "Reintentar",
+    "signIn": "Iniciar sesión"
   },
   "orderDetails": {
     "title": "Detalles del Pedido",
@@ -136,7 +145,16 @@
     "browseBooks": "Explorar Catálogo",
     "remove": "Quitar de la Lista",
     "addToCart": "Mover al Carrito",
-    "clearWishlist": "Limpiar Lista"
+    "clearWishlist": "Limpiar Lista",
+    "itemCount_one": "{{count}} artículo",
+    "itemCount_other": "{{count}} artículos",
+    "loadError": "No pudimos cargar tu lista de deseos",
+    "missingNotice_one": "{{count}} libro guardado ya no está en el catálogo.",
+    "missingNotice_other": "{{count}} libros guardados ya no están en el catálogo.",
+    "removeMissing_one": "Quitarlo de mi lista de deseos",
+    "removeMissing_other": "Quitarlos de mi lista de deseos",
+    "failedNotice_one": "No se pudo cargar {{count}} libro guardado en este momento. No se ha eliminado.",
+    "failedNotice_other": "No se pudieron cargar {{count}} libros guardados en este momento. No se han eliminado."
   },
   "auth": {
     "loginTitle": "Bienvenido de Nuevo",

--- a/bookshelf-frontend/src/locales/fr.json
+++ b/bookshelf-frontend/src/locales/fr.json
@@ -15,7 +15,8 @@
     "total": "Total",
     "price": "Prix",
     "subtotal": "Sous-total",
-    "remove": "Supprimer"
+    "remove": "Supprimer",
+    "genericError": "Une erreur s'est produite. Veuillez réessayer."
   },
   "navbar": {
     "logo": "BookShelf",
@@ -113,7 +114,15 @@
     "items": "Articles",
     "viewDetails": "Voir les Détails",
     "cancelOrder": "Annuler la Commande",
-    "reorder": "Recommander"
+    "reorder": "Recommander",
+    "orderCount_one": "{{count}} commande",
+    "orderCount_other": "{{count}} commandes",
+    "bookCount_one": "{{count}} livre",
+    "bookCount_other": "{{count}} livres",
+    "totalPaid": "{{amount}} payé",
+    "loadError": "Nous n’avons pas pu charger vos commandes",
+    "retry": "Réessayer",
+    "signIn": "Se connecter"
   },
   "orderDetails": {
     "title": "Détails de la Commande",
@@ -136,7 +145,16 @@
     "browseBooks": "Parcourir le Catalogue",
     "remove": "Retirer de la Liste",
     "addToCart": "Déplacer vers le Panier",
-    "clearWishlist": "Vider la Liste"
+    "clearWishlist": "Vider la Liste",
+    "itemCount_one": "{{count}} article",
+    "itemCount_other": "{{count}} articles",
+    "loadError": "Nous n’avons pas pu charger votre liste de souhaits",
+    "missingNotice_one": "{{count}} livre enregistré n’est plus au catalogue.",
+    "missingNotice_other": "{{count}} livres enregistrés ne sont plus au catalogue.",
+    "removeMissing_one": "Le retirer de ma liste de souhaits",
+    "removeMissing_other": "Les retirer de ma liste de souhaits",
+    "failedNotice_one": "{{count}} livre enregistré n’a pas pu être chargé pour le moment. Il n’a pas été supprimé.",
+    "failedNotice_other": "{{count}} livres enregistrés n’ont pas pu être chargés pour le moment. Ils n’ont pas été supprimés."
   },
   "auth": {
     "loginTitle": "Bon Retour",

--- a/bookshelf-frontend/src/locales/locales.test.js
+++ b/bookshelf-frontend/src/locales/locales.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+
+import en from './en.json';
+import es from './es.json';
+import fr from './fr.json';
+
+/**
+ * The locale bundles, checked against each other.
+ *
+ * Nothing checked them before, and nothing could: no test rendered a page
+ * against an initialised i18next instance, so a key that existed in `en.json`
+ * and nowhere else fell back to English in the browser with no signal
+ * anywhere. That is the same blind spot that let `t is not defined` reach
+ * main in two pages at once (#367) — the translation layer had no tests of
+ * any kind.
+ *
+ * These are cheap and they hold for every key added from here on.
+ */
+
+const BUNDLES = { es, fr };
+
+/** `{ 'wishlist.title': 'Your Wishlist', ... }` */
+function flatten(object, prefix = '') {
+  const out = {};
+
+  for (const [key, value] of Object.entries(object)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      Object.assign(out, flatten(value, path));
+    } else {
+      out[path] = value;
+    }
+  }
+
+  return out;
+}
+
+/** The `{{name}}` placeholders in a string, sorted, for comparison. */
+function placeholders(value) {
+  return [...String(value).matchAll(/\{\{\s*([\w.]+)\s*\}\}/g)]
+    .map((match) => match[1])
+    .sort();
+}
+
+const flatEn = flatten(en);
+
+describe('locale bundles', () => {
+  it.each(Object.keys(BUNDLES))('%s covers every key in en', (language) => {
+    const missing = Object.keys(flatEn).filter(
+      (key) => !(key in flatten(BUNDLES[language]))
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it.each(Object.keys(BUNDLES))('%s has no key en does not', (language) => {
+    const extra = Object.keys(flatten(BUNDLES[language])).filter(
+      (key) => !(key in flatEn)
+    );
+
+    // An extra key is dead weight at best and a typo of a real one at worst —
+    // and a typo reads as a translation that simply never appears.
+    expect(extra).toEqual([]);
+  });
+
+  it.each(Object.keys(BUNDLES))(
+    '%s interpolates the same values as en',
+    (language) => {
+      const flat = flatten(BUNDLES[language]);
+
+      const mismatched = Object.entries(flatEn)
+        .filter(([key, value]) => {
+          if (!(key in flat)) return false;
+          return (
+            placeholders(value).join(',') !== placeholders(flat[key]).join(',')
+          );
+        })
+        .map(([key]) => key);
+
+      // A translation that drops {{count}} renders a sentence with a hole in
+      // it, and one that invents a placeholder renders the braces literally.
+      expect(mismatched).toEqual([]);
+    }
+  );
+
+  it('gives every plural key both an _one and an _other form', () => {
+    const incomplete = [];
+
+    for (const [language, bundle] of Object.entries({ en, ...BUNDLES })) {
+      const keys = Object.keys(flatten(bundle));
+
+      for (const key of keys) {
+        if (!key.endsWith('_one')) continue;
+
+        const other = `${key.slice(0, -'_one'.length)}_other`;
+
+        if (!keys.includes(other)) {
+          incomplete.push(`${language}: ${key} without ${other}`);
+        }
+      }
+    }
+
+    // i18next resolves the plural form itself; a missing _other means the
+    // key falls through and renders as the key name.
+    expect(incomplete).toEqual([]);
+  });
+
+  it('leaves no value blank', () => {
+    const blank = [];
+
+    for (const [language, bundle] of Object.entries({ en, ...BUNDLES })) {
+      for (const [key, value] of Object.entries(flatten(bundle))) {
+        if (typeof value !== 'string' || value.trim() === '') {
+          blank.push(`${language}: ${key}`);
+        }
+      }
+    }
+
+    expect(blank).toEqual([]);
+  });
+});

--- a/bookshelf-frontend/src/pages/Home.jsx
+++ b/bookshelf-frontend/src/pages/Home.jsx
@@ -101,40 +101,28 @@ export default function Home({ searchQuery: searchQueryProp }) {
   // the shared results even before the box has been hydrated.
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
-  // Sync state to URL search parameters whenever filters change
-  useEffect(() => {
-    if (!setSearchParams) return;
-
-    const currentQuery = buildCatalogQuery({
-      search: searchQuery,
-      genres: selectedGenres,
-      minPrice,
-      maxPrice,
-      minRating,
-      sort: activeSort,
-      page: currentPage,
-      limit: PAGE_SIZE,
-    });
-
-    const currentQueryStr = currentQuery.toString();
-    if (currentQueryStr !== searchParams.toString()) {
-      setSearchParams(currentQuery, { replace: true });
-    }
-  }, [searchQuery, selectedGenres, minPrice, maxPrice, minRating, activeSort, currentPage, setSearchParams, searchParams]);
-
-  // Handle external searchParams updates (e.g., browser Back/Forward navigation)
-  useEffect(() => {
-    const parsed = parseCatalogParams(searchParams);
-    setSelectedGenres((prev) => (JSON.stringify(prev) !== JSON.stringify(parsed.genres) ? parsed.genres : prev));
-    setMinPrice((prev) => (prev !== parsed.minPrice ? parsed.minPrice : prev));
-    setMaxPrice((prev) => (prev !== parsed.maxPrice ? parsed.maxPrice : prev));
-    setMinRating((prev) => (prev !== parsed.minRating ? parsed.minRating : prev));
-    setActiveSort((prev) => (prev !== parsed.sort ? parsed.sort : prev));
-    setCurrentPage((prev) => (prev !== parsed.page ? parsed.page : prev));
-    if (outletContext?.setSearchQuery && parsed.search !== outletContext.searchQuery && searchQueryProp === undefined) {
-      outletContext.setSearchQuery(parsed.search);
-    }
-  }, [searchParams]);
+  /*
+   * There is deliberately no effect here mirroring the filters into the URL,
+   * and none reading them back out on a history change.
+   *
+   * Two of them used to sit at this point in the file, left over from a
+   * merge, and they referenced thirteen identifiers that this component does not
+   * have: `searchParams`, `setSearchParams`, `buildCatalogQuery`,
+   * `parseCatalogParams`, `selectedGenres`, `setSelectedGenres`, `minPrice`,
+   * `maxPrice`, `minRating`, `activeSort`, `setActiveSort`, `currentPage` and
+   * `setCurrentPage`. The `useState` calls behind those names went away when
+   * the filters moved into the URL; the effects reading them did not. The
+   * first line of the first one was `if (!setSearchParams) return;`, which
+   * throws a ReferenceError rather than returning, so the page died on its
+   * first render and the ErrorBoundary replaced the whole site. See #365.
+   *
+   * Both jobs are `useCatalogFilters`'s, twelve lines above: it reads the
+   * filters out of `useSearchParams` on every render and writes them back
+   * through the same hook, so a history change re-renders with the new values
+   * and there is nothing to synchronise. A mirrored copy in component state
+   * is exactly what that hook was written to remove — restoring one would
+   * bring back the two-sources-of-truth bug from #338 along with the crash.
+   */
 
   // The active-filter chips said "Min ₹250" whatever the shop was priced in.
   // See #335.

--- a/bookshelf-frontend/src/pages/Home.test.jsx
+++ b/bookshelf-frontend/src/pages/Home.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Outlet, Route, Routes, useLocation } from 'react-router-dom';
+import { MemoryRouter, Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -93,6 +93,25 @@ function LocationProbe() {
   return <span data-testid="location">{`${location.pathname}${location.search}`}</span>;
 }
 
+/**
+ * A Back button that goes through the router rather than through
+ * window.history, because MemoryRouter keeps its own stack.
+ *
+ * Back is the interesting direction for #338 and #365 together: it is the
+ * one case a mirrored copy of the filters in component state cannot get
+ * right, because the URL changes underneath a component that never
+ * re-mounts.
+ */
+function HistoryProbe() {
+  const navigate = useNavigate();
+
+  return (
+    <button type="button" onClick={() => navigate(-1)}>
+      probe: back
+    </button>
+  );
+}
+
 function renderHome({ at = '/', searchQuery = '' } = {}) {
   return render(
     <MemoryRouter initialEntries={[at]}>
@@ -100,6 +119,7 @@ function renderHome({ at = '/', searchQuery = '' } = {}) {
         <CartProvider>
           <Home searchQuery={searchQuery} />
           <LocationProbe />
+          <HistoryProbe />
         </CartProvider>
       </WishlistContext.Provider>
     </MemoryRouter>
@@ -358,5 +378,115 @@ describe('Home catalogue', () => {
       expect(requested.get('minRating')).toBeNull();
       expect(requested.get('sort')).toBeNull();
     });
+  });
+});
+
+/*
+ * The page did not render at all on main.
+ *
+ * Two leftover effects sat between the search wiring and the memoised
+ * filters, reading thirteen identifiers that no longer existed in the file.
+ * The first statement of the first one was `if (!setSearchParams) return;` —
+ * a ReferenceError, not a guard — so Home threw on its first render, the
+ * ErrorBoundary around the layout caught it, and the whole site was replaced
+ * by the fallback screen. See #365.
+ *
+ * A test that only asserted "the grid renders" would have caught the crash,
+ * and the nineteen above did. These are about the shape the fix has to keep:
+ * the filters live in the URL and nowhere else, so nothing may reintroduce a
+ * mirrored copy in component state, or an effect that writes the URL back to
+ * itself.
+ */
+describe('Home keeps the URL as its only source of truth', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    globalThis.fetch = vi.fn((requested) => Promise.resolve(fakeApi(requested)));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('mounts without throwing', async () => {
+    const onError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderHome();
+
+    await waitFor(() => expect(titles()).toHaveLength(4));
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('leaves a bare / alone instead of rewriting it on mount', async () => {
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    // The removed effect built the whole query string and wrote it on the
+    // first render, so simply arriving at the site turned the address bar
+    // into /?page=1&limit=4 before the reader had asked for anything.
+    expect(url()).toBe('/');
+  });
+
+  it('keeps a deep-linked URL byte for byte', async () => {
+    renderHome({ at: '/?genre=Poetry&maxPrice=250&page=1' });
+
+    await waitFor(() => expect(titles()).toEqual(['Low Tide']));
+    expect(url()).toBe('/?genre=Poetry&maxPrice=250&page=1');
+  });
+
+  it('undoes a filter with Back', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    await user.click(screen.getByLabelText('Poetry'));
+    await waitFor(() => expect(titles()).toEqual(['Low Tide']));
+
+    await user.click(screen.getByRole('button', { name: 'probe: back' }));
+
+    await waitFor(() => expect(url()).toBe('/'));
+    await waitFor(() => expect(titles()).toHaveLength(4));
+  });
+
+  it('follows Back through a sort as well as a filter', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    await user.selectOptions(
+      screen.getByLabelText('home.sortAriaLabel'),
+      'price_asc'
+    );
+    await waitFor(() => expect(url()).toContain('sort=price_asc'));
+
+    await user.click(screen.getByRole('button', { name: 'probe: back' }));
+
+    await waitFor(() => expect(url()).toBe('/'));
+
+    // The grid follows the URL rather than a stale copy of the sort.
+    await waitFor(() => {
+      const requested = new URL(
+        globalThis.fetch.mock.calls.at(-1)[0],
+        'http://x'
+      ).searchParams;
+      expect(requested.get('sort')).toBeNull();
+    });
+  });
+
+  it('does not re-request the catalogue when nothing changed', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await waitFor(() => expect(titles()).toHaveLength(4));
+
+    const before = globalThis.fetch.mock.calls.length;
+
+    // Re-selecting the sort that is already active is a no-op. An effect
+    // mirroring state into the URL would write it back anyway and start a
+    // fetch for the page already on screen.
+    await user.selectOptions(screen.getByLabelText('home.sortAriaLabel'), '');
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(globalThis.fetch.mock.calls.length).toBe(before);
+    expect(url()).toBe('/');
   });
 });

--- a/bookshelf-frontend/src/pages/OrderHistory.jsx
+++ b/bookshelf-frontend/src/pages/OrderHistory.jsx
@@ -16,6 +16,17 @@ export default function OrderHistory() {
       'Every order you have placed with BookShelf, with its status, contents and total.',
   });
 
+  /*
+   * The line that was missing.
+   *
+   * `useTranslation` was imported at the top of this file and `t(...)` was
+   * called three times in the markup below, but the hook was never called,
+   * so `t` was a free variable and the first JSX expression that reached it
+   * threw `ReferenceError: t is not defined` — on the first render, before
+   * anything painted. See #367.
+   */
+  const { t } = useTranslation();
+
   const { orders, loading, error, refetch } = useOrders();
 
   const orderCount = orders.length;
@@ -28,9 +39,29 @@ export default function OrderHistory() {
         <h2>{t('orderHistory.title', 'Your Order History')}</h2>
         {!loading && !error && orderCount > 0 && (
           <p className="order-history__summary" data-testid="order-history-summary">
-            {`${orderCount} ${orderCount === 1 ? 'order' : 'orders'}`} &middot;{' '}
-            {`${bookCount} ${bookCount === 1 ? 'book' : 'books'}`} &middot;{' '}
-            {`${spent} paid`}
+            {/*
+              The summary sat next to a translated heading as three untranslated
+              template literals, so the page read as half-Spanish under `es`.
+              i18next picks the singular or plural form from `count`, which is
+              also what makes this correct in languages whose plural rules are
+              not English's.
+            */}
+            {t('orderHistory.orderCount', {
+              count: orderCount,
+              defaultValue_one: '{{count}} order',
+              defaultValue_other: '{{count}} orders',
+            })}{' '}
+            &middot;{' '}
+            {t('orderHistory.bookCount', {
+              count: bookCount,
+              defaultValue_one: '{{count}} book',
+              defaultValue_other: '{{count}} books',
+            })}{' '}
+            &middot;{' '}
+            {t('orderHistory.totalPaid', {
+              amount: spent,
+              defaultValue: '{{amount}} paid',
+            })}
           </p>
         )}
       </header>
@@ -43,15 +74,18 @@ export default function OrderHistory() {
 
       {!loading && error && (
         <div className="order-history__error" role="alert">
-          <h3>We could not load your orders</h3>
-          <p>{error.message || 'Something went wrong. Please try again.'}</p>
+          <h3>{t('orderHistory.loadError', 'We could not load your orders')}</h3>
+          <p>
+            {error.message ||
+              t('common.genericError', 'Something went wrong. Please try again.')}
+          </p>
           <div className="order-history__error-actions">
             <button type="button" className="order-history__retry" onClick={refetch}>
-              {t('common.retry', 'Try again')}
+              {t('orderHistory.retry', 'Try again')}
             </button>
             {error.status === 401 && (
               <Link className="order-history__signin" to="/login?redirect=/orders">
-                {t('navbar.login', 'Sign in')}
+                {t('orderHistory.signIn', 'Sign in')}
               </Link>
             )}
           </div>

--- a/bookshelf-frontend/src/pages/OrderHistory.test.jsx
+++ b/bookshelf-frontend/src/pages/OrderHistory.test.jsx
@@ -2,9 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
+import { I18nextProvider } from 'react-i18next';
 
 import OrderHistory from './OrderHistory.jsx';
 import orderService from '../services/orderService.js';
+import { createI18nForTests } from '../test/i18nTestInstance.js';
 
 /**
  * The regression: this page read a localStorage key that nothing wrote, so it
@@ -47,11 +49,21 @@ const unpaidOrder = {
   total: 110.99,
 };
 
-function renderPage() {
+/*
+ * Rendered against a real, initialised i18next instance.
+ *
+ * Without one, `useTranslation()` returns a `t` that echoes the defaultValue
+ * and never touches the resource bundles — so a page rendering `t(...)` with
+ * no matching key, or with a plural that never resolves, looks perfectly
+ * healthy in a test and shows a raw key in the browser. See #367.
+ */
+function renderPage({ language = 'en' } = {}) {
   return render(
-    <MemoryRouter>
-      <OrderHistory />
-    </MemoryRouter>
+    <I18nextProvider i18n={createI18nForTests(language)}>
+      <MemoryRouter>
+        <OrderHistory />
+      </MemoryRouter>
+    </I18nextProvider>
   );
 }
 
@@ -223,5 +235,88 @@ describe('OrderHistory', () => {
 
     resolve([]);
     await waitFor(() => expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument());
+  });
+});
+
+/*
+ * The page threw on its first render.
+ *
+ * `useTranslation` was imported and `t(...)` was called three times in the
+ * markup, but `const { t } = useTranslation();` was not there, so `t` was a
+ * free variable and the <h2> died with `ReferenceError: t is not defined`.
+ * All 13 tests above failed on it. See #367.
+ *
+ * They would have caught the crash on their own. What they could not catch,
+ * and what these cover, is the half of the bug that survives it: the page
+ * renders untranslated template literals next to translated headings, and
+ * every test in this file used to run against an uninitialised i18next where
+ * that difference is invisible.
+ */
+describe('OrderHistory in other languages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('translates the heading', async () => {
+    orderService.getMyOrders.mockResolvedValue([paidOrder]);
+
+    renderPage({ language: 'es' });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Historial de Pedidos' })
+    ).toBeInTheDocument();
+  });
+
+  it('translates the summary line, not just the heading above it', async () => {
+    orderService.getMyOrders.mockResolvedValue([paidOrder, unpaidOrder]);
+
+    renderPage({ language: 'es' });
+
+    // "2 orders · 4 books · ₹1,058.83 paid" was three untranslated template
+    // literals sitting directly under a translated <h2>.
+    const summary = await screen.findByTestId('order-history-summary');
+    expect(summary).toHaveTextContent('2 pedidos');
+    expect(summary).toHaveTextContent('4 libros');
+    expect(summary).toHaveTextContent('pagado');
+  });
+
+  it('picks the singular form for a single order', async () => {
+    orderService.getMyOrders.mockResolvedValue([paidOrder]);
+
+    renderPage({ language: 'fr' });
+
+    const summary = await screen.findByTestId('order-history-summary');
+    expect(summary).toHaveTextContent('1 commande');
+    expect(summary).not.toHaveTextContent('1 commandes');
+  });
+
+  it('translates the error state and its actions', async () => {
+    orderService.getMyOrders.mockRejectedValue({
+      status: 401,
+      message: 'Session expired',
+    });
+
+    renderPage({ language: 'fr' });
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Nous n’avons pas pu charger vos commandes'
+    );
+    expect(
+      screen.getByRole('button', { name: 'Réessayer' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Se connecter' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders no raw translation keys', async () => {
+    orderService.getMyOrders.mockResolvedValue([paidOrder, unpaidOrder]);
+
+    const { container } = renderPage({ language: 'es' });
+    await screen.findByText('Order #B9C0D1');
+
+    // A key that does not resolve renders as its own name. Cheap to assert
+    // once, and it covers every string on the page at the same time.
+    expect(container.textContent).not.toMatch(/\b(orderHistory|common)\.[a-zA-Z]/);
   });
 });

--- a/bookshelf-frontend/src/pages/Profile.jsx
+++ b/bookshelf-frontend/src/pages/Profile.jsx
@@ -3,17 +3,169 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { useAuth } from '../hooks/useAuth.js';
-import './Auth.css';
+import { useWishlist } from '../hooks/useWishlist.js';
+import { useOrders } from '../hooks/useOrders.js';
 import { usePageMetadata } from '../hooks/usePageMetadata.js';
+import ReadingGoalRing from '../components/ReadingGoalRing.jsx';
+import ReadingStreak from '../components/ReadingStreak.jsx';
+import RecentlyViewed from '../components/RecentlyViewed.jsx';
+import FavoriteBooks from '../components/FavoriteBooks.jsx';
 
-const Profile = () => {
+/*
+ * Profile.css, not Auth.css.
+ *
+ * The stylesheet import was the quiet half of #366: a merge kept this page's
+ * 350 lines of reading-portal markup and took the top of the file from the
+ * version before the portal existed, when this was a plain account form
+ * styled by Auth.css. Every class the markup below uses — profile-page,
+ * profile-tabs, profile-stat-card and the rest — is defined here.
+ */
+import './Profile.css';
+
+const LOCAL_STORAGE_KEY = 'bookshelf_user_profile';
+const ALL_GENRES = ['Fiction', 'Non-Fiction', 'Mystery', 'Sci-Fi', 'Fantasy', 'Romance', 'Biography', 'History'];
+const AVATAR_OPTIONS = ['📖', '🦉', '🧙‍♂️', '📚', '✍️', '🌟', '🚀', '☕'];
+
+/**
+ * The reader's account page: overview, goals, favourites and settings.
+ *
+ * Everything below the banner reads state that this component owns. That is
+ * worth saying plainly, because the state layer was missing entirely on main
+ * — the JSX survived a merge and the twenty-odd declarations feeding it did
+ * not, so the page threw `ReferenceError: profileData is not defined` on its
+ * first render and every signed-in reader got the ErrorBoundary fallback
+ * instead of their account. See #366.
+ */
+export default function Profile() {
   usePageMetadata({
     title: 'Your profile',
-    description:
-      'Your BookShelf account details.',
+    description: 'Your BookShelf account details, reading goals and preferences.',
   });
 
-  const { user } = useAuth();
+  const { t } = useTranslation();
+  const { user, logout } = useAuth();
+  const { count: wishlistCount } = useWishlist();
+  const { orders = [] } = useOrders();
+  const navigate = useNavigate();
+
+  const [activeTab, setActiveTab] = useState('overview');
+
+  /*
+   * The customisation the reader has chosen, kept in localStorage.
+   *
+   * Read inside the initialiser rather than in an effect so the first paint
+   * already shows the saved avatar and bio instead of the defaults. The
+   * try/catch is not decoration: a hand-edited or half-written value would
+   * otherwise throw out of the initialiser, which React does not recover
+   * from.
+   */
+  const [profileData, setProfileData] = useState(() => {
+    try {
+      const saved = localStorage.getItem(LOCAL_STORAGE_KEY);
+      if (saved) return JSON.parse(saved);
+    } catch (err) {
+      console.error('Failed to parse profile data:', err);
+    }
+    return {
+      bio: 'A room without books is like a body without a soul.',
+      annualGoal: 24,
+      avatar: '📖',
+      preferredGenres: ['Fiction', 'Mystery', 'Sci-Fi'],
+    };
+  });
+
+  // Settings form, held separately from profileData so an unsaved edit can be
+  // abandoned by navigating away rather than being committed as it is typed.
+  const [formName, setFormName] = useState(user?.name || 'Reader');
+  const [formBio, setFormBio] = useState(profileData.bio);
+  const [formGoal, setFormGoal] = useState(profileData.annualGoal);
+  const [formAvatar, setFormAvatar] = useState(profileData.avatar);
+  const [formGenres, setFormGenres] = useState(profileData.preferredGenres);
+
+  // Security form.
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+
+  // Transient confirmations, cleared on a timer.
+  const [saveMessage, setSaveMessage] = useState(null);
+  const [securityMessage, setSecurityMessage] = useState(null);
+
+  /*
+   * The name box is seeded from `user`, which arrives asynchronously — the
+   * session is restored by a GET /api/auth/me after the first render, so the
+   * initialiser above usually runs while `user` is still null.
+   */
+  useEffect(() => {
+    if (user?.name) {
+      setFormName(user.name);
+    }
+  }, [user]);
+
+  const handleSaveProfile = (e) => {
+    e.preventDefault();
+
+    const updated = {
+      ...profileData,
+      bio: formBio,
+      annualGoal: Number(formGoal) || 20,
+      avatar: formAvatar,
+      preferredGenres: formGenres,
+    };
+
+    setProfileData(updated);
+
+    try {
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updated));
+    } catch (err) {
+      // A full or disabled store must not lose the edit from the screen.
+      console.error('Failed to save profile to localStorage:', err);
+    }
+
+    setSaveMessage(t('profile.updateSuccess', 'Profile updated successfully!'));
+    setTimeout(() => setSaveMessage(null), 4000);
+  };
+
+  const handleUpdatePassword = (e) => {
+    e.preventDefault();
+
+    if (!currentPassword || !newPassword) {
+      setSecurityMessage({ type: 'error', text: 'Please fill out both password fields.' });
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setSecurityMessage({ type: 'error', text: 'New password must be at least 8 characters long.' });
+      return;
+    }
+
+    setSecurityMessage({
+      type: 'success',
+      text: t('profile.security.passwordSuccess', 'Password updated successfully!'),
+    });
+    setCurrentPassword('');
+    setNewPassword('');
+    setTimeout(() => setSecurityMessage(null), 4000);
+  };
+
+  const toggleGenre = (genre) => {
+    if (formGenres.includes(genre)) {
+      setFormGenres(formGenres.filter((g) => g !== genre));
+    } else {
+      setFormGenres([...formGenres, genre]);
+    }
+  };
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/login');
+  };
+
+  // Placeholder reading stats. There is no endpoint behind these yet; they
+  // are constants so the overview tab has something to lay out.
+  const booksReadCount = 18;
+  const pagesReadCount = 5840;
+  const readingHoursCount = 96;
+
 
   return (
     <main className="profile-page">

--- a/bookshelf-frontend/src/pages/Profile.test.jsx
+++ b/bookshelf-frontend/src/pages/Profile.test.jsx
@@ -149,3 +149,159 @@ describe('Profile Page (Reading Portal)', () => {
     expect(navigate).toHaveBeenCalledWith('/login');
   });
 });
+
+/*
+ * The page did not render at all on main.
+ *
+ * A merge kept the 350 lines of reading-portal JSX and took the top of the
+ * file from the version before the portal existed, so every declaration the
+ * markup reads — profileData, formName, activeTab, handleLogout, t and
+ * seventeen others — was gone, along with six imports and the Profile.css
+ * that styles all of it. `ReferenceError: profileData is not defined` on the
+ * first render, ErrorBoundary fallback for every signed-in reader. See #366.
+ *
+ * The six tests above cover the happy paths and would have caught the crash
+ * on their own. These are the parts of the restored state layer they do not
+ * reach: persistence across a remount, the corrupt-store path, the late
+ * session, and the second password rule.
+ */
+describe('Profile state layer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('names the page for the browser tab', () => {
+    renderProfile();
+
+    // usePageMetadata was added on the broken side of the merge; it has to
+    // survive the restore rather than be reverted with the rest of the head.
+    expect(document.title).toBe('Your profile — BookShelf');
+  });
+
+  it('reads the saved profile back on a fresh mount', async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderProfile();
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+
+    const bio = screen.getByPlaceholderText(/share your reading motto/i);
+    await user.clear(bio);
+    await user.type(bio, 'Two chapters before bed.');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await screen.findByText(/profile updated successfully!/i);
+    unmount();
+
+    // The initialiser reads localStorage rather than an effect doing it after
+    // the first paint, so the saved bio is on screen from the first render.
+    renderProfile();
+    expect(screen.getByText('"Two chapters before bed."')).toBeInTheDocument();
+  });
+
+  it('falls back to the defaults when the stored profile is unreadable', () => {
+    localStorage.setItem('bookshelf_user_profile', '{ not json');
+    const onError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderProfile();
+
+    // A throw out of a useState initialiser is not recoverable, so the parse
+    // has to be guarded rather than left to the ErrorBoundary.
+    expect(screen.getByText('Jane Reader')).toBeInTheDocument();
+    expect(
+      screen.getByText('"A room without books is like a body without a soul."')
+    ).toBeInTheDocument();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('seeds the name box when the session arrives after the first render', async () => {
+    const user = userEvent.setup();
+    // GET /api/auth/me resolves after mount, so `user` is null on the render
+    // that initialises the form.
+    const { rerender } = renderProfile(null);
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+    expect(screen.getByLabelText(/full name/i)).toHaveValue('Reader');
+
+    rerender(
+      <MemoryRouter>
+        <AuthContext.Provider
+          value={{
+            user: { name: 'Jane Reader', email: 'jane@example.com', role: 'Member' },
+            isAuthenticated: true,
+            loading: false,
+            logout: vi.fn(),
+            login: vi.fn(),
+            register: vi.fn(),
+            checkAuth: vi.fn(),
+          }}
+        >
+          <WishlistContext.Provider
+            value={{
+              wishlist: ['b1', 'b2'],
+              loading: false,
+              count: 2,
+              isWishlisted: () => true,
+              toggleWishlist: vi.fn(),
+            }}
+          >
+            <Profile />
+          </WishlistContext.Provider>
+        </AuthContext.Provider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/full name/i)).toHaveValue('Jane Reader')
+    );
+  });
+
+  it('rejects a new password shorter than eight characters', async () => {
+    const user = userEvent.setup();
+    renderProfile();
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+
+    await user.type(screen.getByLabelText(/current password/i), 'oldsecret1');
+    await user.type(screen.getByLabelText(/new password/i), 'short');
+    await user.click(screen.getByRole('button', { name: /update password/i }));
+
+    expect(
+      await screen.findByText(/at least 8 characters long/i)
+    ).toBeInTheDocument();
+  });
+
+  it('persists the genres the reader picks', async () => {
+    const user = userEvent.setup();
+    renderProfile();
+
+    await user.click(screen.getByRole('button', { name: /⚙️ Account Settings/i }));
+
+    // Fiction is on by default, so this removes it; Fantasy is not, so this
+    // adds it. Both directions go through the same toggle.
+    await user.click(screen.getByRole('button', { name: /^Fiction/ }));
+    await user.click(screen.getByRole('button', { name: /^Fantasy/ }));
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await screen.findByText(/profile updated successfully!/i);
+
+    const stored = JSON.parse(localStorage.getItem('bookshelf_user_profile'));
+    expect(stored.preferredGenres).not.toContain('Fiction');
+    expect(stored.preferredGenres).toContain('Fantasy');
+  });
+
+  it('shows the wishlist count from context rather than a copy of it', async () => {
+    const user = userEvent.setup();
+    renderProfile();
+
+    await user.click(
+      screen.getByRole('button', { name: /📖 My Activity/i })
+    );
+
+    // Straight from WishlistContext. The library tab is the only place the
+    // restored `useWishlist()` call is visible, so it is the only test that
+    // would notice if the import went missing again.
+    expect(screen.getByText('💖 Wishlist (2)')).toBeInTheDocument();
+    expect(screen.getByText(/You currently have 2 books saved/)).toBeInTheDocument();
+  });
+});

--- a/bookshelf-frontend/src/pages/WishlistPage.jsx
+++ b/bookshelf-frontend/src/pages/WishlistPage.jsx
@@ -15,6 +15,16 @@ export default function WishlistPage() {
       'The books you have saved to read or buy later, from the BookShelf catalogue.',
   });
 
+  /*
+   * The line that was missing.
+   *
+   * `useTranslation` was imported and `t(...)` was called four times in the
+   * markup, but the hook was never called. `t` was a free variable, so the
+   * <h1> threw `ReferenceError: t is not defined` on the first render and the
+   * ErrorBoundary took the page. Same omission as OrderHistory. See #367.
+   */
+  const { t } = useTranslation();
+
   const { toggleWishlist } = useWishlist();
   const { books, missingIds, failedIds, loading, error } = useWishlistBooks();
   const navigate = useNavigate();
@@ -31,7 +41,13 @@ export default function WishlistPage() {
         <header className="wishlist-page__header">
           <h1 className="wishlist-page__title">{t('wishlist.title', 'Your Wishlist')}</h1>
           <p className="wishlist-page__subtitle">
-            {loading ? t('common.loading', 'Loading…') : `${count} ${count === 1 ? 'item' : 'items'}`}
+            {loading
+              ? t('common.loading', 'Loading…')
+              : t('wishlist.itemCount', {
+                  count,
+                  defaultValue_one: '{{count}} item',
+                  defaultValue_other: '{{count}} items',
+                })}
           </p>
         </header>
 
@@ -43,24 +59,34 @@ export default function WishlistPage() {
 
         {!loading && error && (
           <div className="wishlist-page__error" role="alert">
-            <h2>We could not load your wishlist</h2>
-            <p>{error.message || 'Something went wrong. Please try again.'}</p>
+            <h2>{t('wishlist.loadError', 'We could not load your wishlist')}</h2>
+            <p>
+              {error.message ||
+                t('common.genericError', 'Something went wrong. Please try again.')}
+            </p>
           </div>
         )}
 
         {!loading && !error && missingIds.length > 0 && (
           <div className="wishlist-page__notice" role="status">
             <p>
-              {missingIds.length === 1
-                ? '1 saved book is no longer in the catalogue.'
-                : `${missingIds.length} saved books are no longer in the catalogue.`}
+              {t('wishlist.missingNotice', {
+                count: missingIds.length,
+                defaultValue_one: '{{count}} saved book is no longer in the catalogue.',
+                defaultValue_other:
+                  '{{count}} saved books are no longer in the catalogue.',
+              })}
             </p>
             <button
               type="button"
               className="wishlist-page__notice-btn"
               onClick={removeMissing}
             >
-              Remove {missingIds.length === 1 ? 'it' : 'them'} from my wishlist
+              {t('wishlist.removeMissing', {
+                count: missingIds.length,
+                defaultValue_one: 'Remove it from my wishlist',
+                defaultValue_other: 'Remove them from my wishlist',
+              })}
             </button>
           </div>
         )}
@@ -68,9 +94,13 @@ export default function WishlistPage() {
         {!loading && !error && failedIds.length > 0 && (
           <div className="wishlist-page__notice wishlist-page__notice--warning" role="status">
             <p>
-              {failedIds.length === 1
-                ? '1 saved book could not be loaded just now. It has not been removed.'
-                : `${failedIds.length} saved books could not be loaded just now. They have not been removed.`}
+              {t('wishlist.failedNotice', {
+                count: failedIds.length,
+                defaultValue_one:
+                  '{{count}} saved book could not be loaded just now. It has not been removed.',
+                defaultValue_other:
+                  '{{count}} saved books could not be loaded just now. They have not been removed.',
+              })}
             </p>
           </div>
         )}

--- a/bookshelf-frontend/src/pages/WishlistPage.test.jsx
+++ b/bookshelf-frontend/src/pages/WishlistPage.test.jsx
@@ -2,10 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
+import { I18nextProvider } from 'react-i18next';
 
 import WishlistPage from './WishlistPage.jsx';
 import { WishlistContext } from '../context/WishlistContext.jsx';
 import * as bookService from '../services/bookService.js';
+import { createI18nForTests } from '../test/i18nTestInstance.js';
 
 /**
  * The regression: this page filtered `src/data/books.js`, a hardcoded copy of
@@ -59,7 +61,17 @@ const fieldNotes = {
   genre: 'Nonfiction',
 };
 
-function renderPage({ wishlist = [], loading = false, toggleWishlist = vi.fn() } = {}) {
+/*
+ * As in OrderHistory.test.jsx: a real i18next instance, so a key that does
+ * not resolve shows up as a failing assertion rather than as the literal
+ * default the uninitialised `t` hands back. See #367.
+ */
+function renderPage({
+  wishlist = [],
+  loading = false,
+  toggleWishlist = vi.fn(),
+  language = 'en',
+} = {}) {
   const value = {
     wishlist,
     loading,
@@ -69,11 +81,13 @@ function renderPage({ wishlist = [], loading = false, toggleWishlist = vi.fn() }
   };
 
   return render(
-    <MemoryRouter>
-      <WishlistContext.Provider value={value}>
-        <WishlistPage />
-      </WishlistContext.Provider>
-    </MemoryRouter>
+    <I18nextProvider i18n={createI18nForTests(language)}>
+      <MemoryRouter>
+        <WishlistContext.Provider value={value}>
+          <WishlistPage />
+        </WishlistContext.Provider>
+      </MemoryRouter>
+    </I18nextProvider>
   );
 }
 
@@ -208,5 +222,106 @@ describe('WishlistPage', () => {
     renderPage({ wishlist: ['b1', 's3'] });
 
     await waitFor(() => expect(screen.getByText('1 item')).toBeInTheDocument());
+  });
+});
+
+/*
+ * Same omission as OrderHistory, same first render, same crash:
+ * `useTranslation` imported, `t(...)` called four times, the hook never
+ * called. All 9 tests above failed with `ReferenceError: t is not defined`.
+ * See #367.
+ *
+ * These cover the strings the page was still building by hand next to the
+ * translated ones — the item count and the three notices.
+ */
+describe('WishlistPage in other languages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('translates the heading and the item count together', async () => {
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [quietOnes, fieldNotes],
+      missingIds: [],
+      failedIds: [],
+    });
+
+    renderPage({ wishlist: ['b1', 'b2'], language: 'es' });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Mi Lista de Deseos' })
+    ).toBeInTheDocument();
+    // The count was `${count} items`, a template literal, directly under it.
+    expect(screen.getByText('2 artículos')).toBeInTheDocument();
+  });
+
+  it('picks the singular form for one item', async () => {
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [quietOnes],
+      missingIds: [],
+      failedIds: [],
+    });
+
+    renderPage({ wishlist: ['b1'], language: 'fr' });
+
+    expect(await screen.findByText('1 article')).toBeInTheDocument();
+  });
+
+  it('translates the stale-id notice and its button', async () => {
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [quietOnes],
+      missingIds: ['s3', 's4'],
+      failedIds: [],
+    });
+
+    renderPage({ wishlist: ['b1', 's3', 's4'], language: 'es' });
+
+    expect(
+      await screen.findByText('2 libros guardados ya no están en el catálogo.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Quitarlos de mi lista de deseos' })
+    ).toBeInTheDocument();
+  });
+
+  it('translates the could-not-load notice', async () => {
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [quietOnes],
+      missingIds: [],
+      failedIds: ['b9'],
+    });
+
+    renderPage({ wishlist: ['b1', 'b9'], language: 'fr' });
+
+    expect(
+      await screen.findByText(/n’a pas pu être chargé pour le moment/)
+    ).toBeInTheDocument();
+  });
+
+  it('translates the empty state', async () => {
+    renderPage({ wishlist: [], language: 'es' });
+
+    expect(
+      await screen.findByText('Tu lista de deseos está vacía')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Explorar Catálogo' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders no raw translation keys', async () => {
+    bookService.getBooksByIds.mockResolvedValue({
+      books: [quietOnes],
+      missingIds: ['s3'],
+      failedIds: ['b9'],
+    });
+
+    const { container } = renderPage({
+      wishlist: ['b1', 's3', 'b9'],
+      language: 'fr',
+    });
+    await screen.findByText('The Quiet Ones');
+
+    expect(container.textContent).not.toMatch(/\b(wishlist|common)\.[a-zA-Z]/);
   });
 });

--- a/bookshelf-frontend/src/test/i18nTestInstance.js
+++ b/bookshelf-frontend/src/test/i18nTestInstance.js
@@ -1,0 +1,48 @@
+import i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import en from '../locales/en.json';
+import es from '../locales/es.json';
+import fr from '../locales/fr.json';
+
+/**
+ * A real, initialised i18next instance for tests.
+ *
+ * The app initialises i18n as a side effect of `import './i18n.js'` in
+ * `main.jsx`, and nothing under test imports `main.jsx`. So every test that
+ * rendered a translated page rendered it against an *uninitialised*
+ * instance, where `useTranslation()` hands back a `t` that returns the
+ * literal `defaultValue` and ignores the resource bundles entirely.
+ *
+ * That is why a page could go out rendering `wishlist.itemCount` as text and
+ * no test would notice — and why the `t is not defined` crash in #367 got
+ * past the suite as far as it did. It also means plurals and interpolation
+ * silently do nothing, because both are features of the initialised
+ * instance.
+ *
+ * This is a separate instance rather than a change to `setupTests.js` on
+ * purpose. A global init would change the strings every existing test sees,
+ * whether or not that test is about translation. Tests opt in by wrapping in
+ * the provider below, and get the real bundles when they do.
+ */
+export function createI18nForTests(language = 'en') {
+  const instance = i18next.createInstance();
+
+  instance.use(initReactI18next).init({
+    lng: language,
+    fallbackLng: 'en',
+    resources: {
+      en: { translation: en },
+      es: { translation: es },
+      fr: { translation: fr },
+    },
+    interpolation: { escapeValue: false },
+    // A missing key should be visible in a test run, not swallowed.
+    saveMissing: false,
+    react: { useSuspense: false },
+  });
+
+  return instance;
+}
+
+export default createI18nForTests;

--- a/bookshelf-frontend/src/utils/pagination.js
+++ b/bookshelf-frontend/src/utils/pagination.js
@@ -1,0 +1,136 @@
+/**
+ * Which page numbers a pager should show.
+ *
+ * `Pagination` built its list with
+ *
+ *     for (let i = 1; i <= totalPages; i++) pages.push(i);
+ *
+ * which is fine while the catalogue is a fixed 16 titles and four pages. It
+ * stops being fine the moment the catalogue grows — the admin CRUD endpoints
+ * added in #364 mean it can — because the control is then a block of numbers
+ * taller than the grid above it, every one of them re-rendering on every page
+ * change. See #369.
+ *
+ * The arithmetic lives here rather than in the component because it is the
+ * part with edge cases: the first pages, the last pages, a window wider than
+ * the whole range, and the two places where an ellipsis would replace exactly
+ * one number and should not. None of that needs a DOM to be checked.
+ */
+
+/** Marker for a skipped run. Not a number, so a caller cannot render it as one. */
+export const ELLIPSIS = 'ellipsis';
+
+/** Pages either side of the current one. 1 gives `4 [5] 6`. */
+export const DEFAULT_SIBLINGS = 1;
+
+/** Pages pinned at each end. 1 gives `1 … 4 [5] 6 … 50`. */
+export const DEFAULT_BOUNDARIES = 1;
+
+function toPositiveInteger(value, fallback) {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function range(from, to) {
+  const out = [];
+
+  for (let page = from; page <= to; page += 1) {
+    out.push(page);
+  }
+
+  return out;
+}
+
+/**
+ * Bring a page number into `1..totalPages`.
+ *
+ * `?page=7` on a three-page result set is a URL a reader can type, and the
+ * API answers a page past the end with an empty slice rather than an error —
+ * so without this the symptom is a blank grid under a pager that still
+ * offers Next.
+ */
+export function clampPage(page, totalPages) {
+  const total = toPositiveInteger(totalPages, 1);
+  const wanted = toPositiveInteger(page, 1);
+
+  return Math.min(wanted, total);
+}
+
+/**
+ * The page list to render, as numbers and `ELLIPSIS` markers.
+ *
+ * The window is held to a fixed width as it runs into either end, so the
+ * control does not shrink on page 1 and grow again in the middle. The
+ * boundary cases still vary by one entry — `[1 … 47 48 49 50]` against
+ * `[1 … 4 5 6 … 50]` — because the far ellipsis has nothing left to hide.
+ *
+ * An ellipsis is only used where it actually saves something. Replacing a
+ * single skipped page with `…` costs the reader a click and saves no space,
+ * so that case renders the number instead — which is why `[1, 2, 3, …]`
+ * appears rather than `[1, …, 3, …]`.
+ */
+export function pageWindow({
+  currentPage = 1,
+  totalPages = 1,
+  siblings = DEFAULT_SIBLINGS,
+  boundaries = DEFAULT_BOUNDARIES,
+} = {}) {
+  const total = toPositiveInteger(totalPages, 1);
+  const current = clampPage(currentPage, total);
+  const sibling = Math.max(0, Number.isInteger(siblings) ? siblings : DEFAULT_SIBLINGS);
+  const boundary = Math.max(1, Number.isInteger(boundaries) ? boundaries : DEFAULT_BOUNDARIES);
+
+  // Widest the control can ever be: both boundaries, both ellipses, the
+  // current page and its siblings. Below this, showing everything is both
+  // shorter and easier to use.
+  const maxEntries = boundary * 2 + sibling * 2 + 3;
+
+  if (total <= maxEntries) {
+    return range(1, total);
+  }
+
+  const start = Math.max(current - sibling, boundary + 1);
+  const end = Math.min(current + sibling, total - boundary);
+
+  // Keep the window the same width when it runs into either end, so the
+  // control does not shrink on page 1 and grow again in the middle.
+  const windowSize = sibling * 2 + 1;
+  const shiftedStart = Math.max(boundary + 1, Math.min(start, total - boundary - windowSize + 1));
+  const shiftedEnd = Math.min(total - boundary, Math.max(end, boundary + windowSize));
+
+  const head = range(1, boundary);
+  const middle = range(shiftedStart, shiftedEnd);
+  const tail = range(total - boundary + 1, total);
+
+  const pages = [...head];
+
+  // gap of exactly one -> render the number; more than one -> an ellipsis.
+  const leftGap = shiftedStart - boundary - 1;
+
+  if (leftGap === 1) {
+    pages.push(boundary + 1);
+  } else if (leftGap > 1) {
+    pages.push(ELLIPSIS);
+  }
+
+  pages.push(...middle);
+
+  const rightGap = total - boundary - shiftedEnd;
+
+  if (rightGap === 1) {
+    pages.push(shiftedEnd + 1);
+  } else if (rightGap > 1) {
+    pages.push(ELLIPSIS);
+  }
+
+  pages.push(...tail);
+
+  return pages;
+}
+
+export default { ELLIPSIS, DEFAULT_SIBLINGS, DEFAULT_BOUNDARIES, clampPage, pageWindow };

--- a/bookshelf-frontend/src/utils/pagination.test.js
+++ b/bookshelf-frontend/src/utils/pagination.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+
+import { ELLIPSIS, clampPage, pageWindow } from './pagination.js';
+
+/**
+ * The window is the part with the edge cases, so it is the part that gets
+ * enumerated rather than sampled: both ends, the middle, the boundary where
+ * the ellipsis first appears, and the two places where a gap of exactly one
+ * page must render as a number instead. See #369.
+ */
+describe('clampPage', () => {
+  it('leaves a page inside the range alone', () => {
+    expect(clampPage(3, 10)).toBe(3);
+  });
+
+  it('brings a page past the end back to the last one', () => {
+    // The reported case: a hand-typed ?page=7 on a three-page result set.
+    // The API answers with an empty slice rather than an error, so nothing
+    // else in the chain notices.
+    expect(clampPage(7, 3)).toBe(3);
+  });
+
+  it('treats anything that is not a page number as page 1', () => {
+    expect(clampPage(0, 10)).toBe(1);
+    expect(clampPage(-4, 10)).toBe(1);
+    expect(clampPage(2.5, 10)).toBe(1);
+    expect(clampPage(undefined, 10)).toBe(1);
+    expect(clampPage(NaN, 10)).toBe(1);
+    expect(clampPage('sideways', 10)).toBe(1);
+  });
+
+  it('accepts a numeric string, because that is what a URL holds', () => {
+    // The page number reaches Home through useSearchParams, where every
+    // value is a string. Rejecting '3' would send a reader on ?page=3 to
+    // page 1.
+    expect(clampPage('3', 10)).toBe(3);
+    expect(clampPage('30', 10)).toBe(10);
+  });
+
+  it('survives a nonsense total', () => {
+    expect(clampPage(5, 0)).toBe(1);
+    expect(clampPage(5, undefined)).toBe(1);
+  });
+});
+
+describe('pageWindow', () => {
+  it('shows every page while they still fit', () => {
+    expect(pageWindow({ currentPage: 1, totalPages: 4 })).toEqual([1, 2, 3, 4]);
+    expect(pageWindow({ currentPage: 4, totalPages: 7 })).toEqual([
+      1, 2, 3, 4, 5, 6, 7,
+    ]);
+  });
+
+  it('starts eliding one page past the point where it saves anything', () => {
+    // Seven fit; eight do not. The 8-page case is the first that gains from
+    // an ellipsis, and it gains exactly one slot.
+    expect(pageWindow({ currentPage: 1, totalPages: 7 })).toHaveLength(7);
+    expect(pageWindow({ currentPage: 1, totalPages: 8 })).toEqual([
+      1, 2, 3, 4, ELLIPSIS, 8,
+    ]);
+  });
+
+  it('elides on the right at the start of a long range', () => {
+    expect(pageWindow({ currentPage: 1, totalPages: 50 })).toEqual([
+      1, 2, 3, 4, ELLIPSIS, 50,
+    ]);
+  });
+
+  it('elides on both sides in the middle', () => {
+    expect(pageWindow({ currentPage: 25, totalPages: 50 })).toEqual([
+      1, ELLIPSIS, 24, 25, 26, ELLIPSIS, 50,
+    ]);
+  });
+
+  it('elides on the left at the end of a long range', () => {
+    expect(pageWindow({ currentPage: 50, totalPages: 50 })).toEqual([
+      1, ELLIPSIS, 47, 48, 49, 50,
+    ]);
+  });
+
+  it('renders a gap of exactly one page as that page', () => {
+    // 1 … 3 4 5 … 50 would hide a single number behind an ellipsis, which
+    // costs a click and saves no width.
+    expect(pageWindow({ currentPage: 4, totalPages: 50 })).toEqual([
+      1, 2, 3, 4, 5, ELLIPSIS, 50,
+    ]);
+    expect(pageWindow({ currentPage: 47, totalPages: 50 })).toEqual([
+      1, ELLIPSIS, 46, 47, 48, 49, 50,
+    ]);
+  });
+
+  it('holds the control to a stable width across a long range', () => {
+    const widths = [];
+
+    for (let page = 1; page <= 50; page += 1) {
+      widths.push(pageWindow({ currentPage: page, totalPages: 50 }).length);
+    }
+
+    // The whole point: 50 pages must not mean 50 buttons, and the row must
+    // not visibly resize as the reader walks through it.
+    expect(Math.max(...widths)).toBeLessThanOrEqual(7);
+    expect(Math.min(...widths)).toBeGreaterThanOrEqual(6);
+  });
+
+  it('never repeats a page and never drops out of order', () => {
+    for (const total of [8, 9, 12, 50, 137]) {
+      for (let page = 1; page <= total; page += 1) {
+        const numbers = pageWindow({ currentPage: page, totalPages: total }).filter(
+          (entry) => entry !== ELLIPSIS
+        );
+
+        expect(new Set(numbers).size).toBe(numbers.length);
+        expect([...numbers].sort((a, b) => a - b)).toEqual(numbers);
+        // The current page is the one the reader needs to see marked.
+        expect(numbers).toContain(page);
+        // Both ends stay reachable in one click, whatever the range.
+        expect(numbers).toContain(1);
+        expect(numbers).toContain(total);
+      }
+    }
+  });
+
+  it('never places an ellipsis at either end or two in a row', () => {
+    for (const total of [8, 20, 50]) {
+      for (let page = 1; page <= total; page += 1) {
+        const entries = pageWindow({ currentPage: page, totalPages: total });
+
+        expect(entries[0]).toBe(1);
+        expect(entries.at(-1)).toBe(total);
+
+        entries.forEach((entry, index) => {
+          if (entry === ELLIPSIS) {
+            expect(entries[index + 1]).not.toBe(ELLIPSIS);
+          }
+        });
+      }
+    }
+  });
+
+  it('widens with more siblings', () => {
+    expect(pageWindow({ currentPage: 25, totalPages: 50, siblings: 2 })).toEqual([
+      1, ELLIPSIS, 23, 24, 25, 26, 27, ELLIPSIS, 50,
+    ]);
+  });
+
+  it('handles a current page outside the range', () => {
+    // Clamped, so the last page is what is marked rather than nothing at all.
+    expect(pageWindow({ currentPage: 99, totalPages: 5 })).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('survives being called with nothing', () => {
+    expect(pageWindow()).toEqual([1]);
+    expect(pageWindow({ totalPages: 0 })).toEqual([1]);
+  });
+});


### PR DESCRIPTION
Closes #368.

> **Step 5 of a five-PR stack**, on top of #373, #372, #370 and #371 — in that order. This PR adds a CI gate that those four are what make passable, so it carries them. Once they land, the diff here collapses to the six files listed at the bottom; review those. Every pair of the five was checked with `git merge-tree --write-tree` — no conflicts in either direction.

## Two checks that looked like they were guarding `main`, and were not

### `npm run build` was failing

```
src/components/Footer.jsx:94:0: ERROR: Unexpected "}"
```

A closing brace after the component's own, left by the i18n pass in `3ebe868`. Nothing in `bookshelf-frontend` bundled — no production build, no deploy preview — and the `npm run build --if-present` step in CI has been red on every push and PR since. It stayed invisible because `Footer` has no test file and the suites that would reach it stub it out, so `npm test` was green on a tree that could not be built.

### `npm run lint` was checking nothing

The script was `eslint .`. On ESLint 8 with an `.eslintrc` config, a bare directory only picks up files ending in `.js`. The run covered the 50 files under `hooks`, `utils`, `services` and `config` — and not one `.jsx`. Every component and every page in the project was invisible to it.

The config already had the rule that mattered. `eslint:recommended` turns on `no-undef`. Run with the flag against the tree as it stood:

```
$ npx eslint . --ext .js,.jsx
✖ 46 problems (43 errors, 3 warnings)
```

43 `no-undef` errors, all of them in the four pages that crash on `main` — #365, #366, #367. Each of those regressions was one `npm run lint` away from being caught before it was pushed.

And nothing ran lint in CI anyway. `node.js.yml` runs `npm ci`, build and test only.

## What this changes

| | |
| --- | --- |
| `Footer.jsx` | the stray brace goes; the project builds |
| `package.json` | `"lint": "eslint . --ext .js,.jsx"` |
| `node.js.yml` | `npm run lint --if-present`, **before** the build — it is cheaper, and it catches what the build cannot. `vite` will happily bundle a component whose body reads an identifier that does not exist; that is valid JavaScript to a bundler and a `ReferenceError` at render. `--if-present` because `bookshelf-backend` has no lint script yet. |
| `.eslintrc.cjs` | `react/no-unescaped-entities` off; `no-unused-vars` stays a warning |

Two rule decisions, both stated in the config with their reasons:

- **`react/no-unescaped-entities` off.** It fires 45 times, every one a literal `"` or `'` inside a paragraph of prose on the three policy pages. React renders those correctly. The rule is for hand-written JSX where a stray quote might have been a delimiter, which a terms-of-service page is not. Escaping 45 quotes would make that prose unreadable in source to keep a linter quiet.
- **`no-unused-vars` stays `warn`.** 57 of them, mostly imports left by earlier refactors. Worth clearing, but that is a change of its own — promoting them now would mean either a large unrelated diff or a blanket suppression, and neither is what this gate is for.

## Two unresolvable imports the run turned up

Neither is currently reachable, which is exactly why they survived:

- `BookCarousel.jsx` imported `'../BookCard/BookCard'`. There is no `components/BookCard/` directory; the card is `components/BookCard.jsx`, a sibling. Nothing imports `BookCarousel`, so the bundler never had to resolve the specifier — the first page to use the carousel would have failed the build.
- `Bookstartent.jsx` imported `'./FavoriteCategories.css'`. The stylesheet is `Bookstartent.css`: the component and its CSS were renamed together and the import was not. Its header comment still reads `FavoriteCategories.css` and all ten rules in it are `.favorite-categories` ones — the right file under the wrong name, not a missing one.

## Verification

```
$ cd bookshelf-frontend
$ npm run lint   # 0 errors, 57 warnings, exit 0
$ npm run build  # ✓ built in 2.64s
$ npm test       # 44 files, 720 tests passed
$ cd ../bookshelf-backend && npm test   # 477 tests, 0 failed
```

## Files this PR actually changes

- `.github/workflows/node.js.yml`
- `bookshelf-frontend/.eslintrc.cjs`
- `bookshelf-frontend/package.json`
- `bookshelf-frontend/src/components/Footer.jsx`
- `bookshelf-frontend/src/components/BookCarousel.jsx`
- `bookshelf-frontend/src/Bookstartent.jsx`
