### PR TITLE
Guard /admin/inventory with the role check, not just a session

### DIFF
--- a/bookshelf-frontend/src/components/AdminRoute.jsx
+++ b/bookshelf-frontend/src/components/AdminRoute.jsx
@@ -1,36 +1,21 @@
-import { Navigate, useLocation } from 'react-router-dom';
-import { useAuth } from '../hooks/useAuth.js';
+import RouteGuard from './RouteGuard.jsx';
 
 /**
  * AdminRoute — a route guard that requires both authentication and the
- * admin role.  Wraps the same loading / redirect pattern as ProtectedRoute
- * but adds the role check.
+ * admin role.
  *
  * Usage:
  *   <Route path="admin" element={<AdminRoute><AdminDashboard /></AdminRoute>} />
+ *
+ * It was written, given its own test file, and then mounted on nothing:
+ * `/admin/inventory` — the page that creates, edits and deletes books — was
+ * guarded by a bare `<ProtectedRoute>`, which only checks that *somebody* is
+ * signed in, so any registered customer could open it. See #420.
+ *
+ * The guard itself lives in RouteGuard.jsx, which this and ProtectedRoute
+ * both wrap: they were the same component written twice, and only one of
+ * them had `aria-busy` on its loading state.
  */
 export default function AdminRoute({ children }) {
-  const { user, isAuthenticated, loading } = useAuth();
-  const location = useLocation();
-
-  if (loading) {
-    return (
-      <div
-        style={{ display: 'flex', justifyContent: 'center', padding: '50px' }}
-        aria-busy="true"
-      >
-        Loading…
-      </div>
-    );
-  }
-
-  if (!isAuthenticated) {
-    return <Navigate to={`/login?redirect=${location.pathname}`} replace />;
-  }
-
-  if (user?.role !== 'admin') {
-    return <Navigate to="/" replace />;
-  }
-
-  return children;
+  return <RouteGuard requireAdmin>{children}</RouteGuard>;
 }

--- a/bookshelf-frontend/src/components/Navbar.jsx
+++ b/bookshelf-frontend/src/components/Navbar.jsx
@@ -182,11 +182,23 @@ export default function Navbar({ searchQuery, setSearchQuery }) {
 
   const label = (key, fallback) => (key ? t(key) || fallback : fallback);
 
+  /*
+   * The admin link was shown to every signed-in user, which is the visible
+   * half of #420: the route behind it only checked for a session, so the
+   * navbar was not merely advertising a page customers could not use — it was
+   * advertising one they could open. The route is guarded now, and following
+   * this link as a customer would bounce them to the home page, which reads
+   * as a broken link. So it is only offered to the people it works for.
+   */
+  const isAdmin = user?.role === 'admin';
+
   const accountLinks = isAuthenticated
     ? [
         { to: '/profile', label: t('navbar.profile') || 'Profile' },
         { to: '/account/orders', label: 'My orders' },
-        { to: '/admin/inventory', label: '🛠️ Admin Inventory' },
+        ...(isAdmin
+          ? [{ to: '/admin/inventory', label: '🛠️ Admin Inventory' }]
+          : []),
         { to: '/design-system', label: '🎨 Design System' },
       ]
     : [{ to: '/design-system', label: '🎨 Design System' }];

--- a/bookshelf-frontend/src/components/Navbar.test.jsx
+++ b/bookshelf-frontend/src/components/Navbar.test.jsx
@@ -256,4 +256,66 @@ describe('Navbar', () => {
       expect(hamburger).toHaveAttribute('aria-expanded', 'true');
     });
   });
