### PR TITLE
Validate the collections request body instead of trusting it

### DIFF
--- a/bookshelf-backend/controllers/collectionController.js
+++ b/bookshelf-backend/controllers/collectionController.js
@@ -1,4 +1,23 @@
 import Collection from '../models/Collection.js';
+import {
+  MAX_BOOKS_PER_COLLECTION,
+  hasCapacity,
+} from '../utils/collection.js';
+
+/*
+ * Every write route here runs behind `validateBody(schema)` — see
+ * routes/collectionRoutes.js. That is what lets the handlers below read
+ * req.body directly again: by the time one runs, `name` is a trimmed
+ * non-empty string, `description` is a trimmed string or absent, `isPublic`
+ * is a real boolean or absent, and `bookId` is a trimmed non-empty string.
+ * Nothing else survives the middleware.
+ *
+ * The `.trim()` calls that used to be here were not defensive — they were the
+ * bug. `name.trim()` on a request without a name threw a TypeError that
+ * reached the client as a 500, and `String(req.body.bookId).trim()` turned a
+ * missing id into the seven-character string "undefined", which is truthy and
+ * was stored. See #419.
+ */
 
 // ── Get all collections for the current user ───────────────────────────────
 
@@ -35,9 +54,15 @@ export const createCollection = async (req, res, next) => {
     const { name, description, isPublic } = req.body;
     const col = await Collection.create({
       userId: req.user._id,
-      name: name.trim(),
-      description: description || '',
-      isPublic: Boolean(isPublic),
+      name,
+      description: description ?? '',
+      /*
+       * `?? false`, not `Boolean(isPublic)`. The old coercion made the string
+       * "false" — what an HTML form sends for an unchecked box — public.
+       * The validator has already turned "false" into `false`; all this has
+       * to do is supply the default when the field was omitted.
+       */
+      isPublic: isPublic ?? false,
     });
     res.status(201).json({ message: 'Collection created', collection: { ...col.toObject(), id: col._id.toString() } });
   } catch (error) {
@@ -57,10 +82,15 @@ export const updateCollection = async (req, res, next) => {
     if (col.userId.toString() !== req.user._id.toString()) {
       return res.status(403).json({ message: 'Not authorized' });
     }
+    /*
+     * A partial update: only the fields actually sent are touched. The
+     * validator does not require any of them, so a request that flips
+     * `isPublic` alone does not have to resend the name.
+     */
     const { name, description, isPublic } = req.body;
-    if (name !== undefined) col.name = name.trim();
-    if (description !== undefined) col.description = description.trim();
-    if (isPublic !== undefined) col.isPublic = Boolean(isPublic);
+    if (name !== undefined) col.name = name;
+    if (description !== undefined) col.description = description;
+    if (isPublic !== undefined) col.isPublic = isPublic;
     const saved = await col.save();
     res.json({ message: 'Collection updated', collection: { ...saved.toObject(), id: saved._id.toString() } });
   } catch (error) {
@@ -96,11 +126,24 @@ export const addBook = async (req, res, next) => {
     if (col.userId.toString() !== req.user._id.toString()) {
       return res.status(403).json({ message: 'Not authorized' });
     }
-    const bookId = String(req.body.bookId).trim();
-    if (!bookId) return res.status(400).json({ message: 'bookId is required' });
+    const { bookId } = req.body;
+
     if (col.bookIds.includes(bookId)) {
       return res.status(409).json({ message: 'Book already in collection' });
     }
+
+    /*
+     * `bookIds` had no bound, so a loop over this endpoint grew one document
+     * until it hit Mongo's 16 MB limit — after which every save on that
+     * collection fails, not only the ones adding books. The wishlist was
+     * capped for the same reason.
+     */
+    if (!hasCapacity(col.bookIds)) {
+      return res.status(409).json({
+        message: `A collection can hold at most ${MAX_BOOKS_PER_COLLECTION} books`,
+      });
+    }
+
     col.bookIds.push(bookId);
     await col.save();
     res.json({ message: 'Book added', bookIds: col.bookIds });

--- a/bookshelf-backend/routes/collectionRoutes.js
+++ b/bookshelf-backend/routes/collectionRoutes.js
@@ -4,21 +4,33 @@ import {
   deleteCollection, addBook, removeBook,
 } from '../controllers/collectionController.js';
 import { protect } from '../middleware/authMiddleware.js';
+import { validateBody } from '../middleware/validateBody.js';
+import {
+  addBookSchema,
+  createCollectionSchema,
+  updateCollectionSchema,
+} from '../validators/collectionValidators.js';
 
 const router = express.Router();
 
 router.use(protect);
 
+/*
+ * Every write goes through `validateBody`, as the auth and wishlist routes
+ * already did. These three were the last ones in the API without it, and the
+ * controller behind them called `.trim()` on values it had not type-checked.
+ * See #419.
+ */
 router.route('/')
   .get(getCollections)
-  .post(createCollection);
+  .post(validateBody(createCollectionSchema), createCollection);
 
 router.route('/:id')
   .get(getCollection)
-  .put(updateCollection)
+  .put(validateBody(updateCollectionSchema), updateCollection)
   .delete(deleteCollection);
 
-router.post('/:id/books', addBook);
+router.post('/:id/books', validateBody(addBookSchema), addBook);
 router.delete('/:id/books/:bookId', removeBook);
 
 export default router;

--- a/bookshelf-backend/tests/collectionValidators.test.js
+++ b/bookshelf-backend/tests/collectionValidators.test.js
@@ -1,0 +1,436 @@
+import test, { describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { validate } from '../utils/validators.js';
+import {
+  MAX_BOOKS_PER_COLLECTION,
+  MAX_COLLECTION_DESCRIPTION_LENGTH,
+  MAX_COLLECTION_NAME_LENGTH,
+  booleanRule,
+  hasCapacity,
+  normaliseBoolean,
+  normaliseOptionalText,
+  optionalTextRule,
+  presentTextRule,
+} from '../utils/collection.js';
+import {
+  addBookSchema,
+  createCollectionSchema,
+  updateCollectionSchema,
+} from '../validators/collectionValidators.js';
+import collectionRouter from '../routes/collectionRoutes.js';
+
+/**
+ * The collections routes were the last write endpoints in the API with no
+ * `validateBody` in front of them, and the controller behind them called
+ * string methods on values it had not checked. See #419.
+ *
+ * These run the schemas through the same `validate()` the middleware uses, so
+ * a passing test here is the same computation the route performs.
+ */
+
+/** Runs a schema the way `validateBody` does, and reports both halves. */
+function run(schema, body) {
+  const { errors, values } = validate(body, schema);
+  return { errors, values, messages: errors.map((error) => error.message) };
+}
+
+describe('createCollectionSchema — the 500 that should have been a 400', () => {
+  test('an empty body is a field error, not a TypeError', () => {
+    /*
+     * The original: `name.trim()` on `undefined`, which threw
+     * `Cannot read properties of undefined (reading 'trim')` and reached the
+     * client through the error middleware as a 500.
+     */
+    const { errors } = run(createCollectionSchema, {});
+
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].field, 'name');
+    assert.match(errors[0].message, /required/);
+  });
+
+  test('a missing body at all is a field error', () => {
+    const { errors } = run(createCollectionSchema, undefined);
+    assert.equal(errors[0].field, 'name');
+  });
+
+  test('a whitespace-only name is refused', () => {
+    const { errors } = run(createCollectionSchema, { name: '   ' });
+    assert.equal(errors[0].field, 'name');
+    assert.match(errors[0].message, /cannot be empty/);
+  });
+
+  test('a non-string name is named rather than coerced', () => {
+    for (const name of [42, true, {}, []]) {
+      const { errors } = run(createCollectionSchema, { name });
+      assert.equal(errors.length, 1, `name=${JSON.stringify(name)}`);
+      assert.equal(errors[0].field, 'name');
+    }
+  });
+
+  test('a name is trimmed before it is stored', () => {
+    const { errors, values } = run(createCollectionSchema, { name: '  Summer reads  ' });
+
+    assert.equal(errors.length, 0);
+    assert.equal(values.name, 'Summer reads');
+  });
+
+  test('an over-length name is a 400 rather than a Mongoose ValidationError', () => {
+    // The schema caps name at 80. Without a validator that cap was enforced
+    // by Mongoose, whose ValidationError went through next(error) as a 500.
+    const { errors } = run(createCollectionSchema, {
+      name: 'x'.repeat(MAX_COLLECTION_NAME_LENGTH + 1),
+    });
+
+    assert.equal(errors[0].field, 'name');
+    assert.match(errors[0].message, /at most 80 characters/);
+  });
+
+  test('a name exactly at the cap is allowed', () => {
+    const { errors } = run(createCollectionSchema, {
+      name: 'x'.repeat(MAX_COLLECTION_NAME_LENGTH),
+    });
+
+    assert.equal(errors.length, 0);
+  });
+
+  test('an over-length description is refused', () => {
+    const { errors } = run(createCollectionSchema, {
+      name: 'Fine',
+      description: 'x'.repeat(MAX_COLLECTION_DESCRIPTION_LENGTH + 1),
+    });
+
+    assert.equal(errors[0].field, 'description');
+  });
+
+  test('a non-string description is refused rather than trimmed', () => {
+    // `description.trim()` on a number threw the same TypeError the name did.
+    const { errors } = run(createCollectionSchema, { name: 'Fine', description: 7 });
+
+    assert.equal(errors[0].field, 'description');
+    assert.match(errors[0].message, /must be a string/);
+  });
+
+  test('description is optional', () => {
+    const { errors, values } = run(createCollectionSchema, { name: 'Fine' });
+
+    assert.equal(errors.length, 0);
+    assert.equal(values.description, undefined);
+  });
+
+  test('unexpected keys are dropped, not passed to the database', () => {
+    const { values } = run(createCollectionSchema, {
+      name: 'Fine',
+      userId: '000000000000000000000000',
+      bookIds: ['b1', 'b2'],
+      createdAt: '1999-01-01',
+    });
+
+    assert.deepEqual(Object.keys(values).sort(), ['description', 'isPublic', 'name']);
+  });
+});
+
+describe('isPublic — the string "false" that made a collection public', () => {
+  test('the string "false" becomes false, not true', () => {
+    /*
+     * `Boolean("false")` is `true`. An unchecked HTML checkbox sends the
+     * string, so a user who left the box alone got a public collection.
+     */
+    const { errors, values } = run(createCollectionSchema, {
+      name: 'Private list',
+      isPublic: 'false',
+    });
+
+    assert.equal(errors.length, 0);
+    assert.equal(values.isPublic, false);
+  });
+
+  test('the string "true" becomes true', () => {
+    const { values } = run(createCollectionSchema, { name: 'Public list', isPublic: 'true' });
+    assert.equal(values.isPublic, true);
+  });
+
+  test('real booleans pass through untouched', () => {
+    assert.equal(run(createCollectionSchema, { name: 'x', isPublic: true }).values.isPublic, true);
+    assert.equal(run(createCollectionSchema, { name: 'x', isPublic: false }).values.isPublic, false);
+  });
+
+  test('the other form spellings are understood', () => {
+    for (const [raw, expected] of [
+      ['on', true], ['off', false],
+      ['1', true], ['0', false],
+      ['yes', true], ['no', false],
+      ['TRUE', true], ['  False  ', false],
+    ]) {
+      assert.equal(normaliseBoolean(raw), expected, `isPublic=${JSON.stringify(raw)}`);
+    }
+  });
+
+  test('anything else is refused rather than guessed at', () => {
+    // Boolean("maybe") is true. A caller who meant private deserves an error.
+    for (const isPublic of ['maybe', 'public', 2, {}, []]) {
+      const { errors } = run(createCollectionSchema, { name: 'x', isPublic });
+      assert.equal(errors.length, 1, `isPublic=${JSON.stringify(isPublic)}`);
+      assert.equal(errors[0].field, 'isPublic');
+      assert.match(errors[0].message, /must be true or false/);
+    }
+  });
+
+  test('isPublic is optional', () => {
+    const { errors } = run(createCollectionSchema, { name: 'x' });
+    assert.equal(errors.length, 0);
+  });
+});
+
+describe('addBookSchema — the "undefined" that was stored as a book id', () => {
+  test('an empty body is refused', () => {
+    /*
+     * The original guard:
+     *
+     *   const bookId = String(req.body.bookId).trim();
+     *   if (!bookId) return res.status(400)...
+     *
+     * `String(undefined)` is 'undefined' — seven characters, and truthy — so
+     * the guard passed, the endpoint answered 200, and the collection
+     * permanently contained a book id of "undefined".
+     */
+    const { errors } = run(addBookSchema, {});
+
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].field, 'bookId');
+    assert.match(errors[0].message, /required/);
+  });
+
+  test('the literal string "undefined" is not what a missing id becomes', () => {
+    const { values } = run(addBookSchema, {});
+    assert.notEqual(values.bookId, 'undefined');
+    assert.equal(values.bookId, undefined);
+  });
+
+  test('null is refused', () => {
+    const { errors } = run(addBookSchema, { bookId: null });
+    assert.equal(errors[0].field, 'bookId');
+  });
+
+  test('a non-string id is refused rather than stringified', () => {
+    // String(123) is "123", String(true) is "true" — both were stored.
+    for (const bookId of [123, true, {}, ['b1']]) {
+      const { errors } = run(addBookSchema, { bookId });
+      assert.equal(errors.length, 1, `bookId=${JSON.stringify(bookId)}`);
+      assert.equal(errors[0].field, 'bookId');
+    }
+  });
+
+  test('a whitespace-only id is refused', () => {
+    const { errors } = run(addBookSchema, { bookId: '   ' });
+    assert.equal(errors[0].field, 'bookId');
+  });
+
+  test('a valid id is trimmed and kept', () => {
+    const { errors, values } = run(addBookSchema, { bookId: '  b7 ' });
+
+    assert.equal(errors.length, 0);
+    assert.equal(values.bookId, 'b7');
+  });
+
+  test('control characters are refused, as they are in a wishlist id', () => {
+    const { errors } = run(addBookSchema, { bookId: `b1${String.fromCharCode(10)}injected` });
+    assert.equal(errors[0].field, 'bookId');
+  });
+
+  test('an absurdly long id is refused', () => {
+    const { errors } = run(addBookSchema, { bookId: 'b'.repeat(500) });
+    assert.equal(errors[0].field, 'bookId');
+  });
+});
+
+describe('updateCollectionSchema — a partial update stays partial', () => {
+  test('an empty body is valid: nothing is being changed', () => {
+    const { errors } = run(updateCollectionSchema, {});
+    assert.equal(errors.length, 0);
+  });
+
+  test('flipping isPublic alone does not require the name', () => {
+    // The point of not reusing createCollectionSchema here.
+    const { errors, values } = run(updateCollectionSchema, { isPublic: true });
+
+    assert.equal(errors.length, 0);
+    assert.equal(values.isPublic, true);
+    assert.equal(values.name, undefined);
+  });
+
+  test('a name that is present must still be usable', () => {
+    const { errors } = run(updateCollectionSchema, { name: '' });
+
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].field, 'name');
+    assert.match(errors[0].message, /cannot be empty/);
+  });
+
+  test('a present name is trimmed', () => {
+    const { values } = run(updateCollectionSchema, { name: '  Renamed ' });
+    assert.equal(values.name, 'Renamed');
+  });
+
+  test('a description can be cleared with an empty string', () => {
+    // Distinct from omitting it, which leaves the stored value alone.
+    const { errors, values } = run(updateCollectionSchema, { description: '' });
+
+    assert.equal(errors.length, 0);
+    assert.equal(values.description, '');
+  });
+
+  test('an over-length name is refused on update too', () => {
+    const { errors } = run(updateCollectionSchema, {
+      name: 'x'.repeat(MAX_COLLECTION_NAME_LENGTH + 1),
+    });
+
+    assert.equal(errors[0].field, 'name');
+  });
+});
+
+describe('the primitives', () => {
+  test('normaliseOptionalText leaves absence alone', () => {
+    assert.equal(normaliseOptionalText(undefined), undefined);
+    assert.equal(normaliseOptionalText(null), null);
+    assert.equal(normaliseOptionalText('  x '), 'x');
+    assert.equal(normaliseOptionalText(7), 7);
+  });
+
+  test('optionalTextRule accepts absence and rejects a bad present value', () => {
+    const rule = optionalTextRule('field', 5);
+
+    assert.equal(rule(undefined), null);
+    assert.equal(rule('abc'), null);
+    assert.match(rule('abcdef'), /at most 5/);
+    assert.match(rule(7), /must be a string/);
+  });
+
+  test('presentTextRule differs from optionalTextRule only on the empty string', () => {
+    assert.equal(optionalTextRule('f', 5)(''), null);
+    assert.match(presentTextRule('f', 5)(''), /cannot be empty/);
+    assert.equal(presentTextRule('f', 5)(undefined), null);
+  });
+
+  test('booleanRule accepts absence', () => {
+    assert.equal(booleanRule('f')(undefined), null);
+    assert.equal(booleanRule('f')(null), null);
+    assert.equal(booleanRule('f')(true), null);
+    assert.match(booleanRule('f')('maybe'), /true or false/);
+  });
+
+  test('hasCapacity bounds a collection', () => {
+    assert.equal(hasCapacity([]), true);
+    assert.equal(hasCapacity(new Array(MAX_BOOKS_PER_COLLECTION - 1).fill('b')), true);
+    assert.equal(hasCapacity(new Array(MAX_BOOKS_PER_COLLECTION).fill('b')), false);
+    // A document written before `bookIds` existed.
+    assert.equal(hasCapacity(undefined), true);
+  });
+});
+
+describe('the schemas compose with the existing validate()', () => {
+  test('one error per field, as everywhere else in the API', () => {
+    const { errors } = run(createCollectionSchema, {
+      name: '',
+      description: 7,
+      isPublic: 'maybe',
+    });
+
+    assert.equal(errors.length, 3);
+    assert.deepEqual(errors.map((error) => error.field).sort(), [
+      'description',
+      'isPublic',
+      'name',
+    ]);
+  });
+
+  test('a fully valid create body normalises to exactly what the model wants', () => {
+    const { errors, values } = run(createCollectionSchema, {
+      name: '  Winter 2026  ',
+      description: '  Long evenings  ',
+      isPublic: 'true',
+    });
+
+    assert.equal(errors.length, 0);
+    assert.deepEqual(values, {
+      name: 'Winter 2026',
+      description: 'Long evenings',
+      isPublic: true,
+    });
+  });
+});
+
+/**
+ * The schemas above are only worth anything if the routes actually run them.
+ *
+ * That is the shape of this whole bug: the rules were not subtly wrong, they
+ * were absent, and a validator sitting in `validators/` that no route mounts
+ * is exactly as useful as no validator at all. This reads the router's own
+ * stack, so it fails if someone removes a `validateBody` while leaving the
+ * schema file in place.
+ */
+describe('routes/collectionRoutes.js — the middleware is actually mounted', () => {
+  /** The handler chain Express will run for one method and path. */
+  function handlersFor(method, routePath) {
+    for (const layer of collectionRouter.stack) {
+      if (!layer.route || layer.route.path !== routePath) continue;
+
+      const handlers = layer.route.stack.filter((entry) => entry.method === method);
+      if (handlers.length > 0) return handlers;
+    }
+
+    return [];
+  }
+
+  for (const [method, routePath] of [
+    ['post', '/'],
+    ['put', '/:id'],
+    ['post', '/:id/books'],
+  ]) {
+    test(`${method.toUpperCase()} ${routePath} validates the body before the controller`, () => {
+      const handlers = handlersFor(method, routePath);
+
+      assert.equal(
+        handlers.length,
+        2,
+        `${method.toUpperCase()} ${routePath} should be [validateBody, controller]`
+      );
+
+      /*
+       * `validateBody` returns an anonymous closure, which Express reports as
+       * '<anonymous>'; the controller is a named export. So the unnamed one
+       * runs first and the named one second — which is the ordering that
+       * matters, since a validator mounted after its controller validates
+       * nothing.
+       */
+      const [first, second] = handlers;
+
+      assert.equal(first.name, '<anonymous>', 'the validator should run first');
+      assert.notEqual(second.name, '<anonymous>', 'the controller should run second');
+      assert.match(
+        second.name,
+        /^(createCollection|updateCollection|addBook)$/,
+        'the second handler should be the collection controller'
+      );
+    });
+  }
+
+  test('leaves the read and delete routes alone', () => {
+    // Nothing to validate in a body that is not sent. Adding a schema here
+    // would only strip the request of fields it never had.
+    assert.equal(handlersFor('get', '/').length, 1);
+    assert.equal(handlersFor('get', '/:id').length, 1);
+    assert.equal(handlersFor('delete', '/:id').length, 1);
+    assert.equal(handlersFor('delete', '/:id/books/:bookId').length, 1);
+  });
+
+  test('still requires a session for every route', () => {
+    // router.use(protect) — a router-level layer, so it has no .route.
+    const middleware = collectionRouter.stack.filter((layer) => !layer.route);
+
+    assert.ok(
+      middleware.some((layer) => layer.name === 'protect'),
+      'collections must stay behind protect'
+    );
+  });
+});

