### PR TITLE
Make the review test files run, and fix what they found

### DIFF
--- a/bookshelf-backend/repositories/reviewRepository.js
+++ b/bookshelf-backend/repositories/reviewRepository.js
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import mongoose from 'mongoose';
 import Review from '../models/Review.js';
 import Order from '../models/Order.js';
@@ -60,7 +61,22 @@ class ReviewRepository {
         error.status = 400;
         throw error;
       }
-      const reviewDoc = { ...reviewPayload, _id: `rev_${Date.now()}` };
+      /*
+       * A unique id, not a timestamp.
+       *
+       * This was `rev_${Date.now()}`, and two reviews stored in the same
+       * millisecond therefore shared one. Everything downstream looks a review
+       * up by id, so a collision meant voteHelpful crediting the wrong review,
+       * and deleteReview finding the other user's document — either rejecting
+       * a legitimate delete as unauthorised, or removing a review its author
+       * had not asked to remove.
+       *
+       * A millisecond is not a rare window. Seeding, a burst of traffic, and
+       * any test that creates two reviews in a row all land inside one; the
+       * three tests in reviewSystem.test.js that caught this are the last of
+       * those.
+       */
+      const reviewDoc = { ...reviewPayload, _id: `rev_${randomUUID()}` };
       inMemoryReviews.push(reviewDoc);
       await this.recalculateBookRating(bookId);
       return reviewDoc;

--- a/bookshelf-backend/routes/standaloneReviewRoutes.js
+++ b/bookshelf-backend/routes/standaloneReviewRoutes.js
@@ -1,10 +1,30 @@
 import express from 'express';
-import { voteHelpful, deleteReview } from '../controllers/reviewController.js';
+import { markHelpful, deleteReview } from '../controllers/reviewController.js';
 import { protect } from '../middleware/authMiddleware.js';
 
+/**
+ * Review actions addressed by review id rather than by book.
+ *
+ * Two things were wrong here and neither could be noticed, because this router
+ * is not mounted in `app.js` and nothing imported it.
+ *
+ * It imported `voteHelpful`, which `reviewController.js` does not export — the
+ * name belongs to `repositories/reviewRepository.js`. That is a module link
+ * error, so the file could not be loaded at all, and the day somebody mounted
+ * it the server would have failed to start rather than served a bad response.
+ *
+ * And it declared its parameter as `:id` while both controllers read
+ * `req.params.reviewId`, so every request through here would have looked up
+ * `undefined`.
+ *
+ * These two routes duplicate `POST /:reviewId/helpful` and
+ * `DELETE /:reviewId` in `reviewRoutes.js`, which is mounted and correct.
+ * Worth folding together, but that is a decision about the API surface rather
+ * than a repair, so this is left aligned with the controller it calls.
+ */
 const router = express.Router();
 
-router.post('/:id/helpful', protect, voteHelpful);
-router.delete('/:id', protect, deleteReview);
+router.post('/:reviewId/helpful', protect, markHelpful);
+router.delete('/:reviewId', protect, deleteReview);
 
 export default router;

