### PR TITLE
Make the rating breakdown readable to a screen reader

### DIFF
--- a/bookshelf-frontend/src/components/CouponInput.test.jsx
+++ b/bookshelf-frontend/src/components/CouponInput.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import CouponInput from './CouponInput.jsx';
 

--- a/bookshelf-frontend/src/components/RatingBreakdown.css
+++ b/bookshelf-frontend/src/components/RatingBreakdown.css
@@ -1,9 +1,37 @@
 /* ── Rating Breakdown ──────────────────────────────────────────────── */
 
+/*
+ * This stylesheet existed but nothing imported it — not the component, not
+ * ReviewSummary which renders it. So the track and the fill had no height and
+ * no background and the chart rendered as five bare lines of text. The
+ * component imports it now.
+ */
 .rating-breakdown {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
+  /* A <ul> now, for the row semantics — so its list styling has to go. */
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/*
+ * The one sentence per row that a screen reader reads: "5 stars: 10 reviews,
+ * 50%". Off-screen rather than display:none, which would take it out of the
+ * accessibility tree — the one thing it is here for. Same technique as
+ * .pagination__status.
+ */
+.rating-breakdown__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .rating-breakdown__row {
@@ -22,6 +50,7 @@
 }
 
 .rating-breakdown__track {
+  display: block;
   flex: 1;
   height: 10px;
   background: var(--color-progress-track, #e5e7eb);
@@ -30,10 +59,19 @@
 }
 
 .rating-breakdown__fill {
+  display: block;
   height: 100%;
+  min-width: 0;
   background: var(--color-star-filled, #f59e0b);
   border-radius: 999px;
   transition: width 0.35s ease;
+}
+
+/* A bar that animates on load is motion the reader did not ask for. */
+@media (prefers-reduced-motion: reduce) {
+  .rating-breakdown__fill {
+    transition: none;
+  }
 }
 
 .rating-breakdown__count {

--- a/bookshelf-frontend/src/components/RatingBreakdown.jsx
+++ b/bookshelf-frontend/src/components/RatingBreakdown.jsx
@@ -1,37 +1,86 @@
+import './RatingBreakdown.css';
+
 /**
- * RatingBreakdown — horizontal bar chart showing the distribution of star
- * ratings for a book.  The five bars are labelled 5→1 (best first) and each
- * one is filled proportionally to the count of reviews at that star level.
+ * RatingBreakdown — the distribution of star ratings for a book, five rows
+ * labelled 5 down to 1, each with a bar and a count.
+ *
+ * The component's whole job is to answer a question the average cannot: is
+ * this 4.2 made of consistent fours, or of fives and ones? That answer lives
+ * in the numbers, so the numbers have to be reachable.
+ *
+ * They were not. The container carried `role="img"` with
+ * `aria-label="Rating distribution"`, which tells assistive technology to
+ * treat the entire subtree as one graphic and to substitute that label for
+ * everything inside it. Every star level, every count and every percentage —
+ * all of them real text in the DOM — became unreachable, and a screen reader
+ * user got "Rating distribution, image" and nothing else. The label is static
+ * too, so there was no fallback: it says the same thing for a book with four
+ * hundred reviews as for one with two.
+ *
+ * `role="img"` is for a graphic whose meaning cannot be expressed in the
+ * markup — an SVG glyph, a sparkline drawn in canvas. It is not for a list of
+ * numbers. This is a list of numbers, so it is a list now: each row carries
+ * one plain sentence for a screen reader, and the bar beside it is marked
+ * decorative, because a coloured rectangle adds nothing to "10 reviews, 50
+ * per cent" once that has been said.
  */
 export default function RatingBreakdown({ breakdown = [], totalReviews = 0 }) {
   if (!Array.isArray(breakdown) || breakdown.length === 0) {
     return null;
   }
 
-  const maxCount = Math.max(...breakdown.map((b) => b.count), 1);
+  /*
+   * Percentages are of the total, so a total that does not match the rows
+   * would produce percentages that do not add up. The caller's figure is
+   * trusted when it is usable and the rows are summed when it is not, rather
+   * than dividing by a zero and rendering five 0% rows under a chart that
+   * plainly has bars in it.
+   */
+  const rowTotal = breakdown.reduce(
+    (sum, entry) => sum + (Number(entry?.count) || 0),
+    0
+  );
+  const total = Number(totalReviews) > 0 ? Number(totalReviews) : rowTotal;
 
   return (
-    <div className="rating-breakdown" role="img" aria-label="Rating distribution">
+    <ul className="rating-breakdown">
       {breakdown.map(({ star, count }) => {
-        const pct = totalReviews > 0 ? Math.round((count / totalReviews) * 100) : 0;
-        const barWidth = Math.round((count / maxCount) * 100);
+        const reviews = Number(count) || 0;
+        const pct = total > 0 ? Math.round((reviews / total) * 100) : 0;
+
+        /*
+         * The bar and the number next to it measure the same thing.
+         *
+         * The fill used to be `count / maxCount`, so the tallest bar was
+         * always drawn full width while the text beside it read
+         * `count / totalReviews`. On a book with 10 five-star reviews out of
+         * 20, the 5★ bar was full and labelled 50%.
+         */
+        const width = total > 0 ? (reviews / total) * 100 : 0;
 
         return (
-          <div key={star} className="rating-breakdown__row">
-            <span className="rating-breakdown__label">{star} ★</span>
-            <div className="rating-breakdown__track">
-              <div
+          <li key={star} className="rating-breakdown__row">
+            <span className="rating-breakdown__sr-only">
+              {`${star} ${star === 1 ? 'star' : 'stars'}: `}
+              {`${reviews} ${reviews === 1 ? 'review' : 'reviews'}, ${pct}%`}
+            </span>
+
+            <span className="rating-breakdown__label" aria-hidden="true">
+              {star} ★
+            </span>
+            <span className="rating-breakdown__track" aria-hidden="true">
+              <span
                 className="rating-breakdown__fill"
-                style={{ width: `${barWidth}%` }}
+                style={{ width: `${width}%` }}
               />
-            </div>
-            <span className="rating-breakdown__count">
-              {count}
+            </span>
+            <span className="rating-breakdown__count" aria-hidden="true">
+              {reviews}
               <span className="rating-breakdown__pct"> ({pct}%)</span>
             </span>
-          </div>
+          </li>
         );
       })}
-    </div>
+    </ul>
   );
 }

--- a/bookshelf-frontend/src/components/RatingBreakdown.test.jsx
+++ b/bookshelf-frontend/src/components/RatingBreakdown.test.jsx
@@ -1,12 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import RatingBreakdown from './RatingBreakdown.jsx';
 
 /**
- * Unit tests for the RatingBreakdown component.
+ * RatingBreakdown — the star distribution.
  *
- * Validates the star-distribution bar chart renders correctly for various
- * input shapes.
+ * The queries here are all scoped to a row. The previous version asked for
+ * `getByText(/3/)` and `getByText(/10/)` and called it "shows count for each
+ * star level"; with the fixture below, `/3/` matches three different nodes —
+ * the `3 ★` label, the count `3`, and the `(30%)` on the 4★ row — so the test
+ * failed outright. An unanchored single digit cannot tell a star level from a
+ * count from a percentage, so even where it passed it was not checking what
+ * its name claimed. `/6/` found the 4★ count only by luck of which digits
+ * happened to appear elsewhere.
  */
 
 const sampleBreakdown = [
@@ -17,21 +23,52 @@ const sampleBreakdown = [
   { star: 1, count: 0 },
 ];
 
+/**
+ * The row for a star level, found by the sentence a screen reader reads.
+ *
+ * That sentence is real text, positioned off-screen, rather than an
+ * aria-label: a <li> takes its accessible name from the author, not from its
+ * content, so a label would have to be an attribute — and off-screen text is
+ * announced more consistently across screen readers than aria-label is.
+ */
+function rowFor(star) {
+  const label = screen.getByText(new RegExp(`^${star} stars?:`));
+  return label.closest('li');
+}
+
+/** What that row says, with the whitespace normalised. */
+function announcementFor(star) {
+  return screen.getByText(new RegExp(`^${star} stars?:`)).textContent.trim();
+}
+
 describe('RatingBreakdown', () => {
   it('renders all five star rows', () => {
     render(<RatingBreakdown breakdown={sampleBreakdown} totalReviews={20} />);
-    expect(screen.getByText('5 ★')).toBeInTheDocument();
-    expect(screen.getByText('4 ★')).toBeInTheDocument();
-    expect(screen.getByText('3 ★')).toBeInTheDocument();
-    expect(screen.getByText('2 ★')).toBeInTheDocument();
-    expect(screen.getByText('1 ★')).toBeInTheDocument();
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(5);
+    for (const star of [5, 4, 3, 2, 1]) {
+      expect(screen.getByText(`${star} ★`)).toBeInTheDocument();
+    }
   });
 
-  it('shows count for each star level', () => {
+  it('shows the count for each star level', () => {
     render(<RatingBreakdown breakdown={sampleBreakdown} totalReviews={20} />);
-    expect(screen.getByText(/10/)).toBeInTheDocument();
-    expect(screen.getByText(/6/)).toBeInTheDocument();
-    expect(screen.getByText(/3/)).toBeInTheDocument();
+
+    // Scoped to the row, so `3` is unambiguously the 3★ count.
+    expect(within(rowFor(5)).getByText('10')).toBeInTheDocument();
+    expect(within(rowFor(4)).getByText('6')).toBeInTheDocument();
+    expect(within(rowFor(3)).getByText('3')).toBeInTheDocument();
+    expect(within(rowFor(2)).getByText('1')).toBeInTheDocument();
+    expect(within(rowFor(1)).getByText('0')).toBeInTheDocument();
+  });
+
+  it('shows each level as a percentage of the total', () => {
+    render(<RatingBreakdown breakdown={sampleBreakdown} totalReviews={20} />);
+
+    expect(within(rowFor(5)).getByText('(50%)')).toBeInTheDocument();
+    expect(within(rowFor(4)).getByText('(30%)')).toBeInTheDocument();
+    expect(within(rowFor(3)).getByText('(15%)')).toBeInTheDocument();
+    expect(within(rowFor(1)).getByText('(0%)')).toBeInTheDocument();
   });
 
   it('renders nothing for an empty breakdown', () => {
@@ -48,8 +85,113 @@ describe('RatingBreakdown', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('has accessible label', () => {
-    render(<RatingBreakdown breakdown={sampleBreakdown} totalReviews={20} />);
-    expect(screen.getByRole('img', { name: /rating distribution/i })).toBeInTheDocument();
+  describe('what a screen reader gets', () => {
+    it('reads the numbers, not just a title', () => {
+      // role="img" on the container used to collapse the whole subtree into
+      // one graphic labelled "Rating distribution", and every count and
+      // percentage in it became unreachable.
+      render(<RatingBreakdown breakdown={sampleBreakdown} totalReviews={20} />);
+
+      expect(announcementFor(5)).toBe('5 stars: 10 reviews, 50%');
+      expect(announcementFor(3)).toBe('3 stars: 3 reviews, 15%');
+    });
+
+    it('says "1 star" and "1 review", not "1 stars"', () => {
+      render(<RatingBreakdown breakdown={sampleBreakdown} totalReviews={20} />);
+
+      expect(announcementFor(2)).toBe('2 stars: 1 review, 5%');
+      expect(announcementFor(1)).toBe('1 star: 0 reviews, 0%');
+    });
+
+    it('announces a level with no reviews rather than leaving a blank bar', () => {
+      render(<RatingBreakdown breakdown={sampleBreakdown} totalReviews={20} />);
+
+      expect(announcementFor(1)).toMatch(/0 reviews, 0%/);
+    });
+
+    it('is a list, not an image', () => {
+      const { container } = render(
+        <RatingBreakdown breakdown={sampleBreakdown} totalReviews={20} />
+      );
+
+      expect(screen.getByRole('list')).toBeInTheDocument();
+      expect(screen.queryByRole('img')).not.toBeInTheDocument();
+      expect(container.querySelectorAll('[role="img"]')).toHaveLength(0);
+    });
+
+    it('hides the decorative bar from the accessibility tree', () => {
+      const { container } = render(
+        <RatingBreakdown breakdown={sampleBreakdown} totalReviews={20} />
+      );
+
+      const track = container.querySelector('.rating-breakdown__track');
+      expect(track).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  describe('the bar', () => {
+    /** The inline width the fill was given, as a number. */
+    function widthOf(star, container) {
+      const row = [...container.querySelectorAll('.rating-breakdown__row')].find(
+        (node) => node.textContent.startsWith(`${star} stars`) ||
+          node.textContent.startsWith(`${star} star:`)
+      );
+      return Number.parseFloat(
+        row.querySelector('.rating-breakdown__fill').style.width
+      );
+    }
+
+    it('measures the same thing as the number beside it', () => {
+      // The fill used to be count / maxCount while the text was
+      // count / totalReviews, so the tallest bar was always drawn full width.
+      // Here that meant a 5★ bar filling the track and labelled 50%.
+      const { container } = render(
+        <RatingBreakdown breakdown={sampleBreakdown} totalReviews={20} />
+      );
+
+      expect(widthOf(5, container)).toBe(50);
+      expect(widthOf(4, container)).toBe(30);
+      expect(widthOf(1, container)).toBe(0);
+    });
+
+    it('never fills a bar past the track', () => {
+      const { container } = render(
+        <RatingBreakdown breakdown={[{ star: 5, count: 20 }]} totalReviews={20} />
+      );
+
+      expect(widthOf(5, container)).toBe(100);
+    });
+  });
+
+  describe('when totalReviews does not describe the rows', () => {
+    it('falls back to the sum of the counts rather than dividing by zero', () => {
+      render(<RatingBreakdown breakdown={sampleBreakdown} totalReviews={0} />);
+
+      // 10 of 20 is still half, even with the total omitted.
+      expect(announcementFor(5)).toBe('5 stars: 10 reviews, 50%');
+    });
+
+    it('survives a breakdown of nothing but zeroes', () => {
+      render(
+        <RatingBreakdown
+          breakdown={[{ star: 5, count: 0 }, { star: 4, count: 0 }]}
+          totalReviews={0}
+        />
+      );
+
+      expect(announcementFor(5)).toBe('5 stars: 0 reviews, 0%');
+    });
+
+    it('treats a missing or non-numeric count as zero', () => {
+      render(
+        <RatingBreakdown
+          breakdown={[{ star: 5, count: 4 }, { star: 4 }, { star: 3, count: null }]}
+          totalReviews={4}
+        />
+      );
+
+      expect(announcementFor(4)).toBe('4 stars: 0 reviews, 0%');
+      expect(announcementFor(3)).toBe('3 stars: 0 reviews, 0%');
+    });
   });
 });


### PR DESCRIPTION
Fixes #412.

## The chart announced nothing but its own title

```jsx
<div className="rating-breakdown" role="img" aria-label="Rating distribution">
```

`role="img"` tells assistive technology to treat the entire subtree as a single
graphic and to substitute `aria-label` for everything inside it. The star
labels, the counts and the percentages are all real text in the DOM, and
`role="img"` is precisely what made them unreachable — a screen reader user got
"Rating distribution, image" and no distribution. The label is static, so there
was no fallback either: it says the same thing for a book with 400 reviews as
for one with two.

That role is for a graphic whose meaning cannot be expressed in markup — an SVG
glyph, a canvas sparkline. This is a list of numbers, and the numbers are the
entire point of the component: it exists to answer what the average cannot,
whether a 4.2 is consistent fours or a mix of fives and ones.

It is a `<ul>` now. Each row carries one off-screen sentence —

> 5 stars: 10 reviews, 50%

— and the bar next to it is `aria-hidden`, because a coloured rectangle adds
nothing once that has been said. Off-screen text rather than an `aria-label`
for two reasons: a `<li>` takes its accessible name from the author rather than
from its content, so a label would have to be an attribute; and real text is
announced more consistently across screen readers than `aria-label` is.

## Three more things in the same component

**The bar and the number disagreed.** The fill was `count / maxCount`, so the
tallest bar was always drawn full width, while the text beside it was
`count / totalReviews`. On the test fixture the 5★ bar filled the track and was
labelled 50%. Both are of the total now.

**`totalReviews={0}` produced five 0% rows** under a chart that plainly has bars
in it. The row counts are summed as a fallback when the caller's total is not
usable, and a missing or non-numeric `count` reads as zero rather than NaN.

**`RatingBreakdown.css` was never imported** — not by the component, not by
`ReviewSummary` which renders it. The track and the fill had no height and no
background, so the chart drew as five bare lines of text. Imported, with the
list styling reset and the fill's transition dropped under
`prefers-reduced-motion`.

## The test was failing, and not testing what it said

```
TestingLibraryElementError: Found multiple elements with the text: /3/
```

```js
expect(screen.getByText(/10/)).toBeInTheDocument();
expect(screen.getByText(/6/)).toBeInTheDocument();
expect(screen.getByText(/3/)).toBeInTheDocument();
```

With `[{star:5,count:10},{star:4,count:6},{star:3,count:3},…]` and
`totalReviews={20}`, `/3/` matches the `3 ★` label, the count `3`, and the
`(30%)` on the 4★ row. An unanchored single digit cannot distinguish a star
level from a count from a percentage — so even the assertions that passed were
not checking what their names claimed. `/6/` found the 4★ count only by luck of
which digits happened to appear elsewhere.

Every query is scoped to a row now (15 tests, from 5): the counts and
percentages per level, the announcements including the singular "1 star" and
"1 review", that no `role="img"` survives anywhere, that the decorative track
is hidden, the bar widths matching the labels, and the degenerate totals.

## Also

`CouponInput.test.jsx` used `beforeEach` without importing it from vitest —
one of the two hard errors in `npm run lint`. `globals: true` is not set in the
vitest config, so it works at run time only because nothing has tripped it yet.

```
✓ src/components/RatingBreakdown.test.jsx  (15 tests)
✓ src/components/CouponInput.test.jsx      (5 tests)
```

`npm run lint` on this branch is down to the one remaining error, the Checkout
parse failure — that is #408, in flight as a separate PR. Full frontend suite
goes from 3 failing files / 20 failing tests on `main` to 2 / 19; the two left
are #408 and #409.

---

### About the red checks

CI runs lint and both test suites over the whole monorepo for every PR, and
`main` still carries breakages that this branch does not touch. Every failure
on this PR is fixed by one of the sibling PRs below, none of which conflicts
with this one:

| failing check | fixed by |
|---|---|
| `bookshelf-frontend` — `BookDetail.test.jsx` (11 tests) | #414 |
| `bookshelf-backend` — `not ok 2 - formatCurrency` | #416 |
| `bookshelf-backend` — `reviewController.test.js`, `reviewSystem.test.js` | #415 |

The two **Vercel** checks fail with "Authorization required to deploy" on every
PR in this repository, including merged ones from other authors — that needs
the repo owner to authorise the integration and is not caused by any change
here.

I merged all five branches together locally to check they compose. With the
set applied:

```
bookshelf-frontend  npm run build   ✓
bookshelf-frontend  npm run lint    0 errors  (2 before)
bookshelf-frontend  npm test        799 passed, 0 failed   (20 failed before)
bookshelf-backend   npm test        575 passed, 0 failed   (3 failed before)
```