--- a/bookshelf-backend/utils/collection.js
+++ b/bookshelf-backend/utils/collection.js
@@ -1,0 +1,180 @@
+/**
+ * Collection input rules, as pure functions.
+ *
+ * The collections routes were the last write endpoints in the API with
+ * nothing in front of them. Everything else goes through
+ * `validateBody(schema)` — see routes/authRoutes.js and routes/wishlistRoutes.js
+ * — while `collectionController` read `req.body` and called string methods on
+ * values it had not checked:
+ *
+ *   POST /api/collections            {}               -> name.trim() throws, 500
+ *   PUT  /api/collections/:id        {description: 7} -> description.trim() throws, 500
+ *   POST /api/collections/:id/books  {}               -> stores the string "undefined"
+ *
+ * The third is the interesting one. It read
+ *
+ *     const bookId = String(req.body.bookId).trim();
+ *     if (!bookId) return res.status(400)...
+ *
+ * and `String(undefined)` is `'undefined'` — seven characters, and truthy.
+ * The guard let it through, the endpoint answered 200, and a book id of
+ * `"undefined"` was written into the collection permanently. See #419.
+ *
+ * The same trap, and the same shape of fix, as utils/wishlist.js.
+ */
+
+/**
+ * The `Collection` schema's own caps, stated here so validation refuses
+ * before Mongoose throws. A ValidationError reaches the client as a 500
+ * through `next(error)`; a rule reaches it as a field-level 400.
+ */
+export const MAX_COLLECTION_NAME_LENGTH = 80;
+export const MAX_COLLECTION_DESCRIPTION_LENGTH = 300;
+
+/**
+ * A cap on how many books one collection may hold.
+ *
+ * `bookIds: [{ type: String }]` had none, so a loop over
+ * POST /api/collections/:id/books grew a single document until it reached
+ * Mongo's 16 MB ceiling — after which every save on that collection fails,
+ * not only the ones adding books. The same hole wishlists had, capped for the
+ * same reason.
+ */
+export const MAX_BOOKS_PER_COLLECTION = 200;
+
+/**
+ * Control characters have no place in a name that will be printed back into
+ * a page, a log line, or an error message.
+ */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F]/;
+
+/**
+ * Trim a value that may legitimately be absent.
+ *
+ * Returns `undefined` and `null` untouched rather than coercing them, so a
+ * PUT that omits a field stays distinguishable from one that clears it.
+ * `String(undefined)` would collapse those into the same request, which is
+ * the bug above.
+ */
+export function normaliseOptionalText(value) {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  return typeof value === 'string' ? value.trim() : value;
+}
+
+/**
+ * A rule for a field that may be omitted but must be a sane string when it is
+ * present.
+ *
+ * `required()` from utils/validators.js reports a *missing* value, which is
+ * not what a partial update wants: `PUT /api/collections/:id` changing only
+ * `isPublic` must not be forced to resend the name.
+ */
+export function optionalTextRule(field, max) {
+  return (value) => {
+    if (value === undefined || value === null) {
+      return null;
+    }
+
+    if (typeof value !== 'string') {
+      return `${field} must be a string`;
+    }
+
+    if (value.length > max) {
+      return `${field} must be at most ${max} characters`;
+    }
+
+    if (CONTROL_CHARACTERS.test(value)) {
+      return `${field} contains characters that are not allowed`;
+    }
+
+    return null;
+  };
+}
+
+/**
+ * Like `optionalTextRule`, but a present value may not be blank.
+ *
+ * A collection called `''` is not one anyone asked for, and the unique index
+ * on `{ userId, name }` means the first one blocks every later attempt.
+ */
+export function presentTextRule(field, max) {
+  return (value) => {
+    if (value === undefined || value === null) {
+      return null;
+    }
+
+    if (value === '') {
+      return `${field} cannot be empty`;
+    }
+
+    return optionalTextRule(field, max)(value);
+  };
+}
+
+/**
+ * The booleans an HTML form and a JSON client can each plausibly send.
+ *
+ * `isPublic` was coerced with `Boolean(isPublic)`, so the *string* `"false"`
+ * — which is what a form field sends — made a collection public. Everything
+ * outside this table is refused rather than guessed at: `Boolean("no")` is
+ * `true`, and a caller who meant private deserves an error rather than a
+ * public collection.
+ */
+const TRUTHY = new Set(['true', '1', 'yes', 'on']);
+const FALSY = new Set(['false', '0', 'no', 'off']);
+
+export function normaliseBoolean(value) {
+  if (typeof value === 'boolean' || value === undefined || value === null) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const lowered = value.trim().toLowerCase();
+
+    if (TRUTHY.has(lowered)) return true;
+    if (FALSY.has(lowered)) return false;
+  }
+
+  // Left as it arrived, so the rule below can name what was actually sent.
+  return value;
+}
+
+export function booleanRule(field) {
+  return (value) => {
+    if (value === undefined || value === null) {
+      return null;
+    }
+
+    if (typeof value !== 'boolean') {
+      return `${field} must be true or false`;
+    }
+
+    return null;
+  };
+}
+
+/**
+ * Whether a collection has room for one more book.
+ *
+ * Separate from the rules because it needs the stored document, which a body
+ * validator never sees.
+ */
+export function hasCapacity(bookIds, max = MAX_BOOKS_PER_COLLECTION) {
+  return (Array.isArray(bookIds) ? bookIds.length : 0) < max;
+}
+
+export default {
+  MAX_COLLECTION_NAME_LENGTH,
+  MAX_COLLECTION_DESCRIPTION_LENGTH,
+  MAX_BOOKS_PER_COLLECTION,
+  normaliseOptionalText,
+  optionalTextRule,
+  presentTextRule,
+  normaliseBoolean,
+  booleanRule,
+  hasCapacity,
+};

