### PR TITLE
feat: add ReadingTimer component

### DIFF
--- a/bookshelf-frontend/src/components/ReadingTimer.css
+++ b/bookshelf-frontend/src/components/ReadingTimer.css
@@ -1,0 +1,446 @@
+*,
+*::before,
+*::after{
+  box-sizing:border-box;
+}
+
+.reading-timer{
+  width:100%;
+  max-width:460px;
+  padding:22px;
+  border:1px solid #e5e7eb;
+  border-radius:20px;
+  background:#fff;
+  color:#111827;
+  box-shadow:0 8px 24px rgba(0,0,0,.08);
+  transition:
+    transform .25s ease,
+    box-shadow .25s ease,
+    border-color .25s ease;
+}
+
+.reading-timer:hover{
+  transform:translateY(-3px);
+  box-shadow:0 15px 34px rgba(0,0,0,.12);
+}
+
+/* Header */
+
+.reading-timer__header{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:14px;
+}
+
+.reading-timer__eyebrow{
+  margin:0 0 4px;
+  color:#9ca3af;
+  font-size:11px;
+  font-weight:800;
+  letter-spacing:.06em;
+  text-transform:uppercase;
+}
+
+.reading-timer__title{
+  margin:0;
+  font-size:18px;
+  line-height:1.3;
+}
+
+/* Status */
+
+.reading-timer__status{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  flex-shrink:0;
+  padding:6px 10px;
+  border-radius:999px;
+  font-size:11px;
+  font-weight:800;
+}
+
+.reading-timer__status i{
+  width:7px;
+  height:7px;
+  flex:0 0 7px;
+  border-radius:50%;
+  background:currentColor;
+}
+
+.reading-timer__status--active{
+  color:#166534;
+  background:#dcfce7;
+}
+
+.reading-timer__status--paused{
+  color:#92400e;
+  background:#fef3c7;
+}
+
+.reading-timer__status--completed{
+  color:#1d4ed8;
+  background:#dbeafe;
+}
+
+.reading-timer__status--idle{
+  color:#4b5563;
+  background:#f3f4f6;
+}
+
+/* Timer Display */
+
+.reading-timer__display{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  margin:28px 0 22px;
+}
+
+.reading-timer__display strong{
+  font-variant-numeric:tabular-nums;
+  font-size:52px;
+  line-height:1;
+  letter-spacing:-.03em;
+}
+
+.reading-timer__display span{
+  margin-top:8px;
+  color:#6b7280;
+  font-size:12px;
+}
+
+/* Track */
+
+.reading-timer__track{
+  position:relative;
+  height:10px;
+  overflow:hidden;
+  border-radius:999px;
+  background:#e5e7eb;
+}
+
+.reading-timer__fill{
+  display:block;
+  width:var(--reading-timer-progress,0%);
+  height:100%;
+  border-radius:inherit;
+  background:#2563eb;
+  transition:width .4s ease;
+}
+
+/* Goal */
+
+.reading-timer__goal{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  margin-top:9px;
+  color:#6b7280;
+  font-size:11px;
+}
+
+.reading-timer__goal strong{
+  color:#374151;
+}
+
+/* Controls */
+
+.reading-timer__controls{
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  gap:10px;
+  margin-top:20px;
+}
+
+.reading-timer__button{
+  min-height:42px;
+  padding:10px 16px;
+  border-radius:10px;
+  font:700 13px/1 inherit;
+  cursor:pointer;
+  transition:
+    transform .2s ease,
+    background-color .2s ease,
+    border-color .2s ease,
+    box-shadow .2s ease;
+}
+
+.reading-timer__button:hover{
+  transform:translateY(-1px);
+}
+
+.reading-timer__button:active{
+  transform:translateY(0);
+}
+
+.reading-timer__button--primary{
+  border:0;
+  background:#2563eb;
+  color:#fff;
+}
+
+.reading-timer__button--primary:hover{
+  background:#1d4ed8;
+  box-shadow:0 6px 14px rgba(37,99,235,.25);
+}
+
+.reading-timer__button--secondary{
+  border:1px solid #d1d5db;
+  background:#fff;
+  color:#374151;
+}
+
+.reading-timer__button--secondary:hover{
+  border-color:#93c5fd;
+  background:#eff6ff;
+}
+
+/* Blue */
+
+.reading-timer--blue .reading-timer__fill,
+.reading-timer--blue .reading-timer__button--primary{
+  background:#2563eb;
+}
+
+/* Green */
+
+.reading-timer--green .reading-timer__fill,
+.reading-timer--green .reading-timer__button--primary{
+  background:#16a34a;
+}
+
+.reading-timer--green .reading-timer__button--primary:hover{
+  background:#15803d;
+}
+
+/* Purple */
+
+.reading-timer--purple .reading-timer__fill,
+.reading-timer--purple .reading-timer__button--primary{
+  background:#7c3aed;
+}
+
+.reading-timer--purple .reading-timer__button--primary:hover{
+  background:#6d28d9;
+}
+
+/* Orange */
+
+.reading-timer--orange .reading-timer__fill,
+.reading-timer--orange .reading-timer__button--primary{
+  background:#f97316;
+}
+
+.reading-timer--orange .reading-timer__button--primary:hover{
+  background:#ea580c;
+}
+
+/* Pink */
+
+.reading-timer--pink .reading-timer__fill,
+.reading-timer--pink .reading-timer__button--primary{
+  background:#db2777;
+}
+
+.reading-timer--pink .reading-timer__button--primary:hover{
+  background:#be185d;
+}
+
+/* Red */
+
+.reading-timer--red .reading-timer__fill,
+.reading-timer--red .reading-timer__button--primary{
+  background:#dc2626;
+}
+
+.reading-timer--red .reading-timer__button--primary:hover{
+  background:#b91c1c;
+}
+
+/* Teal */
+
+.reading-timer--teal .reading-timer__fill,
+.reading-timer--teal .reading-timer__button--primary{
+  background:#0d9488;
+}
+
+.reading-timer--teal .reading-timer__button--primary:hover{
+  background:#0f766e;
+}
+
+/* Compact */
+
+.reading-timer--compact{
+  padding:17px;
+}
+
+.reading-timer--compact .reading-timer__display{
+  margin:20px 0 17px;
+}
+
+.reading-timer--compact .reading-timer__display strong{
+  font-size:40px;
+}
+
+/* Small */
+
+.reading-timer--sm{
+  max-width:380px;
+  padding:18px;
+}
+
+.reading-timer--sm .reading-timer__display strong{
+  font-size:42px;
+}
+
+/* Large */
+
+.reading-timer--lg{
+  max-width:560px;
+  padding:28px;
+}
+
+.reading-timer--lg .reading-timer__display strong{
+  font-size:64px;
+}
+
+.reading-timer--lg .reading-timer__track{
+  height:12px;
+}
+
+/* Dark */
+
+.reading-timer--dark{
+  border-color:#374151;
+  background:#1f2937;
+  color:#f9fafb;
+}
+
+.reading-timer--dark .reading-timer__eyebrow,
+.reading-timer--dark .reading-timer__display span,
+.reading-timer--dark .reading-timer__goal{
+  color:#9ca3af;
+}
+
+.reading-timer--dark .reading-timer__track{
+  background:#374151;
+}
+
+.reading-timer--dark .reading-timer__goal strong{
+  color:#e5e7eb;
+}
+
+.reading-timer--dark .reading-timer__button--secondary{
+  border-color:#4b5563;
+  background:#111827;
+  color:#f9fafb;
+}
+
+/* Glass */
+
+.reading-timer--glass{
+  border-color:rgba(255,255,255,.3);
+  background:rgba(255,255,255,.55);
+  backdrop-filter:blur(14px);
+  -webkit-backdrop-filter:blur(14px);
+}
+
+/* Minimal */
+
+.reading-timer--minimal{
+  border:0;
+  border-radius:14px;
+  background:#f9fafb;
+  box-shadow:none;
+}
+
+.reading-timer--minimal:hover{
+  transform:none;
+  box-shadow:none;
+}
+
+/* Completion State */
+
+.reading-timer--completed{
+  border-color:#86efac;
+}
+
+.reading-timer--completed .reading-timer__fill{
+  width:100%;
+}
+
+.reading-timer--completed .reading-timer__status{
+  color:#166534;
+  background:#dcfce7;
+}
+
+/* Focus */
+
+.reading-timer__button:focus-visible{
+  outline:3px solid rgba(37,99,235,.35);
+  outline-offset:3px;
+}
+
+/* Disabled */
+
+.reading-timer__button:disabled{
+  opacity:.55;
+  cursor:not-allowed;
+  transform:none;
+}
+
+/* Responsive */
+
+@media(max-width:600px){
+
+  .reading-timer{
+    max-width:100%;
+    padding:18px;
+  }
+
+  .reading-timer__display strong{
+    font-size:44px;
+  }
+
+  .reading-timer__controls{
+    gap:8px;
+  }
+
+}
+
+@media(max-width:380px){
+
+  .reading-timer__header{
+    flex-direction:column;
+  }
+
+  .reading-timer__display strong{
+    font-size:38px;
+  }
+
+  .reading-timer__controls{
+    grid-template-columns:1fr;
+  }
+
+}
+
+/* Reduced Motion */
+
+@media(prefers-reduced-motion:reduce){
+
+  .reading-timer,
+  .reading-timer__fill,
+  .reading-timer__button{
+    transition:none;
+  }
+
+  .reading-timer:hover,
+  .reading-timer__button:hover,
+  .reading-timer__button:active{
+    transform:none;
+  }
+
+}

