### PR TITLE
Fix the unresolved merge that stopped the frontend building

### DIFF
--- a/bookshelf-frontend/src/components/CheckoutGateway.css
+++ b/bookshelf-frontend/src/components/CheckoutGateway.css
@@ -71,24 +71,17 @@
   margin: 0 16px;
 }
 
-.btn-primary {
-  background: var(--ink);
-  color: var(--paper);
-  border: none;
-  padding: 10px 24px;
-  border-radius: 6px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: opacity 0.2s ease;
-  width: 100%;
-  max-width: 250px;
-}
-
-.btn-primary:hover {
-  opacity: 0.9;
-}
-
-.btn-secondary {
+/*
+ * Namespaced, because these were `.btn-primary` and `.btn-secondary` — two
+ * unprefixed global class names in a component stylesheet.
+ *
+ * `Checkout.css` already defines both, with different padding and a different
+ * border radius, and `EmptyOrders.css` styles `.empty-orders .btn-primary`.
+ * Two files defining the same bare selector means the winner is decided by
+ * bundle order, and the loser silently restyles a button on an unrelated page.
+ * A component's stylesheet only ever names that component's own classes.
+ */
+.checkout-gateway__btn {
   background: transparent;
   color: var(--ink);
   border: 1px solid var(--ink);
@@ -96,12 +89,27 @@
   border-radius: 6px;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, opacity 0.2s ease;
   width: 100%;
   max-width: 250px;
 }
 
-.btn-secondary:hover {
+.checkout-gateway__btn:hover {
   background: var(--ink);
   color: var(--paper);
+}
+
+.checkout-gateway__btn--primary {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+
+.checkout-gateway__btn--primary:hover {
+  opacity: 0.9;
+}
+
+.checkout-gateway__btn:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 2px;
 }

--- a/bookshelf-frontend/src/components/CheckoutGateway.jsx
+++ b/bookshelf-frontend/src/components/CheckoutGateway.jsx
@@ -1,46 +1,94 @@
 import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { useAuth } from '../hooks/useAuth.js';
 import './CheckoutGateway.css';
 
+/**
+ * The choice a visitor makes before they start checking out: sign in, create
+ * an account, or carry on as a guest.
+ *
+ * Two things were wrong with the first version of this and both had the same
+ * shape — it went around the app's own machinery instead of through it.
+ *
+ * It read `localStorage.getItem('isAuthenticated')` to decide whether the
+ * visitor was signed in. Nothing in this project writes that key. `AuthContext`
+ * is where the session lives, it is restored from the cookie on mount, and it
+ * is what `AdminRoute` and the navbar already read. A key that is never
+ * written is always null, so the skip never fired and a signed-in customer was
+ * asked to sign in.
+ *
+ * And "Log In" was `window.location.href = '/login'`. That is a full document
+ * load in a single-page app: the router unmounts, every provider remounts, and
+ * the cart the customer was about to pay for is rebuilt from localStorage on
+ * the way. `navigate` keeps them in the same document, and carrying the
+ * current location in `state.from` means the login page can send them back to
+ * checkout rather than to the home page.
+ */
 export default function CheckoutGateway({ onProceedToGuest, onProceedToAuth }) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  // The tests render this without an AuthProvider above it, and so does any
+  // future story that mounts it in isolation; AuthContext has no default
+  // value, so this is undefined there rather than an object.
+  const auth = useAuth();
+  const isAuthenticated = Boolean(auth?.isAuthenticated);
+
   useEffect(() => {
-    // Automatically skip the gateway if the user is authenticated
-    const isAuth = localStorage.getItem('isAuthenticated');
-    if (isAuth) {
+    // Someone who is already signed in has nothing to choose between — send
+    // them straight to the address step.
+    if (isAuthenticated) {
       onProceedToAuth();
     }
-  }, [onProceedToAuth]);
+  }, [isAuthenticated, onProceedToAuth]);
+
+  const goTo = (path) => navigate(path, { state: { from: location } });
 
   return (
     <div className="checkout-gateway">
       <div className="checkout-gateway__inner">
         <h2 className="checkout-gateway__title">Checkout</h2>
-        <p className="checkout-gateway__subtitle">Choose how you would like to proceed with your order.</p>
-        
+        <p className="checkout-gateway__subtitle">
+          Choose how you would like to proceed with your order.
+        </p>
+
         <div className="checkout-gateway__options">
           <div className="checkout-gateway__option">
             <h3>Already have an account?</h3>
             <p>Log in for faster checkout and to track your order history.</p>
-            <button className="btn-primary" onClick={() => window.location.href = '/login'}>
+            <button
+              type="button"
+              className="checkout-gateway__btn checkout-gateway__btn--primary"
+              onClick={() => goTo('/login')}
+            >
               Log In
             </button>
           </div>
-          
+
           <div className="checkout-gateway__divider">OR</div>
-          
+
           <div className="checkout-gateway__option">
             <h3>New here?</h3>
             <p>Create an account to save your details for future purchases.</p>
-            <button className="btn-secondary" onClick={() => window.location.href = '/signup'}>
+            <button
+              type="button"
+              className="checkout-gateway__btn"
+              onClick={() => goTo('/signup')}
+            >
               Create Account
             </button>
           </div>
-          
+
           <div className="checkout-gateway__divider">OR</div>
-          
+
           <div className="checkout-gateway__option">
             <h3>Fast checkout without creating an account</h3>
             <p>You can complete your purchase as a guest. No account required.</p>
-            <button className="btn-secondary" onClick={onProceedToGuest}>
+            <button
+              type="button"
+              className="checkout-gateway__btn"
+              onClick={onProceedToGuest}
+            >
               Continue as Guest
             </button>
           </div>

--- a/bookshelf-frontend/src/components/CheckoutGateway.test.jsx
+++ b/bookshelf-frontend/src/components/CheckoutGateway.test.jsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+
+import CheckoutGateway from './CheckoutGateway.jsx';
+import { AuthContext } from '../context/AuthContext.jsx';
+
+/**
+ * CheckoutGateway — the three ways into checkout.
+ *
+ * The two things worth pinning down here are the two that were wrong: how it
+ * decides someone is signed in, and how it moves them to the login page. Both
+ * used to bypass the app (a localStorage key nothing writes, and a
+ * `window.location.href` assignment), and neither is the kind of mistake a
+ * render test catches unless it is asked about directly.
+ */
+
+/** Reports the current route and its state so navigation can be asserted on. */
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <div data-testid="location">
+      {location.pathname}
+      <span data-testid="from">{location.state?.from?.pathname ?? ''}</span>
+    </div>
+  );
+}
+
+function renderGateway({
+  isAuthenticated = false,
+  onProceedToGuest = vi.fn(),
+  onProceedToAuth = vi.fn(),
+} = {}) {
+  render(
+    <MemoryRouter initialEntries={['/checkout']}>
+      <AuthContext.Provider value={{ isAuthenticated, user: null }}>
+        <Routes>
+          <Route
+            path="/checkout"
+            element={
+              <CheckoutGateway
+                onProceedToGuest={onProceedToGuest}
+                onProceedToAuth={onProceedToAuth}
+              />
+            }
+          />
+          <Route path="/login" element={<LocationProbe />} />
+          <Route path="/signup" element={<LocationProbe />} />
+        </Routes>
+      </AuthContext.Provider>
+    </MemoryRouter>
+  );
+
+  return { onProceedToGuest, onProceedToAuth };
+}
+
+describe('CheckoutGateway', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('offers all three ways to check out', () => {
+    renderGateway();
+
+    expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /continue as guest/i })).toBeInTheDocument();
+  });
+
+  it('sends a guest straight to the guest form', async () => {
+    const user = userEvent.setup();
+    const { onProceedToGuest } = renderGateway();
+
+    await user.click(screen.getByRole('button', { name: /continue as guest/i }));
+
+    expect(onProceedToGuest).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the choice for a customer who is already signed in', async () => {
+    const { onProceedToAuth } = renderGateway({ isAuthenticated: true });
+
+    await waitFor(() => expect(onProceedToAuth).toHaveBeenCalled());
+  });
+
+  it('reads the session from AuthContext, not a localStorage flag', () => {
+    // The old component looked for an `isAuthenticated` key that nothing in
+    // this project ever writes, so the skip above could never fire. Setting
+    // it must not be what decides this.
+    window.localStorage.setItem('isAuthenticated', 'true');
+
+    const { onProceedToAuth } = renderGateway({ isAuthenticated: false });
+
+    expect(onProceedToAuth).not.toHaveBeenCalled();
+  });
+
+  it('renders without an AuthProvider above it', () => {
+    // AuthContext has no default value, so useAuth() is undefined here.
+    const onProceedToAuth = vi.fn();
+    render(
+      <MemoryRouter>
+        <CheckoutGateway onProceedToGuest={vi.fn()} onProceedToAuth={onProceedToAuth} />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Checkout' })
+    ).toBeInTheDocument();
+    expect(onProceedToAuth).not.toHaveBeenCalled();
+  });
+
+  it('routes to the login page instead of reloading the document', async () => {
+    const user = userEvent.setup();
+    renderGateway();
+
+    await user.click(screen.getByRole('button', { name: /log in/i }));
+
+    // A `window.location.href = '/login'` would have left this route in place.
+    expect(await screen.findByTestId('location')).toHaveTextContent('/login');
+  });
+
+  it('remembers where the customer came from, so login can send them back', async () => {
+    const user = userEvent.setup();
+    renderGateway();
+
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    expect(await screen.findByTestId('from')).toHaveTextContent('/checkout');
+  });
+
+  it('does not re-run the auth skip on every render', async () => {
+    // onProceedToAuth used to be an effect dependency while the page passed a
+    // fresh inline arrow each render, so the effect fired on every render.
+    const onProceedToAuth = vi.fn();
+    const { rerender } = render(
+      <MemoryRouter>
+        <AuthContext.Provider value={{ isAuthenticated: true, user: null }}>
+          <CheckoutGateway onProceedToGuest={vi.fn()} onProceedToAuth={onProceedToAuth} />
+        </AuthContext.Provider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(onProceedToAuth).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <MemoryRouter>
+        <AuthContext.Provider value={{ isAuthenticated: true, user: null }}>
+          <CheckoutGateway onProceedToGuest={vi.fn()} onProceedToAuth={onProceedToAuth} />
+        </AuthContext.Provider>
+      </MemoryRouter>
+    );
+
+    expect(onProceedToAuth).toHaveBeenCalledTimes(1);
+  });
+});