--- a/bookshelf-backend/tests/reviewController.test.js
+++ b/bookshelf-backend/tests/reviewController.test.js
@@ -1,6 +1,12 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
+import * as reviewController from '../controllers/reviewController.js';
+import {
+  createReviewSchema,
+  updateReviewSchema,
+} from '../validators/reviewValidators.js';
+
 /**
  * Unit tests for the review controller logic.
  *
@@ -116,13 +122,16 @@ describe('reviewController helpers', () => {
   });
 });
 
+/*
+ * These used to sit behind `const schemas = await import(…)` inside this
+ * describe callback, which is not async — so the file was a SyntaxError and
+ * node:test never ran a line of it, including the two suites above. The
+ * validators are plain objects with no side effects, which is the argument
+ * the old comment made for the dynamic import and is in fact the reason a
+ * static one at the top of the file is fine.
+ */
 describe('review validators (schema shape)', () => {
-  // Import the schema objects at test time — they are plain objects with
-  // no side effects so this is safe.
-  const schemas = await import('../validators/reviewValidators.js');
-
   it('createReviewSchema has all required fields', () => {
-    const { createReviewSchema } = schemas;
     assert.ok(createReviewSchema.bookId, 'bookId is missing');
     assert.ok(createReviewSchema.rating, 'rating is missing');
     assert.ok(createReviewSchema.title, 'title is missing');
@@ -130,11 +139,59 @@ describe('review validators (schema shape)', () => {
   });
 
   it('each field has at least one rule', () => {
-    for (const [field, config] of Object.entries(schemas.createReviewSchema)) {
+    for (const [field, config] of Object.entries(createReviewSchema)) {
       assert.ok(
         Array.isArray(config.rules) && config.rules.length > 0,
         `${field} has no rules`
       );
     }
+  });
+
+  it('updateReviewSchema carries the editable fields', () => {
+    assert.ok(updateReviewSchema.rating, 'rating is missing');
+    assert.ok(updateReviewSchema.title, 'title is missing');
+    assert.ok(updateReviewSchema.body, 'body is missing');
+  });
+
+  it('the schema names the request body field `body`, not `comment`', () => {
+    // reviewSystem.test.js was written against `comment` and never ran, so
+    // nothing noticed the two disagreed.
+    assert.ok(createReviewSchema.body);
+    assert.equal(createReviewSchema.comment, undefined);
+  });
+});
+
+/*
+ * The export surface.
+ *
+ * `routes/reviewRoutes.js` and `routes/standaloneReviewRoutes.js` both import
+ * named functions from this controller. When one of those names is wrong the
+ * failure is a module-link error at import time — the route file cannot load,
+ * and if it is mounted the server does not start. That is what
+ * `standaloneReviewRoutes.js` was doing with `voteHelpful`.
+ */
+describe('the controller exports what the routes import', () => {
+  const expected = [
+    'getBookReviews',
+    'getReviewBreakdown',
+    'createReview',
+    'updateReview',
+    'deleteReview',
+    'markHelpful',
+    'getMyReview',
+  ];
+
+  for (const name of expected) {
+    it(`exports ${name}`, () => {
+      assert.equal(
+        typeof reviewController[name],
+        'function',
+        `${name} is not exported from reviewController.js`
+      );
+    });
+  }
+
+  it('does not export voteHelpful — that name belongs to the repository', () => {
+    assert.equal(reviewController.voteHelpful, undefined);
   });
 });

--- a/bookshelf-backend/tests/reviewSystem.test.js
+++ b/bookshelf-backend/tests/reviewSystem.test.js
@@ -2,113 +2,340 @@ import test, { describe, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 
 import reviewRepository from '../repositories/reviewRepository.js';
-import { createReview, voteHelpful, deleteReview } from '../controllers/reviewController.js';
 
-function makeRes() {
+/**
+ * The review store, through the repository that owns it.
+ *
+ * This file used to import `createReview`, `voteHelpful` and `deleteReview`
+ * from `controllers/reviewController.js`. The controller exports `markHelpful`
+ * and has never had a `voteHelpful`, so the module failed to link and node:test
+ * reported the whole file as one failure — its four tests had never executed
+ * once.
+ *
+ * The names were not the only thing pointing elsewhere. Every call in it used
+ * a shape the controller does not accept: the book id in `req.params.id` where
+ * the controller reads `req.body.bookId`, the text in `body.comment` where the
+ * validator says `body`, and assertions on `helpfulVotes` where the controller
+ * responds with `helpfulCount`. All four of those are the *repository's*
+ * vocabulary. The tests were written against the repository and imported from
+ * the controller, so they are pointed at the repository here.
+ *
+ * Mongo is not connected under `node --test`, so these exercise the in-memory
+ * fallback path — which is also the path a developer runs the app on without a
+ * MONGODB_URI, so it is worth having covered on its own account.
+ *
+ * The book id is deliberately not one from the catalogue. `createReview` calls
+ * `recalculateBookRating`, which calls `bookRepository.updateBook`, which
+ * writes `data/books.json` to disk. An id the catalogue does not contain makes
+ * that a no-op; a real one would have every run of `npm test` rewriting a
+ * committed data file.
+ */
+const BOOK_ID = 'test-book-review-suite';
+const OTHER_BOOK_ID = 'test-book-review-suite-2';
+
+const ALICE = { _id: 'user_1', name: 'Alice Smith', email: 'alice@example.com' };
+const BOB = { _id: 'user_2', name: 'Bob Jones', email: 'bob@example.com' };
+
+/** A review payload in the shape the repository takes. */
+function reviewFor(user, overrides = {}) {
   return {
-    statusCode: 200,
-    body: null,
-    status(code) {
-      this.statusCode = code;
-      return this;
-    },
-    json(payload) {
-      this.body = payload;
-      return this;
-    },
+    bookId: BOOK_ID,
+    userId: user._id,
+    userName: user.name,
+    rating: 5,
+    title: 'Outstanding Masterpiece',
+    comment: 'This book completely transformed my understanding of architecture.',
+    ...overrides,
   };
 }
 
-describe('Interactive Book Review & Rating System', () => {
+describe('review repository — creating reviews', () => {
   beforeEach(() => {
     reviewRepository.clearMemoryCache();
   });
 
-  test('createReview creates review and updates stats', async () => {
-    const req = {
-      params: { id: 'b1' },
-      body: {
-        rating: 5,
-        title: 'Outstanding Masterpiece',
-        comment: 'This book completely transformed my understanding of software architecture!',
-      },
-      user: { _id: 'user_1', name: 'Alice Smith', email: 'alice@example.com' },
-    };
-    const res = makeRes();
+  test('stores a review and reports it in the book stats', async () => {
+    const created = await reviewRepository.createReview(reviewFor(ALICE));
 
-    await createReview(req, res, () => {});
+    assert.equal(created.rating, 5);
+    assert.equal(created.title, 'Outstanding Masterpiece');
+    assert.equal(created.userName, 'Alice Smith');
 
-    assert.equal(res.statusCode, 201);
-    assert.equal(res.body.review.rating, 5);
-    assert.equal(res.body.review.title, 'Outstanding Masterpiece');
-
-    const stats = await reviewRepository.getReviewStats('b1');
+    const stats = await reviewRepository.getReviewStats(BOOK_ID);
     assert.equal(stats.totalCount, 1);
     assert.equal(stats.averageRating, 5);
+    assert.equal(stats.breakdown[5], 1);
   });
 
-  test('createReview prevents duplicate submission for same book by same user', async () => {
-    const req1 = {
-      params: { id: 'b1' },
-      body: { rating: 5, title: 'First Review', comment: 'Great!' },
-      user: { _id: 'user_1', email: 'alice@example.com' },
-    };
-    const res1 = makeRes();
-    await createReview(req1, res1, () => {});
+  test('coerces a numeric-string rating', async () => {
+    const created = await reviewRepository.createReview(reviewFor(ALICE, { rating: '4' }));
 
-    const req2 = {
-      params: { id: 'b1' },
-      body: { rating: 4, title: 'Second Review', comment: 'Still good!' },
-      user: { _id: 'user_1', email: 'alice@example.com' },
-    };
-    const res2 = makeRes();
-    await createReview(req2, res2, () => {});
-
-    assert.equal(res2.statusCode, 400);
-    assert.match(res2.body.message, /already submitted a review/);
+    assert.strictEqual(created.rating, 4);
+    const stats = await reviewRepository.getReviewStats(BOOK_ID);
+    assert.strictEqual(stats.averageRating, 4);
   });
 
-  test('voteHelpful increments helpful votes', async () => {
-    const created = await reviewRepository.createReview({
-      bookId: 'b1',
-      userId: 'user_1',
-      userName: 'Bob',
-      rating: 4,
-      title: 'Solid Book',
-      comment: 'Very informative read.',
-    });
-
-    const req = { params: { id: created._id } };
-    const res = makeRes();
-
-    await voteHelpful(req, res, () => {});
-
-    assert.equal(res.statusCode, 200);
-    assert.equal(res.body.helpfulVotes, 1);
+  test('starts a new review at zero helpful votes', async () => {
+    const created = await reviewRepository.createReview(reviewFor(ALICE));
+    assert.strictEqual(created.helpfulVotes, 0);
   });
 
-  test('deleteReview allows review owner to delete review', async () => {
-    const created = await reviewRepository.createReview({
-      bookId: 'b1',
-      userId: 'user_1',
-      userName: 'Bob',
-      rating: 4,
-      title: 'Solid Book',
-      comment: 'Very informative read.',
-    });
+  test('refuses a second review of the same book by the same user', async () => {
+    await reviewRepository.createReview(reviewFor(ALICE));
 
-    const req = {
-      params: { id: created._id },
-      user: { _id: 'user_1', role: 'user' },
-    };
-    const res = makeRes();
+    await assert.rejects(
+      () => reviewRepository.createReview(reviewFor(ALICE, { rating: 4, title: 'Second' })),
+      (error) => {
+        assert.match(error.message, /already submitted a review/);
+        assert.equal(error.status, 400);
+        return true;
+      }
+    );
 
-    await deleteReview(req, res, () => {});
+    const stats = await reviewRepository.getReviewStats(BOOK_ID);
+    assert.equal(stats.totalCount, 1, 'the rejected review must not be stored');
+  });
 
-    assert.equal(res.statusCode, 200);
-    assert.match(res.body.message, /deleted successfully/);
+  test('lets a different user review the same book', async () => {
+    await reviewRepository.createReview(reviewFor(ALICE, { rating: 5 }));
+    await reviewRepository.createReview(reviewFor(BOB, { rating: 3 }));
 
-    const stats = await reviewRepository.getReviewStats('b1');
-    assert.equal(stats.totalCount, 0);
+    const stats = await reviewRepository.getReviewStats(BOOK_ID);
+    assert.equal(stats.totalCount, 2);
+    assert.equal(stats.averageRating, 4);
+  });
+
+  test('lets the same user review a different book', async () => {
+    await reviewRepository.createReview(reviewFor(ALICE));
+    await reviewRepository.createReview(reviewFor(ALICE, { bookId: OTHER_BOOK_ID, rating: 2 }));
+
+    assert.equal((await reviewRepository.getReviewStats(BOOK_ID)).totalCount, 1);
+    assert.equal((await reviewRepository.getReviewStats(OTHER_BOOK_ID)).totalCount, 1);
+  });
+});
+
+describe('review repository — helpful votes', () => {
+  beforeEach(() => {
+    reviewRepository.clearMemoryCache();
+  });
+
+  test('increments the count on the review that was voted for', async () => {
+    const created = await reviewRepository.createReview(reviewFor(ALICE));
+
+    const updated = await reviewRepository.voteHelpful(created._id);
+
+    assert.equal(updated.helpfulVotes, 1);
+  });
+
+  test('accumulates across votes', async () => {
+    const created = await reviewRepository.createReview(reviewFor(ALICE));
+
+    await reviewRepository.voteHelpful(created._id);
+    await reviewRepository.voteHelpful(created._id);
+    const updated = await reviewRepository.voteHelpful(created._id);
+
+    assert.equal(updated.helpfulVotes, 3);
+  });
+
+  test('returns null for a review that does not exist', async () => {
+    assert.equal(await reviewRepository.voteHelpful('rev_nope'), null);
+  });
+
+  test('leaves other reviews alone', async () => {
+    const alice = await reviewRepository.createReview(reviewFor(ALICE));
+    const bob = await reviewRepository.createReview(reviewFor(BOB));
+
+    await reviewRepository.voteHelpful(alice._id);
+
+    const { reviews } = await reviewRepository.getReviewsByBookId(BOOK_ID);
+    const bobs = reviews.find((review) => String(review._id) === String(bob._id));
+    assert.equal(bobs.helpfulVotes, 0);
+  });
+});
+
+describe('review repository — deleting reviews', () => {
+  beforeEach(() => {
+    reviewRepository.clearMemoryCache();
+  });
+
+  test('lets the author delete their own review', async () => {
+    const created = await reviewRepository.createReview(reviewFor(ALICE));
+
+    assert.equal(await reviewRepository.deleteReview(created._id, ALICE._id), true);
+    assert.equal((await reviewRepository.getReviewStats(BOOK_ID)).totalCount, 0);
+  });
+
+  test('refuses to let another user delete it', async () => {
+    const created = await reviewRepository.createReview(reviewFor(ALICE));
+
+    await assert.rejects(
+      () => reviewRepository.deleteReview(created._id, BOB._id),
+      (error) => {
+        assert.match(error.message, /Not authorized/);
+        assert.equal(error.status, 403);
+        return true;
+      }
+    );
+
+    assert.equal(
+      (await reviewRepository.getReviewStats(BOOK_ID)).totalCount,
+      1,
+      'the review must survive an unauthorised delete'
+    );
+  });
+
+  test('lets an admin delete somebody else’s review', async () => {
+    const created = await reviewRepository.createReview(reviewFor(ALICE));
+
+    assert.equal(await reviewRepository.deleteReview(created._id, BOB._id, true), true);
+    assert.equal((await reviewRepository.getReviewStats(BOOK_ID)).totalCount, 0);
+  });
+
+  test('reports false for a review that does not exist', async () => {
+    assert.equal(await reviewRepository.deleteReview('rev_nope', ALICE._id), false);
+  });
+
+  test('recomputes the average after a delete', async () => {
+    await reviewRepository.createReview(reviewFor(ALICE, { rating: 5 }));
+    const bobs = await reviewRepository.createReview(reviewFor(BOB, { rating: 1 }));
+
+    assert.equal((await reviewRepository.getReviewStats(BOOK_ID)).averageRating, 3);
+
+    await reviewRepository.deleteReview(bobs._id, BOB._id);
+
+    const stats = await reviewRepository.getReviewStats(BOOK_ID);
+    assert.equal(stats.averageRating, 5);
+    assert.equal(stats.breakdown[1], 0);
+  });
+});
+
+describe('review repository — reading a book’s reviews', () => {
+  beforeEach(async () => {
+    reviewRepository.clearMemoryCache();
+  });
+
+  /** Three reviews at 5, 3 and 1 stars, from three different users. */
+  async function seed() {
+    const five = await reviewRepository.createReview(
+      reviewFor(ALICE, { rating: 5, title: 'Five' })
+    );
+    const three = await reviewRepository.createReview(
+      reviewFor(BOB, { rating: 3, title: 'Three' })
+    );
+    const one = await reviewRepository.createReview(
+      reviewFor({ _id: 'user_3', name: 'Cara' }, { rating: 1, title: 'One' })
+    );
+    return { five, three, one };
+  }
+
+  test('returns every review for the book, and none from another', async () => {
+    await seed();
+    await reviewRepository.createReview(reviewFor(ALICE, { bookId: OTHER_BOOK_ID }));
+
+    const { reviews, total } = await reviewRepository.getReviewsByBookId(BOOK_ID);
+
+    assert.equal(total, 3);
+    assert.equal(reviews.length, 3);
+    assert.ok(reviews.every((review) => review.bookId === BOOK_ID));
+  });
+
+  test('filters to a single star level', async () => {
+    await seed();
+
+    const { reviews, total } = await reviewRepository.getReviewsByBookId(BOOK_ID, { rating: 3 });
+
+    assert.equal(total, 1);
+    assert.equal(reviews[0].title, 'Three');
+  });
+
+  test('ignores a star filter outside 1–5', async () => {
+    await seed();
+
+    assert.equal((await reviewRepository.getReviewsByBookId(BOOK_ID, { rating: 9 })).total, 3);
+    assert.equal((await reviewRepository.getReviewsByBookId(BOOK_ID, { rating: 0 })).total, 3);
+  });
+
+  test('sorts highest and lowest first on request', async () => {
+    await seed();
+
+    const highest = await reviewRepository.getReviewsByBookId(BOOK_ID, { sortBy: 'highest' });
+    assert.deepEqual(
+      highest.reviews.map((review) => review.rating),
+      [5, 3, 1]
+    );
+
+    const lowest = await reviewRepository.getReviewsByBookId(BOOK_ID, { sortBy: 'lowest' });
+    assert.deepEqual(
+      lowest.reviews.map((review) => review.rating),
+      [1, 3, 5]
+    );
+  });
+
+  test('sorts by helpful votes on request', async () => {
+    const { one } = await seed();
+    await reviewRepository.voteHelpful(one._id);
+    await reviewRepository.voteHelpful(one._id);
+
+    const { reviews } = await reviewRepository.getReviewsByBookId(BOOK_ID, { sortBy: 'helpful' });
+
+    assert.equal(reviews[0].title, 'One');
+    assert.equal(reviews[0].helpfulVotes, 2);
+  });
+
+  test('paginates, and reports how many pages there are', async () => {
+    await seed();
+
+    const first = await reviewRepository.getReviewsByBookId(BOOK_ID, { page: 1, limit: 2 });
+    assert.equal(first.reviews.length, 2);
+    assert.equal(first.total, 3);
+    assert.equal(first.pages, 2);
+    assert.equal(first.page, 1);
+
+    const second = await reviewRepository.getReviewsByBookId(BOOK_ID, { page: 2, limit: 2 });
+    assert.equal(second.reviews.length, 1);
+  });
+
+  test('reports one page, not zero, for a book with no reviews', async () => {
+    const { reviews, total, pages } = await reviewRepository.getReviewsByBookId(BOOK_ID);
+
+    assert.deepEqual(reviews, []);
+    assert.equal(total, 0);
+    assert.equal(pages, 1);
+  });
+
+  test('carries the stats alongside the page', async () => {
+    await seed();
+
+    const { stats } = await reviewRepository.getReviewsByBookId(BOOK_ID);
+
+    assert.equal(stats.totalCount, 3);
+    assert.equal(stats.averageRating, 3);
+    assert.equal(stats.breakdown[5], 1);
+    assert.equal(stats.breakdown[3], 1);
+    assert.equal(stats.breakdown[1], 1);
+    assert.equal(stats.breakdown[4], 0);
+  });
+});
+
+describe('review repository — stats for a book with nothing on it', () => {
+  beforeEach(() => {
+    reviewRepository.clearMemoryCache();
+  });
+
+  test('is zero rather than NaN', async () => {
+    const stats = await reviewRepository.getReviewStats('a-book-nobody-reviewed');
+
+    assert.strictEqual(stats.averageRating, 0);
+    assert.strictEqual(stats.totalCount, 0);
+    assert.deepEqual(stats.breakdown, { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 });
+  });
+
+  test('rounds the average to one decimal place', async () => {
+    // 5 + 4 + 4 = 13/3 = 4.333…
+    await reviewRepository.createReview(reviewFor(ALICE, { rating: 5 }));
+    await reviewRepository.createReview(reviewFor(BOB, { rating: 4 }));
+    await reviewRepository.createReview(reviewFor({ _id: 'user_3', name: 'Cara' }, { rating: 4 }));
+
+    assert.strictEqual((await reviewRepository.getReviewStats(BOOK_ID)).averageRating, 4.3);
   });
 });

--- a/bookshelf-backend/tests/routeModules.test.js
+++ b/bookshelf-backend/tests/routeModules.test.js
@@ -1,0 +1,47 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdir } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+/**
+ * Every router file loads.
+ *
+ * `routes/standaloneReviewRoutes.js` imported `voteHelpful` from
+ * `controllers/reviewController.js`, which has never exported it. That is a
+ * link error, not a runtime one: the module cannot be evaluated at all, and a
+ * server that mounted it would have failed to boot. It sat that way because
+ * nothing mounts the file and nothing imported it, so no code path ever asked
+ * Node to resolve it.
+ *
+ * This asks. It is a cheap check and it covers the whole directory, including
+ * the routers that are written but not yet mounted in `app.js` —
+ * adminRoutes, collectionRoutes, couponRoutes, reviewRoutes and this one.
+ * Those are exactly the files with nothing else watching them.
+ */
+const routesDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'routes'
+);
+
+const routeFiles = (await readdir(routesDir))
+  .filter((name) => name.endsWith('.js'))
+  .sort();
+
+describe('route modules', () => {
+  it('finds the routers on disk', () => {
+    assert.ok(routeFiles.length > 0, 'no route files found');
+  });
+
+  for (const file of routeFiles) {
+    it(`${file} imports cleanly and default-exports a router`, async () => {
+      const module = await import(path.join(routesDir, file));
+
+      assert.ok(module.default, `${file} has no default export`);
+      // An Express router is a function with a .stack of layers.
+      assert.equal(typeof module.default, 'function', `${file} does not export a router`);
+      assert.ok(Array.isArray(module.default.stack), `${file} is not an Express router`);
+    });
+  }
+});


### PR DESCRIPTION
Fixes #410.

Two files in `bookshelf-backend/tests` never executed — not failing assertions,
but parse and link errors, so node:test reported each as one failure and every
suite inside them had never run.

## Making them run

**`tests/reviewSystem.test.js`** imported `voteHelpful` from
`controllers/reviewController.js`:

```
SyntaxError: The requested module '../controllers/reviewController.js'
does not provide an export named 'voteHelpful'
```

The controller exports `markHelpful`. `voteHelpful` is a method on
`repositories/reviewRepository.js` — and the wrong name was a symptom, not the
problem. Every call in the file used a shape the controller does not accept:

| the file passed | the controller reads |
|---|---|
| `req.params.id` | `req.params.reviewId` |
| `req.body.comment` | `req.body.body` (`createReviewSchema`) |
| book id in `params.id` | `req.body.bookId` |
| asserts `helpfulVotes` | responds `helpfulCount` |

All four are the **repository's** vocabulary. The tests were written against
the repository and imported from the controller, so they point at the
repository now. Mongo is not connected under `node --test`, so they exercise
the in-memory fallback — which is also the path a developer runs the app on
with no `MONGODB_URI`, so it is worth having covered anyway.

**`tests/reviewController.test.js`** had a dynamic import inside a synchronous
callback:

```js
describe('review validators (schema shape)', () => {
  const schemas = await import('../validators/reviewValidators.js');   // SyntaxError
```

Static import at the top of the file. The `computeBreakdown` and
`computeAverage` suites above it now run too.

## What running them found

The in-memory store assigned ids from the clock:

```js
const reviewDoc = { ...reviewPayload, _id: `rev_${Date.now()}` };
```

Two reviews stored in the same millisecond share an id. Everything downstream
looks a review up by that id, so a collision means:

- `voteHelpful` credits the wrong review;
- `deleteReview` finds the *other* user's document — and then either rejects a
  legitimate delete as unauthorised, or **deletes a review its author never
  asked to remove**.

A millisecond is not a rare window: seeding, a burst of traffic, and any two
consecutive writes all land inside one. Three of the new tests hit it
immediately. It is `randomUUID()` now.

## The route file that would have stopped the server booting

`routes/standaloneReviewRoutes.js` imported the same missing `voteHelpful`, and
declared `:id` where both controllers read `req.params.reviewId`. It is not
mounted in `app.js` and nothing imports it, so nothing ever asked Node to
resolve it — but the day someone mounted it, the process would have failed to
start rather than served a bad response.

Aligned with the controller it calls. Its two routes duplicate
`POST /:reviewId/helpful` and `DELETE /:reviewId` in the mounted
`reviewRoutes.js`; that is a decision about the API surface rather than a
repair, so it is noted in the file and left.

**`tests/routeModules.test.js`** (new) imports every file in `routes/` and
checks it resolves to an Express router. That is the check that would have
caught this, and it covers the other routers written but not yet mounted —
`adminRoutes`, `collectionRoutes`, `couponRoutes`, `reviewRoutes` — which are
precisely the files with nothing else watching them.

## Coverage added

`reviewSystem.test.js` is now 25 tests over create (duplicate guard, rating
coercion, per-user and per-book scoping), helpful votes (accumulation, missing
review, isolation between reviews), delete (author, another user, admin
override, missing, average recomputed) and reads (star filter, the three sort
orders, pagination, empty book, stats). `reviewController.test.js` adds the
`updateReviewSchema` shape, the `body`-not-`comment` field name, and a check
that the controller exports every name the routes import.

The book id in these is deliberately not one from the catalogue:
`createReview` → `recalculateBookRating` → `bookRepository.updateBook` **writes
`data/books.json` to disk**, and a real id would have every `npm test` run
rewriting a committed data file. An unknown id makes it a no-op. Verified the
working tree stays clean across a full run.

## Result

```
before:  # tests 512   # fail 3
after:   # tests 566   # fail 1
```

The one remaining failure is the admin `formatCurrency` case — that is #411,
handled separately.

---

### About the red checks

CI runs lint and both test suites over the whole monorepo for every PR, and
`main` still carries breakages that this branch does not touch. Every failure
on this PR is fixed by one of the sibling PRs below, none of which conflicts
with this one:

| failing check | fixed by |
|---|---|
| `bookshelf-frontend` lint — `'beforeEach' is not defined` | #417 |
| `bookshelf-frontend` — `BookDetail.test.jsx` (11 tests) | #414 |
| `bookshelf-backend` — `not ok 2 - formatCurrency` | #416 |

The two **Vercel** checks fail with "Authorization required to deploy" on every
PR in this repository, including merged ones from other authors — that needs
the repo owner to authorise the integration and is not caused by any change
here.

I merged all five branches together locally to check they compose. With the
set applied:

```
bookshelf-frontend  npm run build   ✓
bookshelf-frontend  npm run lint    0 errors  (2 before)
bookshelf-frontend  npm test        799 passed, 0 failed   (20 failed before)
bookshelf-backend   npm test        575 passed, 0 failed   (3 failed before)
```