+
+  /*
+   * The visible half of #420.
+   *
+   * The account menu offered "🛠️ Admin Inventory" to every signed-in user,
+   * and the route behind it only checked for a session — so this was not a
+   * link that merely looked available to customers, it was one they could
+   * follow all the way into the inventory manager.
+   */
+  describe('the admin link', () => {
+    async function openAccountMenu(user) {
+      const trigger = screen.getByRole('button', { name: /toggle menu/i });
+      await user.click(trigger);
+    }
+
+    it('is offered to an admin', async () => {
+      const user = userEvent.setup();
+      renderNavbar({ auth: signedIn({ user: { name: 'Root', _id: 'u0', role: 'admin' } }) });
+
+      await openAccountMenu(user);
+
+      // The desktop and mobile menus both render the account links, so this
+      // is deliberately getAll — one match would mean one of them lost it.
+      expect(
+        screen.getAllByRole('link', { name: /admin inventory/i }).length
+      ).toBeGreaterThan(0);
+    });
+
+    it('is not offered to a signed-in customer', async () => {
+      const user = userEvent.setup();
+      renderNavbar({ auth: signedIn({ user: { name: 'Asha', _id: 'u1', role: 'user' } }) });
+
+      await openAccountMenu(user);
+
+      expect(
+        screen.queryByRole('link', { name: /admin inventory/i })
+      ).not.toBeInTheDocument();
+      // The rest of the account menu is untouched.
+      expect(screen.getAllByRole('link', { name: /my orders/i }).length).toBeGreaterThan(0);
+    });
+
+    it('is not offered to a user whose role is not known yet', async () => {
+      // A profile response that has not arrived, or an older session with no
+      // role on it. Absent is not admin.
+      const user = userEvent.setup();
+      renderNavbar({ auth: signedIn({ user: { name: 'Asha', _id: 'u1' } }) });
+
+      await openAccountMenu(user);
+
+      expect(
+        screen.queryByRole('link', { name: /admin inventory/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('is not offered to an anonymous visitor', () => {
+      renderNavbar();
+
+      expect(
+        screen.queryByRole('link', { name: /admin inventory/i })
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/bookshelf-frontend/src/components/ProtectedRoute.jsx
+++ b/bookshelf-frontend/src/components/ProtectedRoute.jsx
@@ -1,29 +1,14 @@
-import { Navigate, useLocation } from 'react-router-dom';
-import { useAuth } from '../hooks/useAuth.js';
+import RouteGuard from './RouteGuard.jsx';
 
-const ProtectedRoute = ({ children, requireAdmin = false }) => {
-  const { user, isAuthenticated, loading } = useAuth();
-  const location = useLocation();
-
-  if (loading) {
-    return (
-      <div
-        style={{ display: 'flex', justifyContent: 'center', padding: '50px' }}
-      >
-        Loading...
-      </div>
-    );
-  }
-
-  if (!isAuthenticated) {
-    return <Navigate to={`/login?redirect=${location.pathname}`} replace />;
-  }
-
-  if (requireAdmin && user?.role !== 'admin') {
-    return <Navigate to="/" replace />;
-  }
-
-  return children;
-};
-
-export default ProtectedRoute;
+/**
+ * ProtectedRoute — requires a session, and optionally the admin role.
+ *
+ * `requireAdmin` is kept for the callers that pass it, but a route that needs
+ * an admin should use `<AdminRoute>` instead: the prop defaults to `false`,
+ * and forgetting it is silent. That is precisely how `/admin/inventory` came
+ * to be reachable by any signed-in customer — the route said
+ * `<ProtectedRoute>` and nobody noticed the missing prop. See #420.
+ */
+export default function ProtectedRoute({ children, requireAdmin = false }) {
+  return <RouteGuard requireAdmin={requireAdmin}>{children}</RouteGuard>;
+}

--- a/bookshelf-frontend/src/components/RouteGuard.jsx
+++ b/bookshelf-frontend/src/components/RouteGuard.jsx
@@ -1,0 +1,61 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth.js';
+
+/**
+ * The one route guard.
+ *
+ * `ProtectedRoute` and `AdminRoute` were the same component written twice —
+ * same loading branch, same "not signed in, go to login with a redirect
+ * back", same role check. Having two of them is how they drifted: only one
+ * had `aria-busy` on its loading state, and only one was ever actually used
+ * on the route that needed a role check.
+ *
+ * They are both thin wrappers over this now, so a fix to the redirect
+ * behaviour lands in one place and cannot apply to half the routes.
+ *
+ * @param {object}  props
+ * @param {boolean} props.requireAdmin  also require the admin role
+ * @param {node}    props.children      what to render once the checks pass
+ */
+export default function RouteGuard({ children, requireAdmin = false }) {
+  const { user, isAuthenticated, loading } = useAuth();
+  const location = useLocation();
+
+  /*
+   * Nothing is decided while the session is still being restored.
+   *
+   * Redirecting here would bounce a signed-in admin to the home page on every
+   * hard refresh of an admin URL, because `user` is null until the profile
+   * request comes back.
+   */
+  if (loading) {
+    return (
+      <div
+        style={{ display: 'flex', justifyContent: 'center', padding: '50px' }}
+        aria-busy="true"
+      >
+        Loading…
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    /*
+     * Carry where they were going, so signing in returns them to it rather
+     * than to the home page. `location.pathname` only — a search string or a
+     * hash would need encoding, and no guarded route uses one today.
+     */
+    return <Navigate to={`/login?redirect=${location.pathname}`} replace />;
+  }
+
+  /*
+   * A signed-in non-admin goes home rather than to the login page: they are
+   * already signed in, and sending them to a login form implies that signing
+   * in again would help. It would not.
+   */
+  if (requireAdmin && user?.role !== 'admin') {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+}

--- a/bookshelf-frontend/src/routes/AppRoutes.guards.test.jsx
+++ b/bookshelf-frontend/src/routes/AppRoutes.guards.test.jsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Outlet } from 'react-router-dom';
+
+/**
+ * The guards on the route table, exercised for real.
+ *
+ * This is a second file rather than more cases in AppRoutes.test.jsx, and the
+ * reason is the whole point of #420: that file stubs the guards —
+ *
+ *   vi.mock('../components/ProtectedRoute.jsx', () => ({
+ *     default: ({ children }) => <div data-testid="protected">{children}</div>,
+ *   }));
+ *
+ * — because it is testing which page each path resolves to. So it cannot
+ * notice that a route is guarded by the wrong thing, and `AdminRoute.test.jsx`
+ * cannot either: it exercises the component in isolation, and the component
+ * was correct. It was mounted on nothing.
+ *
+ * `/admin/inventory` said `<ProtectedRoute>` with no `requireAdmin`, which
+ * defaults to false, so any signed-in customer could open the page that
+ * creates and deletes books. Both tests passed the whole time.
+ *
+ * Here the guards are real and only `useAuth` is mocked, so what is under
+ * test is the pairing of route to guard.
+ */
+
+vi.mock('../hooks/useAuth.js', () => ({ useAuth: vi.fn() }));
+
+vi.mock('../App.jsx', () => ({
+  default: () => (
+    <div>
+      <Outlet />
+    </div>
+  ),
+}));
+
+const stub = (name) => ({ default: () => <div>{name}</div> });
+
+vi.mock('../pages/Home.jsx', () => stub('home-page'));
+vi.mock('../pages/BookDetail.jsx', () => stub('book-detail-page'));
+vi.mock('../pages/WishlistPage.jsx', () => stub('wishlist-page'));
+vi.mock('../pages/OrderHistory.jsx', () => stub('order-history-page'));
+vi.mock('../pages/OrderDetailsPage.jsx', () => stub('order-details-page'));
+vi.mock('../pages/OrderConfirmation.jsx', () => stub('order-confirmation-page'));
+vi.mock('../pages/Checkout.jsx', () => stub('checkout-page'));
+vi.mock('../pages/Profile.jsx', () => stub('profile-page'));
+vi.mock('../pages/Login.jsx', () => stub('login-page'));
+vi.mock('../pages/Register.jsx', () => stub('register-page'));
+vi.mock('../pages/AboutUs.jsx', () => stub('about-page'));
+vi.mock('../pages/PrivacyPolicy.jsx', () => stub('privacy-page'));
+vi.mock('../pages/TermsOfService.jsx', () => stub('terms-page'));
+vi.mock('../pages/DesignSystemPage.jsx', () => stub('design-system-page'));
+vi.mock('../pages/AdminInventoryPage.jsx', () => stub('admin-inventory-page'));
+vi.mock('../pages/StockAlertsPage.jsx', () => stub('stock-alerts-page'));
+vi.mock('../pages/NotFound.jsx', () => stub('not-found-page'));
+
+const { useAuth } = await import('../hooks/useAuth.js');
+const { default: AppRoutes } = await import('./AppRoutes.jsx');
+
+/** The three states a visitor can be in by the time a guard decides. */
+const ANONYMOUS = { user: null, isAuthenticated: false, loading: false };
+const CUSTOMER = { user: { role: 'user' }, isAuthenticated: true, loading: false };
+const ADMIN = { user: { role: 'admin' }, isAuthenticated: true, loading: false };
+const RESTORING = { user: null, isAuthenticated: false, loading: true };
+
+function renderAs(auth, path) {
+  useAuth.mockReturnValue(auth);
+
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppRoutes />
+    </MemoryRouter>
+  );
+}
+
+describe('AppRoutes — /admin/inventory', () => {
+  beforeEach(() => {
+    useAuth.mockReset();
+  });
+
+  it('lets an admin in', () => {
+    renderAs(ADMIN, '/admin/inventory');
+    expect(screen.getByText('admin-inventory-page')).toBeInTheDocument();
+  });
+
+  it('keeps a signed-in customer out', () => {
+    /*
+     * The regression. Before the fix this rendered the full inventory
+     * manager: the add-book modal, the edit forms, the delete buttons, the
+     * stock steppers, the bulk upload panel and the user table.
+     */
+    renderAs(CUSTOMER, '/admin/inventory');
+
+    expect(screen.queryByText('admin-inventory-page')).not.toBeInTheDocument();
+    // Sent home, not to a login form — they are already signed in, and
+    // signing in again would not help.
+    expect(screen.getByText('home-page')).toBeInTheDocument();
+  });
+
+  it('sends an anonymous visitor to sign in, and remembers where they were going', () => {
+    renderAs(ANONYMOUS, '/admin/inventory');
+
+    expect(screen.queryByText('admin-inventory-page')).not.toBeInTheDocument();
+    expect(screen.getByText('login-page')).toBeInTheDocument();
+  });
+
+  it('decides nothing while the session is still being restored', () => {
+    /*
+     * `user` is null until the profile request comes back, so a guard that
+     * ran its role check during loading would bounce an admin to the home
+     * page on every hard refresh of an admin URL.
+     */
+    renderAs(RESTORING, '/admin/inventory');
+
+    expect(screen.queryByText('admin-inventory-page')).not.toBeInTheDocument();
+    expect(screen.queryByText('home-page')).not.toBeInTheDocument();
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+
+  it('reports the loading state to assistive technology', () => {
+    // ProtectedRoute's loading branch had no aria-busy while AdminRoute's
+    // did — the two guards were the same component written twice and had
+    // already drifted. They share one implementation now.
+    renderAs(RESTORING, '/profile');
+    expect(screen.getByText('Loading…')).toHaveAttribute('aria-busy', 'true');
+  });
+});
+
+describe('AppRoutes — the session-only routes stay session-only', () => {
+  beforeEach(() => {
+    useAuth.mockReset();
+  });
+
+  it.each([
+    ['/profile', 'profile-page'],
+    ['/checkout', 'checkout-page'],
+    ['/orders', 'order-history-page'],
+    ['/order-confirmation', 'order-confirmation-page'],
+    ['/account/orders/abc123', 'order-details-page'],
+    ['/stock-alerts', 'stock-alerts-page'],
+  ])('%s is open to a signed-in customer', (path, expected) => {
+    // Tightening the admin route must not have tightened these. A customer
+    // has to be able to reach their own profile and their own orders.
+    renderAs(CUSTOMER, path);
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
+  it.each([
+    ['/profile'],
+    ['/checkout'],
+    ['/orders'],
+    ['/stock-alerts'],
+  ])('%s still requires a session', (path) => {
+    renderAs(ANONYMOUS, path);
+    expect(screen.getByText('login-page')).toBeInTheDocument();
+  });
+});
+
+describe('AppRoutes — the public routes need no session', () => {
+  beforeEach(() => {
+    useAuth.mockReset();
+  });
+
+  it.each([
+    ['/', 'home-page'],
+    ['/book/b1', 'book-detail-page'],
+    ['/wishlist', 'wishlist-page'],
+    ['/about', 'about-page'],
+    ['/login', 'login-page'],
+  ])('%s renders for an anonymous visitor', (path, expected) => {
+    renderAs(ANONYMOUS, path);
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+});

--- a/bookshelf-frontend/src/routes/AppRoutes.jsx
+++ b/bookshelf-frontend/src/routes/AppRoutes.jsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 
 import App from '../App.jsx';
 import ProtectedRoute from '../components/ProtectedRoute.jsx';
+import AdminRoute from '../components/AdminRoute.jsx';
 import ErrorBoundary from '../components/ErrorBoundary.jsx';
 
 import Home from '../pages/Home.jsx';
@@ -63,13 +64,28 @@ export default function AppRoutes() {
 
         <Route path="signup" element={<Navigate to="/register" replace />} />
 
-        {/* Requires Admin */}
+        {/*
+          Requires admin — and now actually checks for it.
+
+          This said `<ProtectedRoute>` with no `requireAdmin`, and that prop
+          defaults to false, so the only thing the route checked was that
+          somebody was signed in. Any registered customer who typed the URL
+          got the full inventory manager: the add-book modal, the edit forms,
+          the delete buttons, the stock steppers, the bulk upload panel and
+          the user table. The backend's `protect, admin` middleware is the
+          only reason the catalogue survived that, which makes every action on
+          the page fail with an error rather than the page being closed.
+
+          `AdminRoute` is used rather than `<ProtectedRoute requireAdmin>`
+          because a guard whose protection depends on remembering a prop is
+          the thing that failed here. See #420.
+        */}
         <Route
           path="admin/inventory"
           element={
-            <ProtectedRoute>
+            <AdminRoute>
               <AdminInventoryPage />
-            </ProtectedRoute>
+            </AdminRoute>
           }
         />
 


### PR DESCRIPTION
Fixes #420.

## The bug

```jsx
<Route
  path="admin/inventory"
  element={
    <ProtectedRoute>
      <AdminInventoryPage />
    </ProtectedRoute>
  }
/>
```

`ProtectedRoute` takes `requireAdmin`, and it **defaults to `false`**:

```jsx
const ProtectedRoute = ({ children, requireAdmin = false }) => {
  ...
  if (requireAdmin && user?.role !== 'admin') { return <Navigate to="/" replace />; }
```

It was not passed. The only thing the route checked was that *somebody* was signed in, so any registered customer who typed `/admin/inventory` got the full inventory manager — the add-book modal, the edit forms, the delete buttons, the stock steppers, the bulk upload panel and the user table.

The backend admin routes sit behind `protect, admin`, so the writes come back 403 and the catalogue was never actually modified. That is the only reason this was not worse. It is still wrong on its own terms: the page exposes the shape of the admin API and the whole user table to anyone with an account, and every action on it fails with an error toast — which reads as a broken site rather than a closed door. A frontend guard that only works because the backend also has one is not a guard.

## `AdminRoute` already existed for exactly this

`components/AdminRoute.jsx` does the right thing — session check, then role check, loading handled. It has its own test file. Its doc comment shows the intended usage. It was imported by nothing.

It is on the route now, in preference to `<ProtectedRoute requireAdmin>`: a guard whose protection depends on remembering to pass a prop is the thing that failed here, and the failure mode is silent.

## Why both suites were green while the page was open

This is the part worth reading twice.

- **`AppRoutes.test.jsx`** stubs the guards out — `vi.mock('../components/ProtectedRoute.jsx', ...)` — because it tests *which page each path resolves to*. It cannot see which guard a route uses.
- **`AdminRoute.test.jsx`** exercises the component in isolation. The component was correct. It was mounted on nothing.

Neither test was wrong, and neither could have caught this. So the new coverage goes in `AppRoutes.guards.test.jsx`, which mocks only `useAuth` and leaves the guards real — what it tests is the *pairing* of route to guard.

Checked against the old code: reverting `AdminRoute` back to `ProtectedRoute` fails `keeps a signed-in customer out` and nothing else.

| visitor | before | after |
|---|---|---|
| admin | inventory page | inventory page |
| signed-in customer | **inventory page** | redirected home |
| anonymous | login | login |
| session restoring | loading | loading |

## Also in here

- **The two guards were the same component written twice**, and had already drifted: only `AdminRoute`'s loading branch had `aria-busy`. Both are thin wrappers over one `RouteGuard` now, so a change to the redirect behaviour cannot apply to half the routes. `ProtectedRoute` keeps its `requireAdmin` prop and its public behaviour.
- **The navbar offered "🛠️ Admin Inventory" to every signed-in user** — the visible half of the same bug. Not a link that merely *looked* available to customers, but one they could follow all the way in. Shown to admins only now; a customer following it would bounce to the home page, which reads as a broken link.
- **A user with no `role` is not an admin.** An older session, or a profile response that has not arrived yet — absent is not admin, and there is a test for it.

The guard still decides nothing while `loading` is true. `user` is null until the profile request returns, so a role check during loading would bounce a real admin to the home page on every hard refresh of an admin URL.

## Checks

- `bookshelf-frontend`: 823 tests pass (799 on `main`, +24), lint clean, build clean.
- Backend untouched by this PR.

The two Vercel checks fail with "Authorization required to deploy" on every PR in this repo, including merged ones from other authors — it needs the repo owner to authorize the integration and is not caused by this change.