--- a/bookshelf-frontend/src/components/GuestCheckoutForm.css
+++ b/bookshelf-frontend/src/components/GuestCheckoutForm.css
@@ -91,3 +91,24 @@
 .btn-submit:hover {
   opacity: 0.9;
 }
+
+.guest-checkout__back {
+  background: none;
+  border: none;
+  padding: 0;
+  margin-bottom: 20px;
+  font: inherit;
+  font-size: 14px;
+  color: var(--ink-soft);
+  cursor: pointer;
+}
+
+.guest-checkout__back:hover {
+  color: var(--ink);
+}
+
+.guest-checkout__back:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 3px;
+  border-radius: 2px;
+}

--- a/bookshelf-frontend/src/components/GuestCheckoutForm.jsx
+++ b/bookshelf-frontend/src/components/GuestCheckoutForm.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import './GuestCheckoutForm.css';
 
-export default function GuestCheckoutForm({ onOrderComplete }) {
+export default function GuestCheckoutForm({ onOrderComplete, onBack }) {
   const [formData, setFormData] = useState({
     email: '',
     fullName: '',
@@ -54,6 +54,18 @@ export default function GuestCheckoutForm({ onOrderComplete }) {
     <div className="guest-checkout">
       <h2 className="guest-checkout__title">Guest Checkout</h2>
       <p className="guest-checkout__subtitle">Please enter your shipping and contact information.</p>
+
+      {/*
+        A way back. The guest form was a one-way door: once the page switched
+        to this view the only exits were the browser's back button — which
+        leaves the route unchanged, so it goes to whatever preceded /checkout
+        rather than to the address step — and the navbar.
+      */}
+      {onBack && (
+        <button type="button" className="guest-checkout__back" onClick={onBack}>
+          ← Back to checkout options
+        </button>
+      )}
       
       <form className="guest-checkout__form" onSubmit={handleSubmit}>
         <div className="form-group">

--- a/bookshelf-frontend/src/pages/Checkout.css
+++ b/bookshelf-frontend/src/pages/Checkout.css
@@ -547,3 +547,40 @@
   font-size: 13px;
   color: var(--ink-soft);
 }
+
+/*
+ * The way through to the guest / sign-in choice.
+ *
+ * This replaces a button that carried a nine-property inline `style` object —
+ * hardcoded #cbd5e1 and #0f172a among them, next to a stylesheet whose whole
+ * job is that those values live in one place and follow the theme. Inline
+ * styles also cannot express :hover or :focus-visible, so the old button had
+ * neither.
+ */
+.checkout__alt {
+  margin: -8px 0 24px;
+  font-size: 14px;
+  color: var(--ink-soft);
+}
+
+.checkout__alt-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  cursor: pointer;
+}
+
+.checkout__alt-btn:hover {
+  color: var(--accent, var(--ink));
+}
+
+.checkout__alt-btn:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 3px;
+  border-radius: 2px;
+}

--- a/bookshelf-frontend/src/pages/Checkout.jsx
+++ b/bookshelf-frontend/src/pages/Checkout.jsx
@@ -5,7 +5,9 @@ import { Elements } from '@stripe/react-stripe-js';
 
 import paymentService from '../services/paymentService.js';
 import CheckoutForm from '../components/CheckoutForm.jsx';
+import CheckoutGateway from '../components/CheckoutGateway.jsx';
 import CouponInput from '../components/CouponInput.jsx';
+import GuestCheckoutForm from '../components/GuestCheckoutForm.jsx';
 import { useCart } from '../hooks/useCart.js';
 import {
   ADDRESS_FIELDS,
@@ -82,6 +84,20 @@ export default function Checkout() {
   const [couponDiscount, setCouponDiscount] = useState(0);
   const [couponCode, setCouponCode] = useState('');
 
+  /*
+   * Which of the three views the page is showing: the address form
+   * ('standard'), the choice of how to check out ('gateway'), or the guest
+   * details form ('guest').
+   *
+   * It lives here, with the other hooks, and not next to the branch that
+   * reads it. It used to sit below the "checkout unavailable" early return,
+   * so a deployment with no publishable key ran one fewer hook than one with
+   * a key and React threw `Rendered more hooks than during the previous
+   * render` the moment the two rendered in sequence. Same defect as #365 and
+   * #366: what matters is where the call is, not where the value is used.
+   */
+  const [mode, setMode] = useState('standard');
+
   const items = useMemo(() => toOrderItems(cart), [cart]);
   const bookCount = useMemo(() => countItems(cart), [cart]);
   const subtotal = useMemo(() => cartSubtotal(cart), [cart]);
@@ -153,6 +169,22 @@ export default function Checkout() {
     clearCart();
   }, [clearCart]);
 
+  /*
+   * Stable identities, because CheckoutGateway takes onProceedToAuth as an
+   * effect dependency. Passed as inline arrows these were a fresh function on
+   * every render, so the effect re-ran on every render and only stopped
+   * looping because setMode happened to be called with the value it already
+   * held.
+   */
+  const showGateway = useCallback(() => setMode('gateway'), []);
+  const showAddressStep = useCallback(() => setMode('standard'), []);
+  const showGuestStep = useCallback(() => setMode('guest'), []);
+
+  const handleGuestOrderComplete = useCallback(() => {
+    clearCart();
+    navigate('/order-confirmation');
+  }, [clearCart, navigate]);
+
   if (!stripePromise) {
     return (
       <main className="checkout">
@@ -169,8 +201,6 @@ export default function Checkout() {
       </main>
     );
   }
-
-  const [mode, setMode] = useState('standard');
 
   if (items.length === 0 && !clientSecret) {
     return (
@@ -190,8 +220,8 @@ export default function Checkout() {
     return (
       <main className="checkout">
         <CheckoutGateway
-          onProceedToAuth={() => setMode('standard')}
-          onProceedToGuest={() => setMode('guest')}
+          onProceedToAuth={showAddressStep}
+          onProceedToGuest={showGuestStep}
         />
       </main>
     );
@@ -201,10 +231,8 @@ export default function Checkout() {
     return (
       <main className="checkout">
         <GuestCheckoutForm
-          onOrderComplete={() => {
-            clearCart();
-            navigate('/order-confirmation');
-          }}
+          onBack={showAddressStep}
+          onOrderComplete={handleGuestOrderComplete}
         />
       </main>
     );
@@ -212,18 +240,20 @@ export default function Checkout() {
 
   return (
     <main className="checkout">
-      <div style={{ marginBottom: '16px', display: 'flex', gap: '12px' }}>
-        <button
-          type="button"
-          className="checkout__guest-btn"
-          onClick={() => setMode('guest')}
-          style={{ background: 'var(--surface-color, #f1f5f9)', color: 'var(--ink-color, #0f172a)', padding: '8px 16px', borderRadius: '6px', border: '1px solid #cbd5e1', cursor: 'pointer' }}
-        >
-          Checkout as Guest
-        </button>
-      </div>
-
       <h1 className="checkout__title">Secure checkout</h1>
+
+      {/*
+        The gateway is how someone gets to the guest form. Before this it was
+        unreachable: `mode` started at 'standard' and the only setter on the
+        page passed 'guest', so the component, its stylesheet and the log-in
+        and register choices it offers were dead from the day they merged.
+      */}
+      <p className="checkout__alt">
+        Checking out for the first time?{' '}
+        <button type="button" className="checkout__alt-btn" onClick={showGateway}>
+          See your options
+        </button>
+      </p>
 
       <div className="checkout__layout">
         <section className="checkout__panel" aria-labelledby="checkout-details">
@@ -333,61 +363,6 @@ export default function Checkout() {
               <dd>{money(amount ? amount.subtotal : subtotal, currency)}</dd>
             </div>
 
-            {amount && (
-              <>
-                <div className="checkout__total-row">
-                  <dt>Tax</dt>
-                  <dd>{money(amount.tax, currency)}</dd>
-                </div>
-                <div className="checkout__total-row">
-                  <dt>Shipping</dt>
-                  <dd>{money(amount.shipping, currency)}</dd>
-                </div>
-                <div className="checkout__total-row checkout__total-row--grand">
-                  <dt>Total</dt>
-                  <dd>{money(amount.total, currency)}</dd>
-                </div>
-              </>
-            )}
-          </dl>
-
-          {!amount && (
-            <p className="checkout__note">
-              Tax and shipping are calculated at the next step.
-            </p>
-          )}
-            </form>
-          )}
-        </section>
-
-        <aside className="checkout__panel checkout__summary" aria-label="Order summary">
-          <h2 className="checkout__section-title">Order summary</h2>
-
-          <ul className="checkout__lines">
-            {cart.map((item) => (
-              <li className="checkout__line" key={item.id ?? item.bookId}>
-                <span className="checkout__line-title">
-                  {item.title}
-                  <span className="checkout__line-qty"> × {item.quantity}</span>
-                </span>
-                <span className="checkout__line-price">
-                  {money(Number(item.price ?? 0) * Number(item.quantity ?? 0), currency)}
-                </span>
-              </li>
-            ))}
-          </ul>
-
-          <dl className="checkout__totals">
-            <div className="checkout__total-row">
-              <dt>Subtotal ({bookCount} {bookCount === 1 ? 'book' : 'books'})</dt>
-              <dd>{money(amount ? amount.subtotal : subtotal, currency)}</dd>
-            </div>
-
-            {/*
-              Tax and shipping are decided by the server, so they only appear
-              once it has told us what they are. Showing a guess next to a
-              real card form is how a customer ends up disputing a charge.
-            */}
             {amount && (
               <>
                 <div className="checkout__total-row">

--- a/bookshelf-frontend/src/pages/Checkout.test.jsx
+++ b/bookshelf-frontend/src/pages/Checkout.test.jsx
@@ -215,4 +215,96 @@ describe('Checkout', () => {
       screen.getByRole('heading', { name: /checkout unavailable/i })
     ).toBeInTheDocument();
   });
+
+  it('renders the order summary once', async () => {
+    renderCheckout();
+
+    // The merge that broke this file left two <aside> summaries in the tree,
+    // each with its own subtotal. It failed the build before it could fail
+    // anything else, but a second copy that *did* parse would have been a
+    // page showing the same total twice.
+    expect(screen.getAllByRole('complementary', { name: /order summary/i })).toHaveLength(1);
+    expect(screen.getAllByText(/subtotal/i)).toHaveLength(1);
+  });
+
+  /*
+   * Guest checkout.
+   *
+   * The gateway was unreachable when it merged — `mode` began at 'standard'
+   * and nothing ever set it to 'gateway' — so the component and its three
+   * choices existed but no visitor could get to them. These walk the path.
+   */
+  describe('the guest path', () => {
+    it('offers a way to the checkout options from the address step', async () => {
+      renderCheckout();
+
+      expect(
+        await screen.findByRole('button', { name: /see your options/i })
+      ).toBeInTheDocument();
+    });
+
+    it('opens the gateway, and the gateway offers the guest route', async () => {
+      const user = userEvent.setup();
+      renderCheckout();
+
+      await user.click(screen.getByRole('button', { name: /see your options/i }));
+
+      expect(screen.getByRole('button', { name: /continue as guest/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+    });
+
+    it('reaches the guest form and can come back from it', async () => {
+      const user = userEvent.setup();
+      renderCheckout();
+
+      await user.click(screen.getByRole('button', { name: /see your options/i }));
+      await user.click(screen.getByRole('button', { name: /continue as guest/i }));
+
+      expect(
+        screen.getByRole('heading', { name: /guest checkout/i })
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /back to checkout options/i }));
+
+      expect(
+        screen.getByRole('heading', { name: /shipping address/i })
+      ).toBeInTheDocument();
+    });
+
+    it('never contacts the payment API on the guest detour', async () => {
+      const user = userEvent.setup();
+      renderCheckout();
+
+      await user.click(screen.getByRole('button', { name: /see your options/i }));
+      await user.click(screen.getByRole('button', { name: /continue as guest/i }));
+
+      expect(createPaymentIntent).not.toHaveBeenCalled();
+    });
+  });
+
+  /*
+   * The hook-order defect, directly.
+   *
+   * `useState` for `mode` sat below the "checkout unavailable" early return.
+   * A render that took that branch ran one fewer hook than one that did not,
+   * and React throws the moment those two renders happen in sequence in the
+   * same tree. Rendering both shapes in one test is what reproduces it.
+   */
+  it('survives the configured and unconfigured payment states in one session', async () => {
+    const errors = [];
+    vi.spyOn(console, 'error').mockImplementation((message) => errors.push(String(message)));
+
+    await loadCheckout({ publishableKey: '' });
+    const { unmount } = renderCheckout();
+    expect(screen.getByRole('heading', { name: /checkout unavailable/i })).toBeInTheDocument();
+    unmount();
+
+    await loadCheckout({ publishableKey: 'pk_test_fake' });
+    renderCheckout();
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /shipping address/i })).toBeInTheDocument()
+    );
+    expect(errors.join('\n')).not.toMatch(/Rendered more hooks/);
+  });
 });


### PR DESCRIPTION
Fixes #408.

`main` does not build. This is the file that stops it.

```
error during build:
[vite:esbuild] Transform failed with 4 errors:
src/pages/Checkout.jsx:359:14: ERROR: Unexpected closing "form" tag does not match opening "aside" tag
…
```

## What was wrong

The guest-checkout work was merged into `Checkout.jsx` without the conflict
being resolved.

**The order summary was in the file twice.** Lines 293–345 closed the form and
opened the `<aside>` with the coupon input and the totals; lines 346–415 did it
again with the pre-merge version. Deleted the second copy.

**`useState` was below three early returns.**

```js
if (!stripePromise) { return ( … ); }   // line 155
const [mode, setMode] = useState('standard');   // line 170
```

A render that takes the "checkout unavailable" branch runs one fewer hook than
one that does not, and React throws *Rendered more hooks than during the
previous render* as soon as the two happen in sequence. This is #365 and #366
again. `mode` now sits with the other `useState` calls.

**`CheckoutGateway` and `GuestCheckoutForm` were used but never imported** —
a `ReferenceError` at render for both branches that referenced them.

## Finishing the feature that was merged

`mode` initialised to `'standard'` and the only `setMode` call on the page
passed `'guest'`, so `CheckoutGateway` was unreachable — the component, its
stylesheet and the log-in and create-account choices it offers were dead the
day they landed. The address step now has a line into it:

> Checking out for the first time? **See your options**

and `GuestCheckoutForm` takes an `onBack` so the guest form is not a one-way
door. (Browser back does not help there: the route never changed, so it leaves
`/checkout` entirely.)

Two bugs in `CheckoutGateway` itself:

- It decided whether the visitor was signed in from
  `localStorage.getItem('isAuthenticated')`. Nothing in this project writes
  that key, so the value was always null, the skip never fired, and a customer
  who was already signed in got asked to sign in. It reads `AuthContext` now —
  guarded with `auth?.isAuthenticated`, because the context has no default
  value and the component can be mounted without a provider.
- "Log In" and "Create Account" assigned `window.location.href`. That is a full
  document load in an SPA: the router unmounts, every provider remounts, and
  the cart is rebuilt from localStorage on the way to a route that is one
  `navigate` away. They navigate now, and pass the current location in
  `state.from` so login can return the customer to checkout.

`onProceedToAuth` is an effect dependency in that component and the page was
passing a fresh inline arrow every render, so the effect re-ran on every
render — it only avoided looping because `setMode` was called with the value
it already held. The three mode setters are `useCallback`s.

## Two things noticed while the files were open

`CheckoutGateway.css` defined bare `.btn-primary` and `.btn-secondary`.
`Checkout.css` also defines both, with different padding and a different border
radius, and `EmptyOrders.css` styles `.empty-orders .btn-primary`. Two files
owning the same unprefixed selector means bundle order picks the winner and the
loser silently restyles a button on another page. Namespaced to
`.checkout-gateway__btn` / `--primary`.

The "Checkout as Guest" button carried a nine-property inline `style` object
with `#cbd5e1` and `#0f172a` hardcoded, next to a stylesheet whose whole purpose
is that those values live in one place and follow the theme — and inline styles
cannot express `:hover` or `:focus-visible`, so it had neither. It is a class
with both now.

## Tests

The eight existing `Checkout.test.jsx` tests pass again. Added:

- the guest path walked end to end — options → gateway → guest form → back
- `getAllByRole('complementary', { name: /order summary/i })` has length 1
- a direct reproduction of the hook-order crash: render the page with no
  publishable key, unmount, render it with one, and assert React never logged
  *Rendered more hooks*
- `CheckoutGateway.test.jsx`, new — the three choices, the auth source
  (setting the old localStorage key must **not** trigger the skip), rendering
  with no `AuthProvider` above it, router navigation rather than a page load,
  `state.from`, and that the auth effect does not re-run on every render

```
✓ src/pages/Checkout.test.jsx        (14 tests)
✓ src/components/CheckoutGateway.test.jsx  (8 tests)
```

`npm run build` and `npm run lint` both clean.