--- a/bookshelf-frontend/src/components/ReadingTimer.jsx
+++ b/bookshelf-frontend/src/components/ReadingTimer.jsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from "react";
+import "./ReadingTimer.css";
+
+export default function ReadingTimer({
+  initialSeconds = 0,
+  targetMinutes = 30,
+  variant = "blue",
+  title = "Reading Session",
+  autoStart = false,
+  className = ""
+}) {
+  const [seconds, setSeconds] = useState(Math.max(0, Number(initialSeconds) || 0));
+  const [running, setRunning] = useState(Boolean(autoStart));
+
+  useEffect(() => {
+    if (!running) return;
+    const timer = window.setInterval(() => setSeconds(v => v + 1), 1000);
+    return () => window.clearInterval(timer);
+  }, [running]);
+
+  const target = Math.max(1, (Number(targetMinutes) || 30) * 60);
+  const progress = Math.min(100, (seconds / target) * 100);
+
+  const formatTime = value => {
+    const h = Math.floor(value / 3600);
+    const m = Math.floor((value % 3600) / 60);
+    const s = value % 60;
+    return h
+      ? `${String(h).padStart(2,"0")}:${String(m).padStart(2,"0")}:${String(s).padStart(2,"0")}`
+      : `${String(m).padStart(2,"0")}:${String(s).padStart(2,"0")}`;
+  };
+
+  return (
+    <section className={`reading-timer reading-timer--${variant} ${className}`.trim()}>
+      <div className="reading-timer__header">
+        <div>
+          <p className="reading-timer__eyebrow">Reading time</p>
+          <h3 className="reading-timer__title">{title}</h3>
+        </div>
+        <span className={`reading-timer__status reading-timer__status--${running ? "active" : "paused"}`}>
+          <i aria-hidden="true" />{running ? "Reading" : "Paused"}
+        </span>
+      </div>
+
+      <div className="reading-timer__display" aria-live="polite">
+        <strong>{formatTime(seconds)}</strong>
+        <span>minutes read</span>
+      </div>
+
+      <div className="reading-timer__track" role="progressbar"
+        aria-label="Reading goal progress" aria-valuemin="0"
+        aria-valuemax="100" aria-valuenow={Math.round(progress)}>
+        <span className="reading-timer__fill"
+          style={{ "--reading-timer-progress": `${progress}%` }} />
+      </div>
+
+      <div className="reading-timer__goal">
+        <span>Goal: {targetMinutes} min</span>
+        <strong>{Math.round(progress)}%</strong>
+      </div>
+
+      <div className="reading-timer__controls">
+        <button type="button" className="reading-timer__button reading-timer__button--primary"
+          onClick={() => setRunning(v => !v)}>
+          {running ? "Pause" : "Start"}
+        </button>
+        <button type="button" className="reading-timer__button reading-timer__button--secondary"
+          onClick={() => { setRunning(false); setSeconds(0); }}>
+          Reset
+        </button>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a reusable ReadingTimer component for tracking reading sessions and displaying progress toward a reading goal.

## Changes

- Added live reading timer functionality
- Added Start/Pause and Reset controls
- Added configurable reading goals
- Added animated progress indicator
- Added active/paused status states
- Added blue, green, purple, orange, pink, red, and teal variants
- Added compact, small, large, dark, glass, minimal, and completed styles
- Added responsive mobile layouts
- Added keyboard focus and disabled states
- Added `prefers-reduced-motion` support

## Testing

- [x] Timer starts correctly
- [x] Pause/resume works correctly
- [x] Reset works correctly
- [x] Progress percentage updates correctly
- [x] Responsive styles verified
- [x] Variants verified
- [x] Reduced-motion behavior implemented
- [x] Keyboard focus states implemented

## Related Issue

Closes #375 