--- a/bookshelf-backend/validators/collectionValidators.js
+++ b/bookshelf-backend/validators/collectionValidators.js
@@ -1,0 +1,90 @@
+import { required, trim } from '../utils/validators.js';
+import { bookIdRule, normaliseBookId } from '../utils/wishlist.js';
+import {
+  MAX_COLLECTION_DESCRIPTION_LENGTH,
+  MAX_COLLECTION_NAME_LENGTH,
+  booleanRule,
+  normaliseBoolean,
+  normaliseOptionalText,
+  optionalTextRule,
+  presentTextRule,
+} from '../utils/collection.js';
+
+/**
+ * POST /api/collections
+ *
+ * `validateBody` replaces req.body with only the fields named here, which is
+ * the same protection the auth and wishlist routes get: a request carrying an
+ * extra key cannot smuggle it through to `Collection.create`.
+ *
+ * Note what that means for the controller — by the time it runs, `name` is a
+ * trimmed non-empty string of a known length. The `name.trim()` that used to
+ * throw a TypeError on `{}` and reach the client as a 500 is gone, not
+ * because it was wrapped in a try, but because there is no longer a way to
+ * reach it with something that is not a string. See #419.
+ */
+export const createCollectionSchema = {
+  name: {
+    normalise: trim,
+    rules: [
+      required('name'),
+      optionalTextRule('name', MAX_COLLECTION_NAME_LENGTH),
+    ],
+  },
+  description: {
+    normalise: normaliseOptionalText,
+    rules: [optionalTextRule('description', MAX_COLLECTION_DESCRIPTION_LENGTH)],
+  },
+  isPublic: {
+    normalise: normaliseBoolean,
+    rules: [booleanRule('isPublic')],
+  },
+};
+
+/**
+ * PUT /api/collections/:id
+ *
+ * Deliberately not `createCollectionSchema` reused: an update is partial. A
+ * request that only flips `isPublic` must not be made to resend the name, so
+ * nothing here is `required` — but a field that *is* present still has to be
+ * usable, which is what `presentTextRule` adds over `optionalTextRule`.
+ */
+export const updateCollectionSchema = {
+  name: {
+    normalise: normaliseOptionalText,
+    rules: [presentTextRule('name', MAX_COLLECTION_NAME_LENGTH)],
+  },
+  description: {
+    normalise: normaliseOptionalText,
+    rules: [optionalTextRule('description', MAX_COLLECTION_DESCRIPTION_LENGTH)],
+  },
+  isPublic: {
+    normalise: normaliseBoolean,
+    rules: [booleanRule('isPublic')],
+  },
+};
+
+/**
+ * POST /api/collections/:id/books
+ *
+ * The endpoint that answered 200 OK to an empty body and stored a book id of
+ * `"undefined"`. `normaliseBookId` leaves a non-string alone rather than
+ * coercing it, so `bookIdRule` can say what actually arrived — which is the
+ * whole difference between this and `String(req.body.bookId)`.
+ *
+ * Shares `bookIdRule` with the wishlist: the two features store the same kind
+ * of identifier, and two different opinions about what a book id may look
+ * like is how they drift apart.
+ */
+export const addBookSchema = {
+  bookId: {
+    normalise: normaliseBookId,
+    rules: [required('bookId'), bookIdRule('bookId')],
+  },
+};
+
+export default {
+  createCollectionSchema,
+  updateCollectionSchema,
+  addBookSchema,
+};


