### PR TITLE
Format admin dashboard money through the currency helper

### DIFF
--- a/bookshelf-backend/controllers/adminController.js
+++ b/bookshelf-backend/controllers/adminController.js
@@ -11,7 +11,7 @@ import bookRepository from '../repositories/bookRepository.js';
  * @param {string} period — '7d' | '30d' | '90d' | '1y' | 'all'
  * @returns {{ $gte?: Date }} — a Mongoose-compatible filter, or {} for all.
  */
-function dateFilter(period) {
+export function dateFilter(period) {
   if (!period || period === 'all') return {};
 
   const now = new Date();

--- a/bookshelf-backend/tests/adminController.test.js
+++ b/bookshelf-backend/tests/adminController.test.js
@@ -1,48 +1,33 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
+import { dateFilter } from '../controllers/adminController.js';
+import adminRouter from '../routes/adminRoutes.js';
+
 /**
- * Unit tests for admin controller helper logic.
+ * Admin controller helpers, and the money the dashboard renders.
  *
- * Tests the dateFilter helper and verifies the schema shapes of the admin
- * route definitions.  Run with:
+ * This file used to define its own `dateFilter` and its own `formatCurrency`
+ * at the top and assert against those, under a comment reading
+ * "Re-implementation of the dateFilter helper from adminController.js. Kept in
+ * sync for independent testing."
+ *
+ * Nothing enforced the sync, so `dateFilter` in the controller — the thing
+ * deciding the range behind every /api/admin/analytics query — could have been
+ * changed to anything and these tests would still have passed. It is imported
+ * now.
+ *
+ * The `formatCurrency` block is gone rather than fixed. There is no
+ * formatCurrency in this package; the function it was copying is the one on
+ * the admin dashboard in the frontend, which is where the rupee grouping was
+ * actually wrong and where it is now fixed and tested. A backend test cannot
+ * assert anything true about a frontend helper, and asserting it against a
+ * local copy is how the wrong grouping survived. Money that the backend does
+ * format — for logs and error messages — is `formatAmount` in
+ * `config/currency.js`, covered by `tests/currency.test.js`.
  *
  *   node --test tests/adminController.test.js
  */
-
-// ── Helpers extracted for testing ──────────────────────────────────────────
-
-/**
- * Re-implementation of the dateFilter helper from adminController.js.
- * Kept in sync for independent testing.
- */
-function dateFilter(period) {
-  if (!period || period === 'all') return {};
-
-  const now = new Date();
-  const ranges = {
-    '7d': 7,
-    '30d': 30,
-    '90d': 90,
-    '1y': 365,
-  };
-
-  const days = ranges[period];
-  if (!days) return {};
-
-  const since = new Date(now);
-  since.setDate(since.getDate() - days);
-  return { createdAt: { $gte: since } };
-}
-
-/**
- * Format a currency value for display (matching the frontend helper).
- */
-function formatCurrency(value) {
-  return `₹${(value || 0).toLocaleString()}`;
-}
-
-// ── Tests ──────────────────────────────────────────────────────────────────
 
 describe('dateFilter', () => {
   it('returns empty object for undefined period', () => {
@@ -55,6 +40,10 @@ describe('dateFilter', () => {
 
   it('returns empty object for unknown period', () => {
     assert.deepStrictEqual(dateFilter('xyz'), {});
+  });
+
+  it('returns empty object for an empty string', () => {
+    assert.deepStrictEqual(dateFilter(''), {});
   });
 
   it('returns a valid date filter for "7d"', () => {
@@ -74,51 +63,73 @@ describe('dateFilter', () => {
     assert.ok(diff >= 29 * 24 * 60 * 60 * 1000);
   });
 
+  it('returns a valid date filter for "90d"', () => {
+    const result = dateFilter('90d');
+    const diff = Date.now() - result.createdAt.$gte.getTime();
+    assert.ok(diff <= 91 * 24 * 60 * 60 * 1000);
+    assert.ok(diff >= 89 * 24 * 60 * 60 * 1000);
+  });
+
   it('returns a valid date filter for "1y"', () => {
     const result = dateFilter('1y');
     const diff = Date.now() - result.createdAt.$gte.getTime();
     assert.ok(diff <= 366 * 24 * 60 * 60 * 1000);
     assert.ok(diff >= 364 * 24 * 60 * 60 * 1000);
   });
-});
 
-describe('formatCurrency', () => {
-  it('formats a number with INR symbol', () => {
-    assert.strictEqual(formatCurrency(1234), '₹1,234');
+  it('names a field Mongo can match on', () => {
+    // The shape is spread straight into an aggregation $match, so the key has
+    // to be the document field and the value a comparison operator.
+    assert.deepStrictEqual(Object.keys(dateFilter('7d')), ['createdAt']);
+    assert.deepStrictEqual(Object.keys(dateFilter('7d').createdAt), ['$gte']);
   });
 
-  it('formats zero correctly', () => {
-    assert.strictEqual(formatCurrency(0), '₹0');
-  });
-
-  it('defaults to zero for undefined', () => {
-    assert.strictEqual(formatCurrency(undefined), '₹0');
-  });
-
-  it('handles large numbers', () => {
-    assert.strictEqual(formatCurrency(1234567), '₹12,34,567');
+  it('gives a fresh Date each call, not a shared one', () => {
+    const first = dateFilter('7d').createdAt.$gte;
+    const second = dateFilter('7d').createdAt.$gte;
+    assert.notStrictEqual(first, second);
   });
 });
 
-describe('admin route schema shape', () => {
-  // The admin routes are a plain array — just verify the expected endpoints exist.
+describe('admin routes', () => {
   const endpoints = [
-    'stats',
-    'sales-trend',
-    'monthly-revenue',
-    'top-books',
-    'recent-orders',
-    'order-statuses',
-    'user-growth',
-    'review-stats',
+    '/stats',
+    '/sales-trend',
+    '/monthly-revenue',
+    '/top-books',
+    '/recent-orders',
+    '/order-statuses',
+    '/user-growth',
+    '/review-stats',
   ];
 
-  it('has all expected admin endpoints', () => {
-    // Just verify the endpoint names are defined for documentation.
-    for (const ep of endpoints) {
-      assert.strictEqual(typeof ep, 'string');
-      assert.ok(ep.length > 0);
-    }
-    assert.strictEqual(endpoints.length, 8);
+  /*
+   * This used to loop over a list of bare strings asserting each was a
+   * non-empty string — true of any list of strings, and unrelated to the
+   * router. It reads the router's own stack now, so removing or renaming a
+   * route fails the test.
+   */
+  const registered = adminRouter.stack
+    .filter((layer) => layer.route)
+    .map((layer) => layer.route.path);
+
+  for (const endpoint of endpoints) {
+    it(`registers GET ${endpoint}`, () => {
+      assert.ok(
+        registered.includes(endpoint),
+        `${endpoint} is not registered on adminRouter`
+      );
+    });
+  }
+
+  it('registers no routes beyond the eight documented ones', () => {
+    assert.deepStrictEqual(registered.sort(), [...endpoints].sort());
+  });
+
+  it('guards every route behind auth before any handler runs', () => {
+    // router.use(protect, admin) — two middleware layers with no route,
+    // registered ahead of the endpoints.
+    const middleware = adminRouter.stack.filter((layer) => !layer.route);
+    assert.ok(middleware.length >= 2, 'protect and admin are not both mounted');
   });
 });

--- a/bookshelf-frontend/src/components/AdminRecentOrders.jsx
+++ b/bookshelf-frontend/src/components/AdminRecentOrders.jsx
@@ -1,5 +1,13 @@
 import { useState, useEffect } from 'react';
 import { getRecentOrders } from '../services/adminService.js';
+import { formatMoney } from '../utils/currency.js';
+
+/*
+ * Revenue is formatted by utils/currency.js. It used to be
+ * `₹{value.toLocaleString()}` inline: a hardcoded symbol beside grouping taken
+ * from the browser's locale rather than the currency's, and a method call that
+ * throws outright on a row whose amount came back null.
+ */
 
 /**
  * Maps an order status to a badge class and human label.
@@ -108,7 +116,7 @@ export default function AdminRecentOrders() {
                 <td className="admin-table__name">{order.customerName}</td>
                 <td>{order.itemCount}</td>
                 <td className="admin-table__right">
-                  ₹{order.total.toLocaleString()}
+                  {formatMoney(order.total, { minimumFractionDigits: 0 })}
                 </td>
                 <td>{statusBadge(order.status)}</td>
                 <td>{formatDate(order.createdAt)}</td>

--- a/bookshelf-frontend/src/components/AdminSalesChart.jsx
+++ b/bookshelf-frontend/src/components/AdminSalesChart.jsx
@@ -1,5 +1,13 @@
 import { useState, useEffect } from 'react';
 import { getSalesTrend } from '../services/adminService.js';
+import { formatMoney } from '../utils/currency.js';
+
+/*
+ * Revenue is formatted by utils/currency.js. It used to be
+ * `₹{value.toLocaleString()}` inline: a hardcoded symbol beside grouping taken
+ * from the browser's locale rather than the currency's, and a method call that
+ * throws outright on a row whose amount came back null.
+ */
 
 /**
  * AdminSalesChart — a pure-CSS bar chart showing revenue per day.
@@ -78,7 +86,7 @@ export default function AdminSalesChart() {
             return (
               <div key={entry.date} className="admin-chart__col">
                 <span className="admin-chart__tooltip">
-                  ₹{entry.revenue.toLocaleString()}
+                  {formatMoney(entry.revenue, { minimumFractionDigits: 0 })}
                 </span>
                 <div className="admin-chart__bar-track">
                   <div

--- a/bookshelf-frontend/src/components/AdminTopBooks.jsx
+++ b/bookshelf-frontend/src/components/AdminTopBooks.jsx
@@ -1,5 +1,13 @@
 import { useState, useEffect } from 'react';
 import { getTopBooks } from '../services/adminService.js';
+import { formatMoney } from '../utils/currency.js';
+
+/*
+ * Revenue is formatted by utils/currency.js. It used to be
+ * `₹{value.toLocaleString()}` inline: a hardcoded symbol beside grouping taken
+ * from the browser's locale rather than the currency's, and a method call that
+ * throws outright on a row whose amount came back null.
+ */
 
 /**
  * AdminTopBooks — table showing the best-selling books for a given period.
@@ -81,7 +89,9 @@ export default function AdminTopBooks() {
                 <td className="admin-table__rank">{index + 1}</td>
                 <td className="admin-table__name">{book.title || book.bookId}</td>
                 <td className="admin-table__right">{book.totalSold}</td>
-                <td className="admin-table__right">₹{book.totalRevenue.toLocaleString()}</td>
+                <td className="admin-table__right">
+                  {formatMoney(book.totalRevenue, { minimumFractionDigits: 0 })}
+                </td>
               </tr>
             ))}
           </tbody>

--- a/bookshelf-frontend/src/pages/AdminDashboard.jsx
+++ b/bookshelf-frontend/src/pages/AdminDashboard.jsx
@@ -5,11 +5,19 @@ import AdminSalesChart from '../components/AdminSalesChart.jsx';
 import AdminTopBooks from '../components/AdminTopBooks.jsx';
 import AdminRecentOrders from '../components/AdminRecentOrders.jsx';
 import { getDashboardStats } from '../services/adminService.js';
+import { formatMoney } from '../utils/currency.js';
 
 import '../components/AdminKpiCard.css';
 import '../components/AdminSalesChart.css';
+/*
+ * AdminTopBooks.css also carries AdminRecentOrders' styles — the two share the
+ * whole `.admin-table*` set, badges included — so there is no
+ * AdminRecentOrders.css to import. There was an import for one anyway, which
+ * is an unresolved module: Vite fails the build on it. It went unnoticed
+ * because nothing routes to AdminDashboard, so the page has never been in the
+ * bundle graph for the build to walk.
+ */
 import '../components/AdminTopBooks.css';
-import '../components/AdminRecentOrders.css';
 import './AdminDashboard.css';
 
 /**
@@ -42,9 +50,23 @@ export default function AdminDashboard() {
     return () => controller.abort();
   }, []);
 
-  function formatCurrency(value) {
-    return `₹${(value || 0).toLocaleString()}`;
-  }
+  /*
+   * Money on this page goes through utils/currency.js, like money everywhere
+   * else does since #335.
+   *
+   * There was a local formatter here reading `₹${(value || 0)
+   * .toLocaleString()}`, and it was wrong twice over. `toLocaleString()` with
+   * no locale groups by whatever the *browser* is set to, so total revenue of
+   * 1234567 rendered ₹1,234,567 for most visitors and ₹12,34,567 for one on
+   * an en-IN browser — only the second of which is how a rupee figure is
+   * written. And `|| 0` turned a KPI that failed to load into a confident ₹0;
+   * a dashboard must not report zero revenue when what it means is that it
+   * does not know.
+   *
+   * formatMoney takes the locale from the currency table and renders — for an
+   * absent value. The 0 minimum keeps whole rupees free of a trailing .00.
+   */
+  const money = (value) => formatMoney(value, { minimumFractionDigits: 0 });
 
   return (
     <main className="admin-dashboard">
@@ -68,7 +90,7 @@ export default function AdminDashboard() {
         <AdminKpiCard
           icon="💰"
           label="Total Revenue"
-          value={loading ? undefined : formatCurrency(stats?.totalRevenue)}
+          value={loading ? undefined : money(stats?.totalRevenue)}
           loading={loading}
         />
         <AdminKpiCard
@@ -92,7 +114,7 @@ export default function AdminDashboard() {
         <AdminKpiCard
           icon="🧾"
           label="Avg. Order Value"
-          value={loading ? undefined : formatCurrency(stats?.avgOrderValue)}
+          value={loading ? undefined : money(stats?.avgOrderValue)}
           loading={loading}
         />
       </section>

--- a/bookshelf-frontend/src/pages/AdminDashboard.test.jsx
+++ b/bookshelf-frontend/src/pages/AdminDashboard.test.jsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const getDashboardStats = vi.fn();
+const getSalesTrend = vi.fn();
+const getTopBooks = vi.fn();
+const getRecentOrders = vi.fn();
+
+vi.mock('../services/adminService.js', () => ({
+  getDashboardStats: (...args) => getDashboardStats(...args),
+  getSalesTrend: (...args) => getSalesTrend(...args),
+  getTopBooks: (...args) => getTopBooks(...args),
+  getRecentOrders: (...args) => getRecentOrders(...args),
+}));
+
+import AdminDashboard from './AdminDashboard.jsx';
+import AdminTopBooks from '../components/AdminTopBooks.jsx';
+import AdminRecentOrders from '../components/AdminRecentOrders.jsx';
+import AdminSalesChart from '../components/AdminSalesChart.jsx';
+
+/**
+ * Money on the admin dashboard.
+ *
+ * Every figure here used to be `₹${value.toLocaleString()}` — a hardcoded
+ * symbol next to grouping taken from whatever locale the browser happens to
+ * be set to. `1234567` is `₹12,34,567` in rupees and `₹1,234,567` is not, and
+ * which one a visitor saw depended on their machine.
+ *
+ * jsdom runs in en-US, so a regression here reproduces exactly the way it did
+ * in a browser: these assertions fail on the old code and pass on the new.
+ */
+
+const STATS = {
+  totalRevenue: 1234567,
+  totalOrders: 4820,
+  totalUsers: 913,
+  totalBooks: 128,
+  avgOrderValue: 256,
+};
+
+describe('AdminDashboard money', () => {
+  beforeEach(() => {
+    getDashboardStats.mockReset();
+    getSalesTrend.mockReset().mockResolvedValue({ trend: [] });
+    getTopBooks.mockReset().mockResolvedValue({ topBooks: [] });
+    getRecentOrders.mockReset().mockResolvedValue({ orders: [] });
+  });
+
+  it('groups rupees the Indian way, not the host locale way', async () => {
+    getDashboardStats.mockResolvedValue(STATS);
+
+    render(<AdminDashboard />);
+
+    expect(await screen.findByText('₹12,34,567')).toBeInTheDocument();
+    expect(screen.queryByText('₹1,234,567')).not.toBeInTheDocument();
+  });
+
+  it('drops the trailing paise on a whole-rupee figure', async () => {
+    getDashboardStats.mockResolvedValue(STATS);
+
+    render(<AdminDashboard />);
+
+    expect(await screen.findByText('₹256')).toBeInTheDocument();
+  });
+
+  it('shows a dash, not ₹0, for a KPI the API did not return', async () => {
+    // `|| 0` used to render this as ₹0 — a dashboard stating zero revenue
+    // when what it knows is nothing.
+    getDashboardStats.mockResolvedValue({ ...STATS, totalRevenue: undefined });
+
+    render(<AdminDashboard />);
+
+    await waitFor(() => expect(screen.getByText('₹256')).toBeInTheDocument());
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('still shows ₹0 for a real zero', async () => {
+    getDashboardStats.mockResolvedValue({ ...STATS, totalRevenue: 0 });
+
+    render(<AdminDashboard />);
+
+    expect(await screen.findByText('₹0')).toBeInTheDocument();
+  });
+
+  it('surfaces the error rather than rendering figures it does not have', async () => {
+    getDashboardStats.mockRejectedValue(new Error('aggregation timed out'));
+
+    render(<AdminDashboard />);
+
+    expect(await screen.findByText(/aggregation timed out/i)).toBeInTheDocument();
+  });
+});
+
+describe('AdminTopBooks money', () => {
+  beforeEach(() => {
+    getTopBooks.mockReset();
+  });
+
+  it('groups revenue the Indian way', async () => {
+    getTopBooks.mockResolvedValue({
+      topBooks: [{ bookId: 'b1', title: 'The Quiet Ones', totalSold: 42, totalRevenue: 1234567 }],
+    });
+
+    render(<AdminTopBooks />);
+
+    expect(await screen.findByText('₹12,34,567')).toBeInTheDocument();
+  });
+
+  it('renders a row whose revenue came back null instead of throwing', async () => {
+    // `book.totalRevenue.toLocaleString()` was a TypeError on this row, which
+    // takes the whole table down with it.
+    getTopBooks.mockResolvedValue({
+      topBooks: [{ bookId: 'b1', title: 'The Quiet Ones', totalSold: 0, totalRevenue: null }],
+    });
+
+    render(<AdminTopBooks />);
+
+    expect(await screen.findByText('The Quiet Ones')).toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+});
+
+describe('AdminRecentOrders money', () => {
+  beforeEach(() => {
+    getRecentOrders.mockReset();
+  });
+
+  it('groups order totals the Indian way', async () => {
+    getRecentOrders.mockResolvedValue({
+      orders: [
+        {
+          id: 'order_abc123',
+          customerName: 'A. Sharma',
+          itemCount: 3,
+          total: 1234567,
+          status: 'paid',
+          createdAt: '2026-08-01T10:00:00.000Z',
+        },
+      ],
+    });
+
+    render(<AdminRecentOrders />);
+
+    expect(await screen.findByText('₹12,34,567')).toBeInTheDocument();
+  });
+});
+
+describe('AdminSalesChart money', () => {
+  beforeEach(() => {
+    getSalesTrend.mockReset();
+  });
+
+  it('groups the tooltip figure the Indian way', async () => {
+    getSalesTrend.mockResolvedValue({
+      trend: [{ date: '2026-08-01', revenue: 1234567 }],
+    });
+
+    render(<AdminSalesChart />);
+
+    expect(await screen.findByText('₹12,34,567')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #411.

`npm test` in `bookshelf-backend` was failing on:

```
not ok 4 - handles large numbers
  + actual   - expected
  + '₹1,234,567'
  - '₹12,34,567'
```

The assertion is right — that is how 1234567 rupees is written. The thing it
asserted against was not part of the application.

## The test was testing copies of the code

`tests/adminController.test.js` defined its own `dateFilter` and its own
`formatCurrency` at the top of the file:

```js
/**
 * Re-implementation of the dateFilter helper from adminController.js.
 * Kept in sync for independent testing.
 */
function dateFilter(period) { … }
```

Nothing enforced the sync. The real `dateFilter` — which decides the range
behind every `/api/admin/analytics` query — could have been changed to anything
and those eight tests would still have passed. It is exported from
`adminController.js` and imported by the test now.

## The currency helper was real, just not in this package

The `formatCurrency` block is **deleted** rather than repaired, because there
is no `formatCurrency` in the backend. The function it was copying — comment
and all, "matching the frontend helper" — lives in
`bookshelf-frontend/src/pages/AdminDashboard.jsx`:

```js
function formatCurrency(value) {
  return `₹${(value || 0).toLocaleString()}`;
}
```

That is where the grouping was actually wrong, and it is wrong twice:

- **`toLocaleString()` with no locale** groups by whatever the *browser* is set
  to. Total revenue of 1234567 rendered `₹1,234,567` for most visitors and
  `₹12,34,567` for someone on an en-IN browser. Only the second is a rupee
  figure. (This is also why the backend copy's result depended on the CI
  runner's locale — the assertion was correct and the machine simply wasn't
  en-IN.)
- **`|| 0`** turns a KPI that failed to load into a confident `₹0`. A dashboard
  must not report zero revenue when what it has is *no revenue figure*.
  `config/currency.js` and `utils/currency.js` both document this trap and both
  guard it.

`utils/currency.js` has been the single formatter since #335 — it takes the
locale from the currency table and renders `—` for an absent amount. The
dashboard uses it.

Three more places were doing the same thing inline:

| file | was |
|---|---|
| `AdminTopBooks.jsx` | `₹{book.totalRevenue.toLocaleString()}` |
| `AdminRecentOrders.jsx` | `₹{order.total.toLocaleString()}` |
| `AdminSalesChart.jsx` | `₹{entry.revenue.toLocaleString()}` |

The first two call the method straight on the field, so a row whose amount came
back null is a `TypeError` that takes the whole table down with it. All four go
through `formatMoney` now.

## A build error hiding behind an unrouted page

Writing the test surfaced this:

```
Failed to resolve import "../components/AdminRecentOrders.css" from "src/pages/AdminDashboard.jsx"
```

There is no `AdminRecentOrders.css` — `AdminTopBooks.css` carries the shared
`.admin-table*` set, badges included, for both components. An unresolved import
fails a Vite build outright. It has survived because **nothing routes to
`AdminDashboard`**, so the page has never been in the bundle graph for the
build to walk. Import removed.

(The page not being reachable from `App.jsx` is worth a look, but that is a
decision about the app rather than a repair, so it is left alone here.)

## And one more test that asserted nothing

```js
it('has all expected admin endpoints', () => {
  for (const ep of endpoints) {
    assert.strictEqual(typeof ep, 'string');   // endpoints is a list of strings
    assert.ok(ep.length > 0);
  }
});
```

True of any list of strings, and unconnected to the router. It reads
`adminRouter.stack` now, so a removed or renamed route fails it — plus a check
that the eight are the *only* routes and that `protect`/`admin` are mounted
ahead of them.

## Tests

**Backend** — `tests/adminController.test.js`, 20 tests, every one against
shipped code: the `dateFilter` ranges, the Mongo-matchable shape it produces, a
fresh `Date` per call, and the router's real stack.

**Frontend** — `src/pages/AdminDashboard.test.jsx`, new, 9 tests. jsdom runs in
en-US, so these fail on the old code and pass on the new for exactly the reason
a browser did:

- `₹12,34,567`, and explicitly *not* `₹1,234,567`
- no trailing `.00` on a whole-rupee figure
- `—` for a KPI the API did not return, and `₹0` still shown for a real zero
- a top-books row whose `totalRevenue` is null renders instead of throwing
- the same grouping in the orders table and the chart tooltip

```
✓ src/pages/AdminDashboard.test.jsx  (9 tests)
node --test tests/adminController.test.js  →  # pass 20  # fail 0
```

Both `main`'s open breakages (the Checkout build error, the two review test
files) are still present on this branch — they are #408 and #410, in flight
separately. This branch adds none.

---

### About the red checks

CI runs lint and both test suites over the whole monorepo for every PR, and
`main` still carries breakages that this branch does not touch. Every failure
on this PR is fixed by one of the sibling PRs below, none of which conflicts
with this one:

| failing check | fixed by |
|---|---|
| `bookshelf-frontend` lint — `'beforeEach' is not defined` | #417 |
| `bookshelf-frontend` — `BookDetail.test.jsx` (11 tests) | #414 |
| `bookshelf-backend` — `reviewController.test.js`, `reviewSystem.test.js` | #415 |

The two **Vercel** checks fail with "Authorization required to deploy" on every
PR in this repository, including merged ones from other authors — that needs
the repo owner to authorise the integration and is not caused by any change
here.

I merged all five branches together locally to check they compose. With the
set applied:

```
bookshelf-frontend  npm run build   ✓
bookshelf-frontend  npm run lint    0 errors  (2 before)
bookshelf-frontend  npm test        799 passed, 0 failed   (20 failed before)
bookshelf-backend   npm test        575 passed, 0 failed   (3 failed before)
```
