### PR TITLE
Charge the discount the coupon row promises

### DIFF
--- a/bookshelf-backend/controllers/couponController.js
+++ b/bookshelf-backend/controllers/couponController.js
@@ -1,37 +1,62 @@
 import Coupon from '../models/Coupon.js';
+import {
+  COUPON_REJECTION,
+  MAX_COUPON_CODE_LENGTH,
+  evaluateCoupon,
+  normaliseCouponCode,
+} from '../utils/coupon.js';
+import { toMajorUnits, toMinorUnits } from '../utils/money.js';
+import { formatAmount, getCurrencyConfig } from '../config/currency.js';
 
-// ── Public: validate a coupon code and return the discount ──────────────────
-
+/**
+ * @desc    Preview what a coupon is worth against a cart
+ * @route   POST /api/coupons/validate
+ * @access  Public
+ *
+ * A *preview*, and only a preview. It answers the checkout page's question
+ * "is this code any good, and roughly what will it save me" so the customer
+ * gets an answer while typing rather than after submitting.
+ *
+ * It does not decide what anyone is charged. The subtotal in the body comes
+ * from the client and cannot be trusted with a price, so the binding
+ * calculation happens again inside `createIntent` against the server's own
+ * priced cart. The two agree because both call `evaluateCoupon`, which is why
+ * that lives in utils/coupon.js rather than here. See #418.
+ */
 export const validateCoupon = async (req, res, next) => {
   try {
-    const code = String(req.body.code || '').trim().toUpperCase();
+    const code = normaliseCouponCode(req.body?.code);
     if (!code) return res.status(400).json({ message: 'Coupon code is required' });
 
+    if (code.length > MAX_COUPON_CODE_LENGTH) {
+      // `Coupon.code` is capped at 30, so a longer string cannot match a
+      // document. The route is unauthenticated; no reason to ask the database.
+      return res.status(404).json({ message: 'Invalid coupon code' });
+    }
+
     const coupon = await Coupon.findOne({ code });
-    if (!coupon) return res.status(404).json({ message: 'Invalid coupon code' });
-    if (!coupon.active) return res.status(400).json({ message: 'This coupon is no longer active' });
-    if (coupon.expiresAt && coupon.expiresAt < new Date()) {
-      return res.status(400).json({ message: 'This coupon has expired' });
-    }
-    if (coupon.maxUses > 0 && coupon.usedCount >= coupon.maxUses) {
-      return res.status(400).json({ message: 'This coupon has reached its usage limit' });
-    }
 
-    const subtotal = Number(req.body.subtotal) || 0;
-    if (subtotal < coupon.minOrderAmount) {
-      return res.status(400).json({
-        message: `Minimum order amount of ₹${coupon.minOrderAmount} required`,
-      });
-    }
+    const currency = getCurrencyConfig();
+    const subtotal = Number(req.body?.subtotal);
+    const subtotalMinor = toMinorUnits(
+      Number.isFinite(subtotal) && subtotal > 0 ? subtotal : 0
+    );
 
-    let discount = coupon.discountType === 'percentage'
-      ? Math.round((subtotal * coupon.discountValue) / 100 * 100) / 100
-      : coupon.discountValue;
+    const outcome = evaluateCoupon(coupon, subtotalMinor);
 
-    if (coupon.maxDiscount > 0) {
-      discount = Math.min(discount, coupon.maxDiscount);
+    if (!outcome.ok) {
+      const status = outcome.reason === COUPON_REJECTION.NOT_FOUND ? 404 : 400;
+
+      // The minimum-order sentence is assembled here rather than in
+      // utils/coupon.js, which has no business knowing the shop's currency.
+      // It used to hardcode a `₹`, which was wrong for a USD deployment.
+      const message =
+        outcome.reason === COUPON_REJECTION.BELOW_MINIMUM
+          ? `Minimum order amount of ${formatAmount(outcome.minOrderAmount, currency)} required`
+          : outcome.message;
+
+      return res.status(status).json({ message, reason: outcome.reason });
     }
-    discount = Math.min(discount, subtotal);
 
     res.json({
       valid: true,
@@ -39,19 +64,39 @@ export const validateCoupon = async (req, res, next) => {
       description: coupon.description,
       discountType: coupon.discountType,
       discountValue: coupon.discountValue,
-      discount,
+      discount: toMajorUnits(outcome.discountMinor),
+      currency: currency.code,
     });
   } catch (error) {
     next(error);
   }
 };
 
-// ── Admin: mark a coupon as used (called after successful payment) ──────────
-
+/**
+ * Count one redemption against a coupon.
+ *
+ * Was exported and called from nowhere, so `usedCount` never moved and the
+ * `maxUses` check in `validateCoupon` could never fire — a single-use coupon
+ * was infinitely reusable. `createIntent` calls it now. See #418.
+ *
+ * `$inc` rather than read-modify-write so two checkouts redeeming the last
+ * use of a coupon at the same time cannot both read the same `usedCount`.
+ * The increment is atomic; the check that precedes it is not, so a coupon can
+ * still be overshot by one under a genuine race. That is the right trade here
+ * — refusing a paid-for discount after the card has been charged is worse
+ * than honouring one extra redemption.
+ */
 export const recordCouponUse = async (code) => {
-  await Coupon.findOneAndUpdate(
-    { code: code.toUpperCase() },
-    { $inc: { usedCount: 1 } }
+  const normalised = normaliseCouponCode(code);
+
+  if (!normalised) {
+    return null;
+  }
+
+  return Coupon.findOneAndUpdate(
+    { code: normalised },
+    { $inc: { usedCount: 1 } },
+    { new: true }
   );
 };
 

--- a/bookshelf-backend/controllers/paymentController.js
+++ b/bookshelf-backend/controllers/paymentController.js
@@ -5,8 +5,15 @@ import {
   updateInventoryWithOCC,
   restoreInventory,
 } from '../repositories/bookRepository.js';
-import { prepareCheckout, CheckoutValidationError } from '../utils/checkout.js';
+import { prepareCheckout, priceOrder, CheckoutValidationError } from '../utils/checkout.js';
 import { getCurrencyConfig, formatAmount } from '../config/currency.js';
+import Coupon from '../models/Coupon.js';
+import { recordCouponUse } from './couponController.js';
+import {
+  MAX_COUPON_CODE_LENGTH,
+  evaluateCoupon,
+  normaliseCouponCode,
+} from '../utils/coupon.js';
 
 /**
  * @desc    Create a payment intent for a cart
@@ -27,9 +34,14 @@ import { getCurrencyConfig, formatAmount } from '../config/currency.js';
  *      overselling in the window between charging and reserving.
  *   3. Create the order and the payment intent. Anything that fails from
  *      here on releases the reservation before returning.
+ *
+ * The coupon, if there is one, is resolved between 1 and 2 — after the cart
+ * is priced, because the discount depends on the server's subtotal, and
+ * before anything is written, because a coupon problem should leave the same
+ * nothing behind that a bad cart does.
  */
 export const createIntent = async (req, res, next) => {
-  const { items, shippingAddress } = req.body ?? {};
+  const { items, shippingAddress, couponCode } = req.body ?? {};
 
   /*
    * One currency, read once, used for the price, for the payment intent and
@@ -52,6 +64,50 @@ export const createIntent = async (req, res, next) => {
     }
 
     return next(error);
+  }
+
+  /*
+   * Resolve the coupon against the subtotal the *server* just computed.
+   *
+   * Neither the code nor the discount is taken on trust. The frontend posts a
+   * code and nothing else — it has no way to state an amount — and the
+   * discount is recomputed here from the catalogue-priced cart. Previously no
+   * coupon reached this function at all: the page displayed a discount from
+   * `/api/coupons/validate` and the intent was created for the full amount.
+   * See #418.
+   */
+  let coupon = null;
+  let couponRejection = null;
+
+  try {
+    coupon = await resolveCoupon(couponCode, checkout.minorUnits.subtotal);
+  } catch (error) {
+    if (error?.couponRejection) {
+      /*
+       * A coupon that will not apply does not fail the checkout.
+       *
+       * The cart is valid and the customer is mid-payment; refusing the whole
+       * order because a code expired between the preview and the submit would
+       * lose the sale over the cheaper of the two problems. The order is
+       * priced without it and the response says so, so the summary can tell
+       * the customer why the discount is not there.
+       */
+      couponRejection = error.couponRejection;
+    } else {
+      return next(error);
+    }
+  }
+
+  if (coupon) {
+    // Re-price with the discount. Same cart, same catalogue lookup, so the
+    // reservation below is unaffected — only the money changes.
+    checkout = {
+      ...checkout,
+      ...priceOrder(checkout.items, {
+        currency,
+        discountMinor: coupon.discountMinor,
+      }),
+    };
   }
 
   // Reserve stock. A version mismatch or insufficient stock is the client's
@@ -107,6 +163,10 @@ export const createIntent = async (req, res, next) => {
        */
       currency: checkout.currency,
       subtotal: checkout.subtotal,
+      // What was actually taken off, and by which code. Recorded so the order
+      // history shows the price that was paid rather than the list price.
+      discount: checkout.discount,
+      couponCode: coupon ? coupon.code : '',
       tax: checkout.tax,
       shipping: checkout.shipping,
       total: checkout.total,
@@ -147,6 +207,30 @@ export const createIntent = async (req, res, next) => {
     savedOrder.stripePaymentIntentId = paymentIntent.id;
     await orderRepository.save(savedOrder);
 
+    /*
+     * Count the redemption once the intent exists, not before.
+     *
+     * Before, and a customer who abandoned the page would have burned a use
+     * of a single-use coupon they never redeemed. This is the first moment
+     * the order is real enough to charge for.
+     *
+     * It is deliberately not awaited into the failure path: a coupon counter
+     * that did not increment must never turn a successful checkout into an
+     * error response. It is logged instead, which is what a human would need
+     * to reconcile it.
+     */
+    if (coupon) {
+      try {
+        await recordCouponUse(coupon.code);
+      } catch (error) {
+        console.error(
+          `[checkout] could not record use of coupon ${coupon.code} ` +
+            `for order ${savedOrder._id}:`,
+          error.message
+        );
+      }
+    }
+
     // Past this point the reservation belongs to the order, and the webhook
     // is responsible for it: payment_intent.payment_failed and
     // payment_intent.canceled are where it gets released.
@@ -162,10 +246,20 @@ export const createIntent = async (req, res, next) => {
       amount: {
         currency: checkout.currency,
         subtotal: checkout.subtotal,
+        discount: checkout.discount,
         tax: checkout.tax,
         shipping: checkout.shipping,
         total: checkout.total,
       },
+      /*
+       * The applied code, or null. The checkout summary renders its discount
+       * row from this and from `amount.discount` — never from what the client
+       * worked out for itself — so the number on screen is by construction
+       * the number being charged.
+       */
+      coupon: coupon ? { code: coupon.code, discount: checkout.discount } : null,
+      // Present only when a code was sent and could not be applied.
+      couponError: couponRejection,
     });
   } catch (error) {
     release('the payment intent could not be created');
@@ -192,3 +286,41 @@ export const createIntent = async (req, res, next) => {
     return next(error);
   }
 };
+
+/**
+ * Look a coupon up and decide what it is worth against a priced cart.
+ *
+ * Returns `null` when no code was sent — the ordinary case — and throws an
+ * error carrying `couponRejection` when a code was sent but will not apply,
+ * so the caller can tell "no coupon" from "that coupon is no good" without
+ * inspecting a result shape.
+ *
+ * @param {unknown} rawCode      whatever arrived in the request body
+ * @param {number}  subtotalMinor the server's subtotal, in minor units
+ */
+async function resolveCoupon(rawCode, subtotalMinor) {
+  const code = normaliseCouponCode(rawCode);
+
+  if (!code) {
+    return null;
+  }
+
+  if (code.length > MAX_COUPON_CODE_LENGTH) {
+    throw couponRejected('not_found', 'Invalid coupon code');
+  }
+
+  const coupon = await Coupon.findOne({ code });
+  const outcome = evaluateCoupon(coupon, subtotalMinor);
+
+  if (!outcome.ok) {
+    throw couponRejected(outcome.reason, outcome.message);
+  }
+
+  return { code: coupon.code, discountMinor: outcome.discountMinor };
+}
+
+function couponRejected(reason, message) {
+  const error = new Error(`Coupon rejected: ${message}`);
+  error.couponRejection = { reason, message };
+  return error;
+}

--- a/bookshelf-backend/models/Order.js
+++ b/bookshelf-backend/models/Order.js
@@ -37,6 +37,17 @@ const orderSchema = new mongoose.Schema(
       default: 'INR',
     },
     subtotal: { type: Number, required: true },
+    /*
+     * What a coupon took off, and which coupon did it.
+     *
+     * Recorded on the order rather than recomputed from the code at render
+     * time, for the same reason `currency` is: the coupon can later be edited
+     * or deactivated, and the order must keep saying what was actually
+     * charged. Defaulted rather than `required` so orders written before #418
+     * still load.
+     */
+    discount: { type: Number, required: true, default: 0, min: 0 },
+    couponCode: { type: String, uppercase: true, trim: true, default: '' },
     tax: { type: Number, required: true, default: 0 },
     shipping: { type: Number, required: true, default: 0 },
     total: { type: Number, required: true },

--- a/bookshelf-backend/tests/checkout.test.js
+++ b/bookshelf-backend/tests/checkout.test.js
@@ -248,6 +248,10 @@ describe('priceOrder', () => {
 
     assert.deepEqual(minorUnits, {
       subtotal: 104700,
+      // Zero rather than absent when no coupon was applied, so a caller never
+      // has to tell "no discount" from "this response predates discounts".
+      // See #418.
+      discount: 0,
       tax: 5235,
       shipping: 4900,
       total: 114835,

--- a/bookshelf-backend/tests/coupon.test.js
+++ b/bookshelf-backend/tests/coupon.test.js
@@ -1,0 +1,342 @@
+import test, { describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  COUPON_REJECTION,
+  CouponError,
+  computeDiscountMinor,
+  evaluateCoupon,
+  normaliseCouponCode,
+} from '../utils/coupon.js';
+import { priceOrder } from '../utils/checkout.js';
+import { SUPPORTED_CURRENCIES } from '../config/currency.js';
+import { toMinorUnits } from '../utils/money.js';
+
+/**
+ * Coupons, priced in minor units.
+ *
+ * The old tests for this lived in couponController.test.js and exercised a
+ * copy of the logic pasted into the test file, so they passed while the
+ * shipped controller did something else. These import the module the
+ * controller and the payment intent both call. See #418.
+ */
+
+const INR = SUPPORTED_CURRENCIES.INR;
+
+/** A coupon with every field set, so a test only states what it changes. */
+function coupon(overrides = {}) {
+  return {
+    code: 'SAVE10',
+    active: true,
+    discountType: 'percentage',
+    discountValue: 10,
+    minOrderAmount: 0,
+    maxDiscount: 0,
+    maxUses: 0,
+    usedCount: 0,
+    expiresAt: undefined,
+    ...overrides,
+  };
+}
+
+describe('normaliseCouponCode', () => {
+  test('trims and upper-cases', () => {
+    assert.equal(normaliseCouponCode('  save10 '), 'SAVE10');
+  });
+
+  test('returns empty for anything that is not a string', () => {
+    // The trap this exists to avoid: String(undefined) is 'undefined', a
+    // seven-character truthy string, which is exactly how the collections
+    // endpoint came to store a book id of "undefined".
+    for (const value of [undefined, null, 42, {}, [], true]) {
+      assert.equal(normaliseCouponCode(value), '');
+    }
+  });
+
+  test('returns empty for whitespace', () => {
+    assert.equal(normaliseCouponCode('   '), '');
+  });
+});
+
+describe('computeDiscountMinor — the arithmetic', () => {
+  test('a percentage discount is exact where the float version was not', () => {
+    // 15% of 1047.00 is 157.04999999999998 in floating point. The old
+    // expression was Math.round(x / 100 * 100) / 100 on that value.
+    const subtotalMinor = toMinorUnits(1047);
+    const discount = computeDiscountMinor(
+      coupon({ discountType: 'percentage', discountValue: 15 }),
+      subtotalMinor
+    );
+
+    assert.equal(discount, 15705);
+    assert.ok(Number.isSafeInteger(discount));
+  });
+
+  test('a fixed discount converts to minor units', () => {
+    const discount = computeDiscountMinor(
+      coupon({ discountType: 'fixed', discountValue: 50 }),
+      toMinorUnits(200)
+    );
+
+    assert.equal(discount, 5000);
+  });
+
+  test('rounds half up, once', () => {
+    // 33% of 1.05 is 0.3465 -> 34.65 minor units -> 35.
+    const discount = computeDiscountMinor(
+      coupon({ discountType: 'percentage', discountValue: 33 }),
+      105
+    );
+
+    assert.equal(discount, 35);
+  });
+
+  test('maxDiscount caps the payout', () => {
+    const discount = computeDiscountMinor(
+      coupon({ discountValue: 50, maxDiscount: 30 }),
+      toMinorUnits(200)
+    );
+
+    assert.equal(discount, toMinorUnits(30));
+  });
+
+  test('the subtotal caps the payout', () => {
+    const discount = computeDiscountMinor(
+      coupon({ discountType: 'fixed', discountValue: 500 }),
+      toMinorUnits(100)
+    );
+
+    assert.equal(discount, toMinorUnits(100));
+  });
+
+  test('maxDiscount is applied before the subtotal cap, not after', () => {
+    /*
+     * A "₹500 off, up to ₹200" coupon against a ₹100 order.
+     *
+     * Capping by the subtotal first gives min(500, 100) = 100, then
+     * min(100, 200) = 100 — the order is free. Capping by maxDiscount first
+     * gives min(500, 200) = 200, then min(200, 100) = 100. Same answer here,
+     * so the case that actually separates them:
+     */
+    const discount = computeDiscountMinor(
+      coupon({ discountType: 'fixed', discountValue: 500, maxDiscount: 200 }),
+      toMinorUnits(300)
+    );
+
+    // maxDiscount first: min(500, 200) = 200, then min(200, 300) = 200.
+    assert.equal(discount, toMinorUnits(200));
+  });
+
+  test('refuses a discount type it does not know', () => {
+    assert.throws(
+      () => computeDiscountMinor(coupon({ discountType: 'buy-one-get-one' }), 1000),
+      (error) => error instanceof CouponError && error.reason === COUPON_REJECTION.MALFORMED
+    );
+  });
+
+  test('refuses a negative discount value', () => {
+    assert.throws(
+      () => computeDiscountMinor(coupon({ discountValue: -10 }), 1000),
+      CouponError
+    );
+  });
+});
+
+describe('evaluateCoupon — eligibility', () => {
+  test('a missing coupon is not found rather than a crash', () => {
+    const outcome = evaluateCoupon(null, 10000);
+    assert.equal(outcome.ok, false);
+    assert.equal(outcome.reason, COUPON_REJECTION.NOT_FOUND);
+  });
+
+  test('an inactive coupon is refused', () => {
+    const outcome = evaluateCoupon(coupon({ active: false }), 10000);
+    assert.equal(outcome.ok, false);
+    assert.equal(outcome.reason, COUPON_REJECTION.INACTIVE);
+  });
+
+  test('an expired coupon is refused', () => {
+    const outcome = evaluateCoupon(
+      coupon({ expiresAt: new Date('2020-01-01') }),
+      10000
+    );
+    assert.equal(outcome.ok, false);
+    assert.equal(outcome.reason, COUPON_REJECTION.EXPIRED);
+  });
+
+  test('expiry is compared against the injected clock', () => {
+    const expiresAt = new Date('2030-06-01');
+
+    assert.equal(
+      evaluateCoupon(coupon({ expiresAt }), 10000, { now: new Date('2030-05-31') }).ok,
+      true
+    );
+    assert.equal(
+      evaluateCoupon(coupon({ expiresAt }), 10000, { now: new Date('2030-06-02') }).ok,
+      false
+    );
+  });
+
+  test('an expiry stored as a string still compares', () => {
+    // Mongoose gives a Date, but a lean() read or a fixture may not.
+    const outcome = evaluateCoupon(coupon({ expiresAt: '2020-01-01T00:00:00.000Z' }), 10000);
+    assert.equal(outcome.reason, COUPON_REJECTION.EXPIRED);
+  });
+
+  test('a coupon at its usage limit is refused', () => {
+    const outcome = evaluateCoupon(coupon({ maxUses: 1, usedCount: 1 }), 10000);
+    assert.equal(outcome.ok, false);
+    assert.equal(outcome.reason, COUPON_REJECTION.LIMIT_REACHED);
+  });
+
+  test('maxUses of 0 means unlimited', () => {
+    const outcome = evaluateCoupon(coupon({ maxUses: 0, usedCount: 999 }), 10000);
+    assert.equal(outcome.ok, true);
+  });
+
+  test('a subtotal below the minimum is refused, and reports the minimum', () => {
+    const outcome = evaluateCoupon(coupon({ minOrderAmount: 500 }), toMinorUnits(499));
+
+    assert.equal(outcome.ok, false);
+    assert.equal(outcome.reason, COUPON_REJECTION.BELOW_MINIMUM);
+    // The controller formats this with the shop's currency. The message from
+    // this module carries no currency symbol of its own — the one that used
+    // to be hardcoded here was a ₹ on a USD deployment.
+    assert.equal(outcome.minOrderAmount, 500);
+    assert.doesNotMatch(outcome.message, /[₹$]/);
+  });
+
+  test('a subtotal exactly at the minimum is allowed', () => {
+    const outcome = evaluateCoupon(coupon({ minOrderAmount: 500 }), toMinorUnits(500));
+    assert.equal(outcome.ok, true);
+  });
+
+  test('a usable coupon reports the discount in minor units', () => {
+    const outcome = evaluateCoupon(coupon({ discountValue: 20 }), toMinorUnits(1000));
+
+    assert.equal(outcome.ok, true);
+    assert.equal(outcome.discountMinor, toMinorUnits(200));
+  });
+
+  test('a malformed coupon is a rejection, not a throw', () => {
+    // It reaches the checkout, where a throw would be a 500 mid-payment.
+    const outcome = evaluateCoupon(coupon({ discountType: 'mystery' }), 10000);
+    assert.equal(outcome.ok, false);
+    assert.equal(outcome.reason, COUPON_REJECTION.MALFORMED);
+  });
+});
+
+describe('priceOrder — where the discount lands in the total', () => {
+  const items = [
+    { bookId: 'b1', quantity: 3, book: { id: 'b1', title: 'The Quiet Ones', price: 349 } },
+  ];
+
+  test('no discount prices exactly as before', () => {
+    const priced = priceOrder(items, { currency: INR });
+
+    assert.equal(priced.subtotal, 1047);
+    assert.equal(priced.discount, 0);
+    assert.equal(priced.tax, 52.35);
+    assert.equal(priced.shipping, 49);
+    assert.equal(priced.total, 1148.35);
+  });
+
+  test('the discount comes off the subtotal before the tax is computed', () => {
+    const priced = priceOrder(items, { currency: INR, discountMinor: toMinorUnits(100) });
+
+    // Subtotal is still the list price — the customer should see what the
+    // books cost and what came off, not a silently reduced subtotal.
+    assert.equal(priced.subtotal, 1047);
+    assert.equal(priced.discount, 100);
+    // 5% of 947, not of 1047.
+    assert.equal(priced.tax, 47.35);
+    assert.equal(priced.total, 947 + 47.35 + 49);
+  });
+
+  test('the minor-unit total is the one Stripe is handed, and it is discounted', () => {
+    const priced = priceOrder(items, { currency: INR, discountMinor: toMinorUnits(100) });
+
+    assert.equal(priced.minorUnits.discount, 10000);
+    assert.equal(priced.minorUnits.total, 104335);
+    assert.ok(Number.isSafeInteger(priced.minorUnits.total));
+  });
+
+  test('shipping is not discounted', () => {
+    const priced = priceOrder(items, {
+      currency: INR,
+      discountMinor: toMinorUnits(1047),
+    });
+
+    assert.equal(priced.discount, 1047);
+    assert.equal(priced.tax, 0);
+    assert.equal(priced.shipping, 49);
+    // The goods are free; the delivery is not.
+    assert.equal(priced.total, 49);
+  });
+
+  test('a discount larger than the subtotal is clamped, not subtracted', () => {
+    const priced = priceOrder(items, {
+      currency: INR,
+      discountMinor: toMinorUnits(99999),
+    });
+
+    assert.equal(priced.discount, 1047);
+    assert.equal(priced.total, 49);
+    assert.ok(priced.total > 0, 'a coupon must never produce a refund');
+  });
+
+  test('a negative discount is ignored rather than charged as a surcharge', () => {
+    const priced = priceOrder(items, { currency: INR, discountMinor: -50000 });
+
+    assert.equal(priced.discount, 0);
+    assert.equal(priced.total, 1148.35);
+  });
+
+  test('a non-numeric discount is ignored', () => {
+    for (const value of [undefined, null, NaN, 'free', {}]) {
+      const priced = priceOrder(items, { currency: INR, discountMinor: value });
+      assert.equal(priced.discount, 0, `discountMinor=${String(value)}`);
+    }
+  });
+
+  test('the discount is reported in both units and they agree', () => {
+    const priced = priceOrder(items, { currency: INR, discountMinor: 15705 });
+
+    assert.equal(priced.minorUnits.discount, 15705);
+    assert.equal(priced.discount, 157.05);
+  });
+});
+
+describe('the coupon rules and the pricing compose', () => {
+  const items = [
+    { bookId: 'b1', quantity: 3, book: { id: 'b1', title: 'The Quiet Ones', price: 349 } },
+  ];
+
+  test('a percentage coupon end to end', () => {
+    const subtotalMinor = priceOrder(items, { currency: INR }).minorUnits.subtotal;
+    const outcome = evaluateCoupon(coupon({ discountValue: 15 }), subtotalMinor);
+
+    assert.equal(outcome.ok, true);
+
+    const priced = priceOrder(items, {
+      currency: INR,
+      discountMinor: outcome.discountMinor,
+    });
+
+    assert.equal(priced.discount, 157.05);
+    assert.equal(priced.subtotal - priced.discount, 889.95);
+    assert.equal(priced.tax, 44.5);
+    assert.equal(priced.total, 889.95 + 44.5 + 49);
+  });
+
+  test('a refused coupon prices the same cart at full price', () => {
+    const subtotalMinor = priceOrder(items, { currency: INR }).minorUnits.subtotal;
+    const outcome = evaluateCoupon(coupon({ active: false }), subtotalMinor);
+
+    assert.equal(outcome.ok, false);
+    assert.equal(outcome.discountMinor, undefined);
+
+    const priced = priceOrder(items, { currency: INR });
+    assert.equal(priced.total, 1148.35);
+  });
+});

--- a/bookshelf-backend/tests/couponController.test.js
+++ b/bookshelf-backend/tests/couponController.test.js
@@ -1,26 +1,30 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
+import { evaluateCoupon } from '../utils/coupon.js';
+import { toMajorUnits, toMinorUnits } from '../utils/money.js';
+
 /**
- * Unit tests for coupon validation logic.
+ * Coupon validation, as the controller performs it.
  *
- * Exercises the discount computation extracted from couponController.js.
+ * This file used to define its own `computeDiscount` at the top and test
+ * that. The copy and the shipped controller then drifted — and because the
+ * copy was the only thing under test, the suite stayed green while
+ * `validateCoupon` computed a discount that nothing ever charged. See #418.
+ *
+ * The helper below now calls the real `evaluateCoupon`, the same function the
+ * controller and `createIntent` both use, and converts at the boundary so
+ * these cases can keep speaking in whole rupees.
+ *
+ * The deeper coverage — rounding, cap ordering, how the discount lands in the
+ * total — is in tests/coupon.test.js.
  */
-
 function computeDiscount(coupon, subtotal) {
-  if (!coupon.active) return { valid: false, reason: 'inactive' };
-  if (coupon.expiresAt && coupon.expiresAt < new Date()) return { valid: false, reason: 'expired' };
-  if (coupon.maxUses > 0 && coupon.usedCount >= coupon.maxUses) return { valid: false, reason: 'limit' };
-  if (subtotal < coupon.minOrderAmount) return { valid: false, reason: 'min_order' };
+  const outcome = evaluateCoupon(coupon, toMinorUnits(subtotal));
 
-  let discount = coupon.discountType === 'percentage'
-    ? Math.round((subtotal * coupon.discountValue) / 100 * 100) / 100
-    : coupon.discountValue;
-
-  if (coupon.maxDiscount > 0) discount = Math.min(discount, coupon.maxDiscount);
-  discount = Math.min(discount, subtotal);
-
-  return { valid: true, discount };
+  return outcome.ok
+    ? { valid: true, discount: toMajorUnits(outcome.discountMinor) }
+    : { valid: false, reason: outcome.reason };
 }
 
 describe('computeDiscount', () => {
@@ -65,5 +69,19 @@ describe('computeDiscount', () => {
   it('rejects when subtotal below minimum', () => {
     const result = computeDiscount({ active: true, discountType: 'fixed', discountValue: 10, minOrderAmount: 200, maxDiscount: 0, maxUses: 0, usedCount: 0 }, 100);
     assert.strictEqual(result.valid, false);
+  });
+
+  it('reports a machine-readable reason, not just a boolean', () => {
+    // The checkout needs to tell "you mistyped it" from "it ran out while you
+    // were filling in your address", which reads the same to a customer and
+    // means something different.
+    assert.strictEqual(
+      computeDiscount({ active: false, discountType: 'fixed', discountValue: 10, minOrderAmount: 0, maxDiscount: 0, maxUses: 0, usedCount: 0 }, 100).reason,
+      'inactive'
+    );
+    assert.strictEqual(
+      computeDiscount({ active: true, discountType: 'fixed', discountValue: 10, minOrderAmount: 200, maxDiscount: 0, maxUses: 0, usedCount: 0 }, 100).reason,
+      'below_minimum'
+    );
   });
 });

--- a/bookshelf-backend/utils/checkout.js
+++ b/bookshelf-backend/utils/checkout.js
@@ -237,7 +237,20 @@ function describe(value) {
  */
 export function priceOrder(
   items,
-  { taxRate = TAX_RATE, currency = getCurrencyConfig(), shipping = currency.defaultShipping } = {}
+  {
+    taxRate = TAX_RATE,
+    currency = getCurrencyConfig(),
+    shipping = currency.defaultShipping,
+    /*
+     * A coupon discount, already decided, in minor units.
+     *
+     * It arrives as a number rather than as a coupon document because this
+     * module prices carts and knows nothing about coupons — utils/coupon.js
+     * decides *whether* and *how much*, and this decides where it lands in
+     * the total. See #418.
+     */
+     discountMinor = 0,
+  } = {}
 ) {
   const orderItems = [];
   const lineTotals = [];
@@ -257,9 +270,26 @@ export function priceOrder(
   }
 
   const subtotalMinor = sum(lineTotals);
-  const taxMinor = applyRate(subtotalMinor, taxRate);
+
+  /*
+   * Clamped here as well as in utils/coupon.js. That is deliberate
+   * belt-and-braces: this function is exported and a future caller could pass
+   * a discount from somewhere that has not run the coupon rules. A discount
+   * larger than the subtotal would otherwise make the goods free and start
+   * eating into the tax and the shipping, and a negative one would be a
+   * surcharge wearing a discount's name.
+   */
+  const appliedDiscountMinor = clampDiscount(discountMinor, subtotalMinor);
+
+  /*
+   * Tax is charged on what the customer actually pays for the goods, not on
+   * the list price — so the discount comes off before the rate is applied.
+   * Shipping is not discounted: a coupon is against the order's contents.
+   */
+  const discountedSubtotalMinor = subtotalMinor - appliedDiscountMinor;
+  const taxMinor = applyRate(discountedSubtotalMinor, taxRate);
   const shippingMinor = toMinorUnits(shipping);
-  const totalMinor = sum([subtotalMinor, taxMinor, shippingMinor]);
+  const totalMinor = sum([discountedSubtotalMinor, taxMinor, shippingMinor]);
 
   return {
     orderItems,
@@ -270,15 +300,42 @@ export function priceOrder(
     currency: currency.code,
     minorUnits: {
       subtotal: subtotalMinor,
+      discount: appliedDiscountMinor,
       tax: taxMinor,
       shipping: shippingMinor,
       total: totalMinor,
     },
     subtotal: toMajorUnits(subtotalMinor),
+    /*
+     * Always present, and zero when no coupon was used, so a caller never has
+     * to distinguish "no discount" from "this response predates discounts".
+     * The checkout summary renders the row from this rather than from what
+     * the client computed for itself.
+     */
+    discount: toMajorUnits(appliedDiscountMinor),
     tax: toMajorUnits(taxMinor),
     shipping: toMajorUnits(shippingMinor),
     total: toMajorUnits(totalMinor),
   };
+}
+
+/**
+ * A discount that is a whole number of minor units, at least nothing, and at
+ * most the whole subtotal.
+ *
+ * A non-integer is rounded rather than refused: the callers all produce
+ * integers, so reaching this with a fraction means a rounding slipped through
+ * somewhere upstream, and turning that into a 500 in the middle of a checkout
+ * is worse than absorbing it.
+ */
+function clampDiscount(discountMinor, subtotalMinor) {
+  const value = Number(discountMinor);
+
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+
+  return Math.min(Math.round(value), subtotalMinor);
 }
 
 /**

--- a/bookshelf-backend/utils/coupon.js
+++ b/bookshelf-backend/utils/coupon.js
@@ -1,0 +1,223 @@
+/**
+ * Coupon eligibility and discount arithmetic.
+ *
+ * Pure functions over a plain coupon object, so the rule that decides how
+ * much a customer is let off can be tested without MongoDB — and, more to the
+ * point, so it can be run in two places and give the same answer both times.
+ *
+ * The bug this replaces: there was no shared rule. `validateCoupon` computed a
+ * discount for the checkout page to display, and the payment intent was
+ * created without ever hearing about it. The customer saw a discount row and
+ * was charged as though it were not there. See #418.
+ *
+ * Everything here works in integer minor units, like utils/money.js, for the
+ * same reason: the old expression was
+ *
+ *     Math.round((subtotal * coupon.discountValue) / 100 * 100) / 100
+ *
+ * — a float divided by 100 and multiplied by 100 to fake two decimal places.
+ * A 15% discount on 1047 gives 157.04999999999998 before that rounding and
+ * 157.05 after, and the value handed to Stripe would have been the first one.
+ * In minor units it is one integer multiply and one deliberate round.
+ */
+
+import { MoneyError, applyRate, toMinorUnits } from './money.js';
+
+/**
+ * Why a coupon was refused.
+ *
+ * A machine-readable reason next to the human sentence, because the checkout
+ * has to tell the two kinds apart: a code that is simply wrong is worth
+ * showing to the customer, while a code that was valid when they typed it and
+ * has since hit its usage limit has to be reported differently — by then they
+ * are mid-checkout and the cart is still good.
+ */
+export const COUPON_REJECTION = Object.freeze({
+  NOT_FOUND: 'not_found',
+  INACTIVE: 'inactive',
+  EXPIRED: 'expired',
+  LIMIT_REACHED: 'limit_reached',
+  BELOW_MINIMUM: 'below_minimum',
+  MALFORMED: 'malformed',
+});
+
+/**
+ * The longest code we will look up.
+ *
+ * `Coupon.code` is capped at 30 characters by the schema, so anything longer
+ * cannot match a document and there is no reason to send it to the database.
+ * `/api/coupons/validate` is unauthenticated.
+ */
+export const MAX_COUPON_CODE_LENGTH = 30;
+
+export class CouponError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.name = 'CouponError';
+    this.status = 400;
+    this.reason = reason;
+  }
+}
+
+/**
+ * Normalise a code the way the schema stores it: trimmed and upper-cased.
+ *
+ * Returns `''` for anything that is not a usable string, so the caller has a
+ * single falsy check rather than a type check and an emptiness check. Note
+ * `String(undefined)` is `'undefined'` — a seven-character truthy string — so
+ * the type has to be tested before the coercion, not after.
+ */
+export function normaliseCouponCode(raw) {
+  if (typeof raw !== 'string') {
+    return '';
+  }
+
+  return raw.trim().toUpperCase();
+}
+
+/**
+ * The discount a coupon is worth against a subtotal, in minor units.
+ *
+ * Order of the two caps matters and is not arbitrary:
+ *
+ *   1. `maxDiscount` first — it is a cap on the coupon's generosity, and a
+ *      "20% off, up to ₹200" coupon means 200 is the ceiling on the 20%.
+ *   2. The subtotal second — a discount larger than the order would make the
+ *      goods free and then start refunding the tax and the shipping.
+ *
+ * Doing it the other way round lets a fixed ₹500 coupon with a ₹200 cap pay
+ * out 200 on a 100-rupee order.
+ */
+export function computeDiscountMinor(coupon, subtotalMinor) {
+  if (!Number.isSafeInteger(subtotalMinor) || subtotalMinor < 0) {
+    throw new MoneyError(
+      `Subtotal must be a non-negative integer of minor units, received ${subtotalMinor}`
+    );
+  }
+
+  const value = Number(coupon?.discountValue);
+
+  if (!Number.isFinite(value) || value < 0) {
+    throw new CouponError(
+      COUPON_REJECTION.MALFORMED,
+      'This coupon is not configured correctly'
+    );
+  }
+
+  let discountMinor;
+
+  if (coupon.discountType === 'percentage') {
+    // `applyRate` rounds half up, once, on an integer — the same rounding the
+    // tax gets, so a discount and a tax of the same size never disagree by a
+    // paisa for reasons nobody can reconstruct.
+    discountMinor = applyRate(subtotalMinor, value / 100);
+  } else if (coupon.discountType === 'fixed') {
+    discountMinor = toMinorUnits(value);
+  } else {
+    throw new CouponError(
+      COUPON_REJECTION.MALFORMED,
+      'This coupon is not configured correctly'
+    );
+  }
+
+  const maxDiscount = Number(coupon.maxDiscount) || 0;
+
+  if (maxDiscount > 0) {
+    discountMinor = Math.min(discountMinor, toMinorUnits(maxDiscount));
+  }
+
+  return Math.min(discountMinor, subtotalMinor);
+}
+
+/**
+ * Decide whether a coupon may be used against a subtotal, and for how much.
+ *
+ * Returns `{ ok: true, discountMinor, coupon }` or `{ ok: false, reason,
+ * message }` rather than throwing, because both answers are ordinary: a
+ * customer mistyping a code is not an exceptional condition.
+ *
+ * `subtotalMinor` is the *server's* subtotal, priced from the catalogue.
+ * That is the whole point of this function taking minor units — the previous
+ * code read `req.body.subtotal`, so the number the discount was computed
+ * against was whatever the client said it was, and a client that says its
+ * cart is worth ₹100000 gets a percentage discount to match. See #418.
+ *
+ * `now` is injected so an expiry test does not have to sleep.
+ */
+export function evaluateCoupon(coupon, subtotalMinor, { now = new Date() } = {}) {
+  if (!coupon) {
+    return {
+      ok: false,
+      reason: COUPON_REJECTION.NOT_FOUND,
+      message: 'Invalid coupon code',
+    };
+  }
+
+  if (!coupon.active) {
+    return {
+      ok: false,
+      reason: COUPON_REJECTION.INACTIVE,
+      message: 'This coupon is no longer active',
+    };
+  }
+
+  if (coupon.expiresAt && new Date(coupon.expiresAt) < now) {
+    return {
+      ok: false,
+      reason: COUPON_REJECTION.EXPIRED,
+      message: 'This coupon has expired',
+    };
+  }
+
+  const maxUses = Number(coupon.maxUses) || 0;
+  const usedCount = Number(coupon.usedCount) || 0;
+
+  if (maxUses > 0 && usedCount >= maxUses) {
+    return {
+      ok: false,
+      reason: COUPON_REJECTION.LIMIT_REACHED,
+      message: 'This coupon has reached its usage limit',
+    };
+  }
+
+  const minOrderMinor = toMinorUnits(Number(coupon.minOrderAmount) || 0);
+
+  if (subtotalMinor < minOrderMinor) {
+    return {
+      ok: false,
+      reason: COUPON_REJECTION.BELOW_MINIMUM,
+      // The caller formats the amount — this module has no opinion about
+      // which currency the shop trades in, and the `₹` that used to be
+      // hardcoded into this sentence was wrong for a USD deployment. See #335.
+      message: 'minimum order amount not met',
+      minOrderAmount: Number(coupon.minOrderAmount) || 0,
+    };
+  }
+
+  try {
+    return { ok: true, coupon, discountMinor: computeDiscountMinor(coupon, subtotalMinor) };
+  } catch (error) {
+    if (error instanceof CouponError) {
+      return { ok: false, reason: error.reason, message: error.message };
+    }
+
+    if (error instanceof MoneyError) {
+      return {
+        ok: false,
+        reason: COUPON_REJECTION.MALFORMED,
+        message: 'This coupon is not configured correctly',
+      };
+    }
+
+    throw error;
+  }
+}
+
+export default {
+  COUPON_REJECTION,
+  MAX_COUPON_CODE_LENGTH,
+  CouponError,
+  normaliseCouponCode,
+  computeDiscountMinor,
+  evaluateCoupon,
+};

--- a/bookshelf-frontend/src/components/CouponInput.jsx
+++ b/bookshelf-frontend/src/components/CouponInput.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { validateCoupon } from '../services/couponService.js';
+import { formatMoney } from '../utils/currency.js';
 import './CouponInput.css';
 
 /**
@@ -8,11 +9,25 @@ import './CouponInput.css';
  *
  * Props:
  *   subtotal   the current cart subtotal (for min-order checks)
+ *   currency   the currency the shop is pricing in, once known
  *   onApply    callback({ code, discount, discountType }) when valid
  *   onRemove   callback() when the user clears an applied coupon
  *   disabled   disable the input (e.g. while payment is processing)
+ *
+ * What this component reports is a *preview*. The saving in the badge is what
+ * the server says the code is worth against the cart the browser knows about;
+ * the amount actually taken off is recomputed server-side when the payment
+ * intent is created, and rendered by the checkout summary from that response.
+ * The two agree, but only one of them is binding, and it is not this one.
+ * See #418.
  */
-export default function CouponInput({ subtotal = 0, onApply, onRemove, disabled = false }) {
+export default function CouponInput({
+  subtotal = 0,
+  currency,
+  onApply,
+  onRemove,
+  disabled = false,
+}) {
   const [code, setCode] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -58,9 +73,11 @@ export default function CouponInput({ subtotal = 0, onApply, onRemove, disabled 
         <span className="coupon-input__badge">
           🏷️ {applied.code} — {applied.discountType === 'percentage'
             ? `${applied.discountValue}% off`
-            : `₹${applied.discountValue} off`}
+            : `${formatMoney(applied.discountValue, { currency: applied.currency ?? currency })} off`}
           {applied.discount > 0 && (
-            <span className="coupon-input__savings"> (−₹{applied.discount})</span>
+            <span className="coupon-input__savings">
+              {' '}(−{formatMoney(applied.discount, { currency: applied.currency ?? currency })})
+            </span>
           )}
         </span>
         <button

--- a/bookshelf-frontend/src/pages/Checkout.css
+++ b/bookshelf-frontend/src/pages/Checkout.css
@@ -584,3 +584,53 @@
   outline-offset: 3px;
   border-radius: 2px;
 }
+
+/*
+ * The discount row.
+ *
+ * It renders only when the server actually applied a coupon, so its presence
+ * is itself information: a row here means the total below is lower because of
+ * it. Green, and the only green in the summary, so the eye lands on the one
+ * line that reduces the bill. See #418.
+ */
+.checkout__total-row--discount dt {
+  color: var(--ink-soft, #5a5147);
+}
+
+.checkout__discount {
+  color: #0f7b4f;
+  font-variant-numeric: tabular-nums;
+}
+
+/*
+ * Said when a code was accepted at preview time and refused at payment time —
+ * expired, deactivated, or out of uses in between. The order is still priced
+ * and still payable, so this is a notice rather than an error: it explains a
+ * missing discount row, it does not report a failure.
+ */
+.checkout__coupon-notice {
+  margin: 0.5rem 0 0;
+  padding: 0.55rem 0.7rem;
+  border-radius: 8px;
+  border: 1px solid #e5c98a;
+  background: #fdf6e6;
+  color: #7a5a12;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+@media (prefers-color-scheme: dark) {
+  .checkout__discount {
+    color: #4ade80;
+  }
+}
+
+[data-theme='dark'] .checkout__discount {
+  color: #4ade80;
+}
+
+[data-theme='dark'] .checkout__coupon-notice {
+  border-color: #6b5520;
+  background: #2c2412;
+  color: #e8cf94;
+}

--- a/bookshelf-frontend/src/pages/Checkout.jsx
+++ b/bookshelf-frontend/src/pages/Checkout.jsx
@@ -81,8 +81,21 @@ export default function Checkout() {
   // Only known once the server has priced the cart; until then the summary
   // labels its subtotal with this deployment's configured currency.
   const [currency, setCurrency] = useState(undefined);
-  const [couponDiscount, setCouponDiscount] = useState(0);
+  /*
+   * The code the customer typed, and the coupon the *server* actually
+   * applied. Two values, deliberately.
+   *
+   * `couponCode` is an intent: what to send with the next create-intent call.
+   * `appliedCoupon` is a fact: what came back on the response, alongside the
+   * total that was charged for it. The summary renders the fact.
+   *
+   * They used to be one thing — a discount from `/api/coupons/validate`,
+   * rendered next to a total that had never heard of it, so the page showed a
+   * saving the customer did not get. See #418.
+   */
   const [couponCode, setCouponCode] = useState('');
+  const [appliedCoupon, setAppliedCoupon] = useState(null);
+  const [couponNotice, setCouponNotice] = useState('');
 
   /*
    * Which of the three views the page is showing: the address form
@@ -143,6 +156,13 @@ export default function Checkout() {
       const data = await paymentService.createPaymentIntent({
         items,
         shippingAddress: normalised,
+        /*
+         * The code only. Not the discount, and not the subtotal — the server
+         * prices the cart from the catalogue and recomputes what the coupon
+         * is worth against *that*. A client that could state its own discount
+         * could state its own price.
+         */
+        couponCode: couponCode || undefined,
       });
 
       if (!data?.clientSecret) {
@@ -153,6 +173,21 @@ export default function Checkout() {
       setOrderId(data.orderId ?? '');
       setAmount(data.amount ?? null);
       setCurrency(data.currency ?? data.amount?.currency);
+
+      /*
+       * What the server did with the code, which is not always what the
+       * preview promised: a coupon can expire, be deactivated or hit its
+       * usage limit between the customer applying it and submitting the
+       * address. The order is priced without it in that case rather than
+       * refused — the cart is still good — so the page has to say why the
+       * discount is gone instead of quietly dropping the row.
+       */
+      setAppliedCoupon(data.coupon ?? null);
+      setCouponNotice(
+        data.couponError
+          ? `${data.couponError.message}. The order has been priced without it.`
+          : ''
+      );
     } catch (error) {
       // The old page swallowed this into console.error and left the customer
       // on a spinner forever. Say what happened and let them retry.
@@ -328,19 +363,26 @@ export default function Checkout() {
 
           <CouponInput
             subtotal={subtotal}
+            currency={currency}
             onApply={(result) => {
-              setCouponDiscount(result.discount || 0);
+              // Only the code is kept. The saving shown in the badge is the
+              // preview's estimate; the binding number arrives with the
+              // payment intent and is rendered in the totals below.
               setCouponCode(result.code || '');
+              setCouponNotice('');
             }}
-            onRemove={() => { setCouponDiscount(0); setCouponCode(''); }}
+            onRemove={() => {
+              setCouponCode('');
+              setAppliedCoupon(null);
+              setCouponNotice('');
+            }}
             disabled={!!clientSecret}
           />
 
-          {couponCode && amount && (
-            <div className="checkout__total-row">
-              <dt>Discount ({couponCode})</dt>
-              <dd className="checkout__discount">−{money(couponDiscount, currency)}</dd>
-            </div>
+          {couponNotice && (
+            <p className="checkout__coupon-notice" role="status">
+              {couponNotice}
+            </p>
           )}
 
           <ul className="checkout__lines">
@@ -365,6 +407,25 @@ export default function Checkout() {
 
             {amount && (
               <>
+                {/*
+                  Rendered from the server's response, and only when the
+                  server actually applied something. It sits between the
+                  subtotal and the tax because that is where it lands in the
+                  arithmetic — the tax below is charged on the discounted
+                  goods.
+                */}
+                {amount.discount > 0 && (
+                  <div className="checkout__total-row checkout__total-row--discount">
+                    <dt>
+                      Discount
+                      {appliedCoupon?.code ? ` (${appliedCoupon.code})` : ''}
+                    </dt>
+                    <dd className="checkout__discount">
+                      −{money(amount.discount, currency)}
+                    </dd>
+                  </div>
+                )}
+
                 <div className="checkout__total-row">
                   <dt>Tax</dt>
                   <dd>{money(amount.tax, currency)}</dd>

--- a/bookshelf-frontend/src/pages/Checkout.test.jsx
+++ b/bookshelf-frontend/src/pages/Checkout.test.jsx
@@ -27,6 +27,13 @@ vi.mock('../services/paymentService.js', () => ({
   },
 }));
 
+const validateCoupon = vi.fn();
+
+vi.mock('../services/couponService.js', () => ({
+  validateCoupon: (...args) => validateCoupon(...args),
+  default: { validateCoupon: (...args) => validateCoupon(...args) },
+}));
+
 const CART = [
   { id: 'b1', title: 'The Quiet Ones', price: 349, quantity: 2, cover: '#7A2E2E' },
   { id: 'b3', title: 'Half Moon Bay', price: 399, quantity: 1, cover: '#B85C2C' },
@@ -88,6 +95,7 @@ describe('Checkout', () => {
   beforeEach(async () => {
     window.localStorage.clear();
     createPaymentIntent.mockReset();
+    validateCoupon.mockReset();
     await loadCheckout();
   });
 
@@ -306,5 +314,179 @@ describe('Checkout', () => {
       expect(screen.getByRole('heading', { name: /shipping address/i })).toBeInTheDocument()
     );
     expect(errors.join('\n')).not.toMatch(/Rendered more hooks/);
+  });
+
+  /*
+   * Coupons.
+   *
+   * The bug (#418): applying a coupon changed the summary and nothing else.
+   * The code never reached `create-intent`, so the payment intent was created
+   * for the undiscounted total — the page showed a saving the customer was
+   * not given. These tests pin the two halves that make that impossible to
+   * reintroduce: the code has to travel with the request, and the discount
+   * row has to be rendered from the response rather than from the preview.
+   */
+  describe('coupons', () => {
+    const APPLIED = {
+      clientSecret: 'cs_test_123',
+      orderId: 'order-1',
+      currency: 'INR',
+      amount: {
+        currency: 'INR',
+        subtotal: 1097,
+        discount: 100,
+        tax: 49.85,
+        shipping: 49,
+        total: 1095.85,
+      },
+      coupon: { code: 'SAVE100', discount: 100 },
+    };
+
+    async function applyCoupon(user, code = 'SAVE100') {
+      validateCoupon.mockResolvedValue({
+        valid: true,
+        code,
+        discountType: 'fixed',
+        discountValue: 100,
+        discount: 100,
+        currency: 'INR',
+      });
+
+      await user.type(screen.getByPlaceholderText(/have a coupon code/i), code);
+      await user.click(screen.getByRole('button', { name: /^apply$/i }));
+      await screen.findByText(new RegExp(code));
+    }
+
+    it('sends the coupon code to the payment API, and nothing else about it', async () => {
+      const user = userEvent.setup();
+      createPaymentIntent.mockResolvedValue(APPLIED);
+
+      renderCheckout();
+      await applyCoupon(user);
+      await fillAddress(user);
+      await user.click(screen.getByRole('button', { name: /continue to payment/i }));
+
+      await waitFor(() => expect(createPaymentIntent).toHaveBeenCalledTimes(1));
+
+      const payload = createPaymentIntent.mock.calls[0][0];
+      expect(payload.couponCode).toBe('SAVE100');
+
+      /*
+       * The client states the code and nothing more. A discount or a subtotal
+       * in this payload would be a price the customer had chosen for
+       * themselves — the server recomputes both from the catalogue.
+       */
+      expect(payload).not.toHaveProperty('discount');
+      expect(payload).not.toHaveProperty('subtotal');
+      expect(payload).not.toHaveProperty('total');
+    });
+
+    it('omits the coupon field entirely when no code was applied', async () => {
+      const user = userEvent.setup();
+      createPaymentIntent.mockResolvedValue({
+        clientSecret: 'cs_test_123',
+        orderId: 'order-1',
+        currency: 'INR',
+        amount: { currency: 'INR', subtotal: 1097, discount: 0, tax: 54.85, shipping: 49, total: 1200.85 },
+        coupon: null,
+      });
+
+      renderCheckout();
+      await fillAddress(user);
+      await user.click(screen.getByRole('button', { name: /continue to payment/i }));
+
+      await waitFor(() => expect(createPaymentIntent).toHaveBeenCalledTimes(1));
+      expect(createPaymentIntent.mock.calls[0][0].couponCode).toBeUndefined();
+    });
+
+    it('renders the discount the server applied, and a total that accounts for it', async () => {
+      const user = userEvent.setup();
+      createPaymentIntent.mockResolvedValue(APPLIED);
+
+      renderCheckout();
+      await applyCoupon(user);
+      await fillAddress(user);
+      await user.click(screen.getByRole('button', { name: /continue to payment/i }));
+
+      const discountRow = await screen.findByText(/discount \(SAVE100\)/i);
+      expect(discountRow).toBeInTheDocument();
+
+      // The saving and the total both come from the same response, so they
+      // cannot disagree. 1097 − 100 + 49.85 + 49 = 1095.85.
+      expect(screen.getByText('−₹100.00')).toBeInTheDocument();
+      expect(screen.getByText('₹1,095.85')).toBeInTheDocument();
+    });
+
+    it('shows no discount row when the server applied nothing', async () => {
+      const user = userEvent.setup();
+      createPaymentIntent.mockResolvedValue({
+        ...APPLIED,
+        amount: { ...APPLIED.amount, discount: 0, tax: 54.85, total: 1200.85 },
+        coupon: null,
+      });
+
+      renderCheckout();
+      await fillAddress(user);
+      await user.click(screen.getByRole('button', { name: /continue to payment/i }));
+
+      await screen.findByText('₹1,200.85');
+      expect(screen.queryByText(/^Discount/i)).not.toBeInTheDocument();
+    });
+
+    it('explains a coupon the server refused instead of dropping it silently', async () => {
+      const user = userEvent.setup();
+
+      /*
+       * The race this covers: the code validated when the customer typed it,
+       * and hit its usage limit while they filled in the address. The order
+       * is still valid and still payable, so it is priced without the coupon
+       * — but the page has to account for the discount that is no longer
+       * there.
+       */
+      createPaymentIntent.mockResolvedValue({
+        ...APPLIED,
+        amount: { ...APPLIED.amount, discount: 0, tax: 54.85, total: 1200.85 },
+        coupon: null,
+        couponError: {
+          reason: 'limit_reached',
+          message: 'This coupon has reached its usage limit',
+        },
+      });
+
+      renderCheckout();
+      await applyCoupon(user);
+      await fillAddress(user);
+      await user.click(screen.getByRole('button', { name: /continue to payment/i }));
+
+      const notice = await screen.findByRole('status');
+      expect(notice).toHaveTextContent(/reached its usage limit/i);
+      expect(notice).toHaveTextContent(/priced without it/i);
+
+      // Priced without it, and the summary says so rather than showing a row.
+      expect(screen.queryByText(/^Discount/i)).not.toBeInTheDocument();
+      expect(screen.getByText('₹1,200.85')).toBeInTheDocument();
+    });
+
+    it('does not block the checkout when the coupon preview fails', async () => {
+      const user = userEvent.setup();
+      validateCoupon.mockRejectedValue(new Error('Invalid coupon code'));
+      createPaymentIntent.mockResolvedValue({
+        ...APPLIED,
+        amount: { ...APPLIED.amount, discount: 0, tax: 54.85, total: 1200.85 },
+        coupon: null,
+      });
+
+      renderCheckout();
+      await user.type(screen.getByPlaceholderText(/have a coupon code/i), 'NOPE');
+      await user.click(screen.getByRole('button', { name: /^apply$/i }));
+      await screen.findByText(/invalid coupon code/i);
+
+      await fillAddress(user);
+      await user.click(screen.getByRole('button', { name: /continue to payment/i }));
+
+      await waitFor(() => expect(createPaymentIntent).toHaveBeenCalledTimes(1));
+      // A code that never applied is not sent.
+      expect(createPaymentIntent.mock.calls[0][0].couponCode).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
Fixes #418.

## The bug

Applying a coupon changed what the customer was **shown** and not what they were **charged**.

`CouponInput` validates the code against `POST /api/coupons/validate` and `Checkout.jsx` renders a discount row from the answer. But the code never travelled to `POST /api/payments/create-intent` — that handler reads only `items` and `shippingAddress`, and `prepareCheckout` has no notion of a discount. The payment intent was created for the undiscounted total, and that is what Stripe charged.

`recordCouponUse` was the other half. Exported, and called from nowhere:

```
$ grep -rn "recordCouponUse" bookshelf-backend --include="*.js" | grep -v /tests/
bookshelf-backend/controllers/couponController.js:52:export const recordCouponUse = async (code) => {
```

`usedCount` never moved, so the `maxUses > 0 && usedCount >= maxUses` check in `validateCoupon` could never fire. A single-use coupon was infinitely reusable.

## Why the discount could not just be forwarded

`validateCoupon` computes its discount from `req.body.subtotal` — whatever the caller says it is. Passing that number through to the payment intent would let anyone post their own subtotal, or their own discount, and set their own price.

So the rule moved into `utils/coupon.js` as pure functions over minor-unit integers, and both callers use it:

- the **preview** (`/api/coupons/validate`) answers against the client's subtotal, because it is only ever an estimate shown while the customer types;
- the **charge** (`createIntent`) answers again, against the subtotal the server priced from the catalogue, and that one is binding.

They agree because it is the same function. Only one of them decides what is charged, and it is not the one the browser can influence.

## Where the discount lands

`priceOrder` now takes a `discountMinor` and puts it where it belongs:

```
subtotal            1047.00     ← still the list price; the customer sees what came off
discount            − 100.00
tax (5% of 947)       47.35     ← charged on the discounted goods, not the list price
shipping              49.00     ← a coupon is against the order's contents
total                943.35
```

Clamped to the subtotal, so a coupon can never make the total negative or start refunding the shipping. A negative discount is ignored rather than charged as a surcharge. The minor-unit integer handed to Stripe is the discounted one.

## The arithmetic was also wrong in the small

```js
Math.round((subtotal * coupon.discountValue) / 100 * 100) / 100
```

A float divided by 100 and multiplied by 100 to fake two decimal places. 15% of 1047 is `157.04999999999998` before that rounding. In minor units it is one integer multiply and one deliberate half-up round — the same rounding the tax already gets, so a discount and a tax of the same size cannot disagree by a paisa for reasons nobody can reconstruct.

## Also in here

- **`discount` and `couponCode` on the order document.** Recorded rather than recomputed at render time, next to `currency` and for the same reason as #335: the coupon can later be edited or deactivated, and the order has to keep saying what was actually paid. Defaulted rather than required, so pre-#418 orders still load.
- **A refused coupon does not fail the checkout.** A code can expire, be deactivated, or hit its limit between the customer applying it and submitting their address. The cart is still valid and they are mid-payment, so the order is priced without it and the response carries a `couponError` the summary explains — rather than losing the sale over the cheaper of the two problems.
- **`recordCouponUse` is called** once the payment intent exists, not before, so an abandoned checkout does not burn a use. It is `$inc`, and its failure is logged rather than turned into an error response — a counter that did not increment must never fail a checkout that succeeded.
- **The `₹` hardcoded into the minimum-order message and the coupon badge** is gone. It was wrong on a USD deployment, same defect as #335.

## The test that was passing while the bug shipped

`tests/couponController.test.js` defined its own `computeDiscount` at the top of the file and tested that. The copy and the shipped controller had drifted, which is exactly how the suite stayed green while `validateCoupon` computed a discount nothing ever charged. It calls the real `evaluateCoupon` now, and the deeper coverage is in the new `tests/coupon.test.js`.

## Checks

- `bookshelf-backend`: 608 tests pass (575 before, +33).
- `bookshelf-frontend`: 805 tests pass (799 before, +6), lint clean, build clean.

The two Vercel checks fail with "Authorization required to deploy" on every PR in this repo, including merged ones from other authors — it needs the repo owner to authorize the integration and is not caused by this change.