### PR DESCRIPTION
Fixes #419.

## The bug

The collections routes were the last write endpoints in the API with no `validateBody` in front of them. Auth, wishlist and books all run a spec from `validators/` and answer 400 with every field-level problem at once. `collectionController` read `req.body` and called string methods on values it had not checked.

### A missing name was a 500

```js
const { name, description, isPublic } = req.body;
const col = await Collection.create({ name: name.trim(), ... });
```

`POST /api/collections` with `{}` throws `TypeError: Cannot read properties of undefined (reading 'trim')`, which reaches the client through the error middleware as a server error. `description.trim()` did the same on update when given a number.

### A missing bookId was *stored*

```js
const bookId = String(req.body.bookId).trim();
if (!bookId) return res.status(400).json({ message: 'bookId is required' });
```

`String(undefined)` is `"undefined"` — seven characters, and truthy. It sailed past the guard, `POST /api/collections/:id/books` with an empty body answered **200 OK**, and a book id of `"undefined"` was written into the collection permanently. The page then asked the catalogue for a book called `undefined`, got nothing back, and rendered a collection whose count and contents disagreed. The only way out was `DELETE /api/collections/:id/books/undefined`.

### There were no bounds

The model caps `name` at 80 and `description` at 300 — but with nothing validating first, those caps were enforced by Mongoose, and a `ValidationError` through `next(error)` is also a 500 rather than a field-level 400.

