### PR TITLE
Move the reviewKey hook above BookDetail's early returns

### DIFF
--- a/bookshelf-frontend/src/pages/BookDetail.jsx
+++ b/bookshelf-frontend/src/pages/BookDetail.jsx
@@ -35,14 +35,8 @@ import './BookDetail.css';
  * copy), and a book added to the catalogue rendered "Book Not Found" on its
  * own page. See #317.
  */
-import AIBookSummaryCard from '../components/AIBookSummaryCard.jsx';
-import BookChapterList from '../components/BookChapterList.jsx';
 import BookReviewSummary from '../components/BookReviewSummary.jsx';
-import BookDimensions from '../components/BookDimensions.jsx';
-import BookWeight from '../components/BookWeight.jsx';
 import ISBNCopy from '../components/ISBNCopy.jsx';
-import BookMetadata from '../components/BookMetadata.jsx';
-import QRCodeGenerator from '../components/QRCodeGenerator.jsx';
 import BookBadge from '../components/BookBadge.jsx';
 import VerifiedPurchaseBadge from '../components/VerifiedPurchaseBadge.jsx';
 import BookSpine from '../components/BookSpine.jsx';
@@ -71,6 +65,21 @@ export default function BookDetail() {
   const [myReview, setMyReview] = useState(null);
   const [reviewSubmitting, setReviewSubmitting] = useState(false);
 
+  /*
+   * Bumped after a review is posted, to remount ReviewList and make it
+   * refetch.
+   *
+   * It belongs here, with every other hook, and not 130 lines down past the
+   * loading, not-found and error returns where it used to sit. The first
+   * render of this page is always the loading render and it returns before
+   * reaching that point, so React recorded one fewer hook than the render
+   * that followed it and threw `Rendered more hooks than during the previous
+   * render` the moment the book arrived — which is to say on every book, every
+   * time. Same defect as #365 and #366: React counts where the call is, not
+   * where the value is used.
+   */
+  const [reviewKey, setReviewKey] = useState(0);
+
   useEffect(() => {
     setRating(0);
     setReviewTitle('');
@@ -78,6 +87,7 @@ export default function BookDetail() {
     setReviewError('');
     setSuccessMsg('');
     setMyReview(null);
+    setReviewKey(0);
   }, [id]);
 
   /*
@@ -202,27 +212,19 @@ export default function BookDetail() {
     );
   }
 
-  const [reviewKey, setReviewKey] = useState(0);
-
   const ratingLabel = formatRating(book.rating);
   const priceLabel = formatPrice(book.price);
   const stockLabel = describeStock(book);
   const available = isInStock(book);
 
-  const sampleChapters = [
-    { id: 'c1', number: 1, title: 'Introduction & Foundations', duration: '12 min', completed: true },
-    { id: 'c2', number: 2, title: 'Core Concepts & Principles', duration: '18 min', completed: false },
-    { id: 'c3', number: 3, title: 'Practical Application', duration: '25 min', completed: false },
-    { id: 'c4', number: 4, title: 'Advanced Strategies', duration: '20 min', completed: false },
-  ];
-
-  const bookMetadataObj = {
-    Publisher: book.publisher || 'BookShelf Publishing',
-    Format: 'Hardcover',
-    Language: 'English',
-    Edition: '1st Edition (2026)',
-    Pages: book.pages || '340 pages',
-  };
+  /*
+   * `sampleChapters` and `bookMetadataObj` used to be built here, on every
+   * render, and were no longer read by anything. Both were hardcoded
+   * placeholders — four chapter titles beginning "Introduction & Foundations",
+   * and a metadata block asserting every book in the catalogue is a hardcover
+   * 1st Edition (2026) of 340 pages. Left in the tree they would eventually
+   * have been rendered by someone who took them for real data.
+   */
 
   return (
     <main className="book-detail-page">

--- a/bookshelf-frontend/src/pages/BookDetail.test.jsx
+++ b/bookshelf-frontend/src/pages/BookDetail.test.jsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -21,6 +22,29 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('../components/SkeletonLoader.jsx', () => ({
   default: () => <div data-testid="skeleton" />,
+}));
+
+/*
+ * ReviewList reports a fresh id on every mount, so a test can tell a remount
+ * from a re-render. BookDetail keys it on `reviewKey` precisely to force one.
+ */
+let reviewListMounts = 0;
+vi.mock('../components/ReviewList.jsx', () => ({
+  default: () => {
+    const id = useMemo(() => {
+      reviewListMounts += 1;
+      return reviewListMounts;
+    }, []);
+    return <div data-testid="review-list" data-mount={String(id)} />;
+  },
+}));
+
+const createReview = vi.fn();
+const getMyReview = vi.fn();
+
+vi.mock('../services/reviewService.js', () => ({
+  createReview: (...args) => createReview(...args),
+  getMyReview: (...args) => getMyReview(...args),
 }));
 
 import { BookNotFoundError } from '../services/bookService.js';
@@ -69,6 +93,10 @@ describe('BookDetail', () => {
     getBookById.mockReset();
     getBooks.mockReset();
     getBooks.mockResolvedValue({ books: [] });
+    createReview.mockReset();
+    getMyReview.mockReset();
+    // 404 for "you have not reviewed this book yet" is the normal case.
+    getMyReview.mockRejectedValue(new Error('not found'));
   });
 
   afterEach(() => {
@@ -150,7 +178,8 @@ describe('BookDetail', () => {
   });
 
   it('renders a book with no rating instead of throwing on toFixed', async () => {
-    const { rating, ...withoutRating } = BOOK;
+    // eslint-disable-next-line no-unused-vars -- destructured to drop it
+    const { rating: _rating, ...withoutRating } = BOOK;
     getBookById.mockResolvedValue(withoutRating);
 
     renderDetail('b1');
@@ -257,5 +286,78 @@ describe('BookDetail', () => {
     await user.click(screen.getByRole('button', { name: /submit/i }));
 
     expect(await screen.findByText(/select a rating/i)).toBeInTheDocument();
+  });
+
+  /*
+   * The hook order, directly.
+   *
+   * `useState` for `reviewKey` sat below the loading, not-found and error
+   * returns. Every one of the tests above went through the loading render
+   * first and so tripped it, which is why eleven of fifteen were failing at
+   * once — but they each report it as whatever assertion happened to run
+   * after the throw. These say what the defect actually is, so a regression
+   * names itself.
+   */
+  describe('hook order', () => {
+    /** Renders and returns whatever React logged as an error. */
+    async function renderAndCollectErrors(setup) {
+      const logged = [];
+      vi.spyOn(console, 'error').mockImplementation((...args) => {
+        logged.push(args.map(String).join(' '));
+      });
+
+      setup();
+      const view = renderDetail('b1');
+      await waitFor(() => expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument());
+
+      return { logged, view };
+    }
+
+    it('runs the same hooks on the loading render and the loaded render', async () => {
+      const { logged } = await renderAndCollectErrors(() => {
+        getBookById.mockResolvedValue(BOOK);
+      });
+
+      expect(logged.join('\n')).not.toMatch(/Rendered more hooks/);
+      expect(screen.getByRole('heading', { name: 'The Quiet Ones' })).toBeInTheDocument();
+    });
+
+    it('runs the same hooks when the book is not found', async () => {
+      const { logged } = await renderAndCollectErrors(() => {
+        getBookById.mockRejectedValue(new BookNotFoundError('nope'));
+      });
+
+      expect(logged.join('\n')).not.toMatch(/Rendered more hooks/);
+    });
+
+    it('runs the same hooks when the request fails', async () => {
+      const { logged } = await renderAndCollectErrors(() => {
+        getBookById.mockRejectedValue(new Error('network down'));
+      });
+
+      expect(logged.join('\n')).not.toMatch(/Rendered more hooks/);
+    });
+  });
+
+  it('remounts the review list after a review is posted', async () => {
+    // This is the whole reason reviewKey exists, and nothing covered it —
+    // which is part of why the hook could sit in an illegal position for as
+    // long as it did.
+    getBookById.mockResolvedValue(BOOK);
+    createReview.mockResolvedValue({ review: { id: 'r1' } });
+    const user = userEvent.setup();
+
+    renderDetail('b1');
+    await screen.findByRole('heading', { name: 'The Quiet Ones' });
+
+    const before = screen.getByTestId('review-list').getAttribute('data-mount');
+
+    await user.click(screen.getByRole('button', { name: '4 Stars' }));
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => expect(createReview).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByTestId('review-list').getAttribute('data-mount')).not.toBe(before)
+    );
   });
 });


### PR DESCRIPTION
Fixes #409.

Every book detail page throws as soon as the book finishes loading:

```
Error: Rendered more hooks than during the previous render.
 ❯ BookDetail src/pages/BookDetail.jsx:205:37
    205|   const [reviewKey, setReviewKey] = useState(0);
```

11 of the 15 tests in `BookDetail.test.jsx` failed on it.

## The fix

`reviewKey` was declared 200 lines into the component, below three early
returns:

```js
if (loading)  { return <SkeletonLoader … />; }       // 171
if (notFound) { return … }                            // 179
if (error || !book) { return … }                      // 190

const [reviewKey, setReviewKey] = useState(0);        // 205
```

The first render of this page is always the loading render, and it returns
before line 205 — so React records N hooks. When the fetch resolves, `loading`
flips false, the component runs past all three guards and calls a hook React
has no slot for.

It is #365 and #366 again. What makes it easy to miss is that the *value* is
only used on the success path, so the code reads as if it belongs there. React
counts where the call is.

The state itself is wanted — `handleReviewSubmit` bumps it to remount
`ReviewList` after a review is posted — so it moves up with the other `useState`
calls, and resets in the `[id]` effect alongside the rest of the per-book state.

## Also in this file

`npm run lint` was flagging six imports nothing referenced
(`AIBookSummaryCard`, `BookChapterList`, `BookDimensions`, `BookWeight`,
`BookMetadata`, `QRCodeGenerator`) and two literals rebuilt on every render and
read by nothing:

```js
const sampleChapters = [
  { id: 'c1', number: 1, title: 'Introduction & Foundations', … },
  …
];
const bookMetadataObj = {
  Format: 'Hardcover', Edition: '1st Edition (2026)', Pages: book.pages || '340 pages',
};
```

Both are hardcoded placeholders that assert every book in the catalogue is the
same hardcover 340-page 1st edition. Removed, with a note where they were, so
nobody wires them up later taking them for real data.

## Tests

The 15 existing tests pass. Four added:

**Three that name the defect.** Each of the eleven failures above reports the
crash as whatever assertion happened to run after the throw, which is not a
useful thing for a regression to say. These render the loading path, the
not-found path and the failed-request path and assert that React never logged
*Rendered more hooks* — so if this comes back, the failure says what it is.

**One for what `reviewKey` is for.** `ReviewList` is mocked to report a fresh id
per mount; posting a review must change it. That behaviour had no coverage at
all, which is part of why the hook could sit in an illegal position as long as
it did.

```
✓ src/pages/BookDetail.test.jsx  (19 tests)
```

`npx eslint src/pages/BookDetail.jsx src/pages/BookDetail.test.jsx` is clean.

---

### About the red checks

CI runs lint and both test suites over the whole monorepo for every PR, and
`main` still carries breakages that this branch does not touch. Every failure
on this PR is fixed by one of the sibling PRs below, none of which conflicts
with this one:

| failing check | fixed by |
|---|---|
| `bookshelf-frontend` lint — `'beforeEach' is not defined` | #417 |
| `bookshelf-backend` — `not ok 2 - formatCurrency` | #416 |
| `bookshelf-backend` — `reviewController.test.js`, `reviewSystem.test.js` | #415 |

The two **Vercel** checks fail with "Authorization required to deploy" on every
PR in this repository, including merged ones from other authors — that needs
the repo owner to authorise the integration and is not caused by any change
here.

I merged all five branches together locally to check they compose. With the
set applied:

```
bookshelf-frontend  npm run build   ✓
bookshelf-frontend  npm run lint    0 errors  (2 before)
bookshelf-frontend  npm test        799 passed, 0 failed   (20 failed before)
bookshelf-backend   npm test        575 passed, 0 failed   (3 failed before)
```