`bookIds: [{ type: String }]` had no cap at all, so a loop over `POST /:id/books` grows a single document until it reaches Mongo's 16 MB ceiling, after which *every* save on that collection fails, not only the ones adding books. The wishlist was capped for this reason; collections never were.

`isPublic` was coerced with `Boolean(isPublic)`, so the string `"false"` — what an unchecked HTML checkbox sends — made a collection public.

## The fix

Rules in `utils/collection.js` as pure functions, specs in `validators/collectionValidators.js`, following `wishlistValidators.js`. `validateBody` on the three write routes.

| | before | after |
|---|---|---|
| `POST /` `{}` | 500 TypeError | 400 `name is required` |
| `POST /:id/books` `{}` | 200, stores `"undefined"` | 400 `bookId is required` |
| `PUT /:id` `{description: 7}` | 500 TypeError | 400 `description must be a string` |
| `name` 81 chars | 500 ValidationError | 400 `name must be at most 80 characters` |
| `isPublic: "false"` | public | private |
| 201st book | grows toward 16 MB | 409 with the limit |

The book id rule is **shared with the wishlist** rather than written twice. The two features store the same kind of identifier, and two different opinions about what one may look like is how they drift apart.

`validateBody` also strips unknown keys, so a request carrying `userId` or `bookIds` cannot reach `Collection.create` with them.

## Update stays partial

Deliberately not the create schema reused. A request that flips `isPublic` alone must not be made to resend the name, so nothing in `updateCollectionSchema` is `required` — but a field that *is* present still has to be usable, which is the difference between `presentTextRule` and `optionalTextRule`. `{ description: '' }` still clears the description; omitting it leaves the stored value alone.

## The tests read the router, not just the schemas

A validator sitting in `validators/` that no route mounts is exactly as useful as no validator at all, and that is the shape this bug had. So alongside the schema cases there is a block that walks `collectionRouter.stack` and asserts each write route runs `[validateBody, controller]` in that order — a validator mounted *after* its controller validates nothing — and that `protect` is still there.

## Checks

- `bookshelf-backend`: 618 tests pass (575 on `main`, +43).
- Frontend untouched by this PR.

The two Vercel checks fail with "Authorization required to deploy" on every PR in this repo, including merged ones from other authors — it needs the repo owner to authorize the integration and is not caused by this change.
