### PR TITLE
Name the books on the stock alerts page instead of showing their ids

### DIFF
--- a/bookshelf-frontend/src/pages/StockAlertsPage.css
+++ b/bookshelf-frontend/src/pages/StockAlertsPage.css
@@ -160,3 +160,72 @@
     border-bottom-color: var(--color-border-dark, #374151);
   }
 }
+
+/* ── Resolved book details ──────────────────────────────────────────── */
+
+/*
+ * A row is now a cover swatch, the book's details, and the remove button.
+ * The swatch does not shrink: with a long title the flex row would otherwise
+ * squeeze it to a sliver rather than truncating the text, which is what the
+ * ellipsis on .alerts-page__book-link is for. See #422.
+ */
+.alerts-page__cover {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 48px;
+  margin-right: 0.9rem;
+  border-radius: 3px;
+  background: var(--color-border, #e5e7eb);
+  box-shadow: inset -2px 0 3px rgba(0, 0, 0, 0.18);
+}
+
+/* The info column takes the space the swatch and the button leave. */
+.alerts-page__info {
+  flex: 1 1 auto;
+}
+
+.alerts-page__author,
+.alerts-page__price {
+  font-size: 0.78rem;
+  color: var(--color-text-muted, #6b7280);
+}
+
+.alerts-page__price {
+  font-variant-numeric: tabular-nums;
+}
+
+/*
+ * A book the catalogue no longer has. The id is all that is known about it,
+ * so it is shown — greyed and not a link, because there is nothing to link
+ * to, with the sentence below saying why.
+ */
+.alerts-page__book-link--missing {
+  color: var(--color-text-muted, #9ca3af);
+  font-style: italic;
+}
+
+.alerts-page__unavailable {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #9ca3af);
+}
+
+/* Sits under the row it belongs to rather than in the page-level banner. */
+.alerts-page__row-error {
+  margin-top: 0.2rem;
+  font-size: 0.75rem;
+  color: #b91c1c;
+}
+
+.alerts-page__remove:disabled {
+  opacity: 0.55;
+  cursor: progress;
+}
+
+@media (prefers-color-scheme: dark) {
+  .alerts-page__cover {
+    background: var(--color-border-dark, #374151);
+  }
+  .alerts-page__row-error {
+    color: #fca5a5;
+  }
+}

--- a/bookshelf-frontend/src/pages/StockAlertsPage.jsx
+++ b/bookshelf-frontend/src/pages/StockAlertsPage.jsx
@@ -1,83 +1,301 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import api from '../utils/api.js';
 import { unsubscribeStockAlert } from '../services/stockAlertService.js';
+import { useBooksByIds, isCanceled } from '../hooks/useBooksByIds.js';
+import { usePageMetadata } from '../hooks/usePageMetadata.js';
+import { describeApiError } from '../utils/apiError.js';
+import { formatMoney } from '../utils/currency.js';
 import './StockAlertsPage.css';
 
 /**
- * StockAlertsPage — shows all back-in-stock alerts the current user has set.
- * Fetches alert list from a dedicated endpoint and lets the user remove them.
+ * StockAlertsPage — the books the current user is waiting to come back in
+ * stock.
+ *
+ * The page used to render
+ *
+ *     {alert.bookTitle || alert.bookId}
+ *
+ * and there is no `bookTitle` anywhere in the system. `models/StockAlert.js`
+ * stores `userId`, `bookId`, `notified` and `notifiedAt`, and `getMyAlerts`
+ * returns those documents unchanged. So the `||` never took its left branch:
+ * every row showed a raw catalogue id — `b3`, `b7` — on a page whose entire
+ * purpose is to name the books somebody is waiting for. The fallback read
+ * like a defence against a rare case and was in fact the only branch that
+ * ever ran. See #422.
+ *
+ * The ids are resolved against the catalogue instead, through the same
+ * `useBooksByIds` the wishlist (#328) and Recently Viewed (#336) use. This is
+ * the third page with this bug and the last one that was still doing it by
+ * hand.
  */
 
+/**
+ * The alert list.
+ *
+ * Left as a local function rather than moved into services/stockAlertService.js
+ * — it is the only caller, and adding it to the service would be a second
+ * place to look for the same request.
+ */
 async function getMyAlerts({ signal } = {}) {
   const response = await api.get('/stock-alerts/mine', { signal });
   return response.data;
 }
 
+/**
+ * A subscribe date that cannot render "Invalid Date".
+ *
+ * `new Date(undefined).toLocaleDateString()` produces exactly that string,
+ * and an alert document with no `createdAt` reaches this unguarded. Saying
+ * nothing is better than saying something wrong.
+ */
+function formatSubscribedOn(value) {
+  if (!value) {
+    return '';
+  }
+
+  const date = new Date(value);
+
+  return Number.isNaN(date.getTime()) ? '' : date.toLocaleDateString();
+}
+
 export default function StockAlertsPage() {
+  /*
+   * The page had no title, so the browser tab kept whatever the previous
+   * route set. See #337 for the rest of them.
+   */
+  usePageMetadata({
+    title: 'Your stock alerts',
+    description: 'The books you asked to be told about when they are back in stock.',
+  });
+
   const [alerts, setAlerts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
+  /*
+   * Which rows have a removal in flight, and which rows failed.
+   *
+   * Two pieces of state rather than one status per row: a row that failed and
+   * is being retried is in both, and collapsing them would make the retry
+   * clear the error it is retrying before the retry has finished.
+   */
+  const [removing, setRemoving] = useState(() => new Set());
+  const [rowErrors, setRowErrors] = useState({});
+
   useEffect(() => {
-    const c = new AbortController();
+    const controller = new AbortController();
+
     setLoading(true);
-    getMyAlerts({ signal: c.signal })
-      .then((data) => { setAlerts(Array.isArray(data) ? data : data.alerts || []); setLoading(false); })
-      .catch((err) => { if (err?.code !== 'ERR_CANCELED') { setError(err.message || 'Failed to load alerts'); setLoading(false); } });
-    return () => c.abort();
+
+    getMyAlerts({ signal: controller.signal })
+      .then((data) => {
+        setAlerts(Array.isArray(data) ? data : data?.alerts ?? []);
+        setLoading(false);
+      })
+      .catch((err) => {
+        // An abort is not a failure — the page is unmounting. Rendering it
+        // would flash "canceled" into the error slot.
+        if (isCanceled(err)) {
+          return;
+        }
+
+        setError(describeApiError(err, 'Failed to load your stock alerts.'));
+        setLoading(false);
+      });
+
+    return () => controller.abort();
   }, []);
 
-  const handleRemove = async (bookId) => {
+  /*
+   * Memoised on the joined ids, not on `alerts`. `alerts` gets a new array
+   * identity every time a row is removed, and `useBooksByIds` keys its effect
+   * on the ids it is given — handing it a fresh array on every render would
+   * refetch the catalogue continuously.
+   */
+  const alertIdKey = alerts.map((alert) => alert.bookId).join(',');
+  const bookIds = useMemo(
+    () => (alertIdKey === '' ? [] : alertIdKey.split(',')),
+    [alertIdKey]
+  );
+
+  /*
+   * Held in its loading state until the alerts themselves have arrived.
+   * Resolving the empty interim list would flash "no alerts yet" at someone
+   * who has several.
+   */
+  const {
+    books,
+    missingIds,
+    loading: booksLoading,
+  } = useBooksByIds(bookIds, { enabled: !loading });
+
+  const booksById = useMemo(
+    () => new Map(books.map((book) => [book.id, book])),
+    [books]
+  );
+
+  /*
+   * `missingIds` is "the catalogue answered 404" — the book has been
+   * delisted, which is worth telling the customer because an alert for it
+   * will never fire. That is a different thing from `failedIds`, a request
+   * that did not complete: saying "no longer available" about a book behind a
+   * flaky network would be a lie told by the network.
+   */
+  const missing = useMemo(() => new Set(missingIds), [missingIds]);
+
+  const handleRemove = useCallback(async (bookId) => {
+    setRemoving((previous) => new Set(previous).add(bookId));
+    setRowErrors((previous) => {
+      if (!previous[bookId]) return previous;
+      const next = { ...previous };
+      delete next[bookId];
+      return next;
+    });
+
     try {
       await unsubscribeStockAlert(bookId);
-      setAlerts((prev) => prev.filter((a) => a.bookId !== bookId));
+      setAlerts((previous) => previous.filter((alert) => alert.bookId !== bookId));
     } catch (err) {
-      setError(err.message || 'Failed to remove alert');
+      /*
+       * Reported on the row, not in the banner at the top of the page. The
+       * banner is a long way from the button that was pressed, and with
+       * several alerts on screen it does not say which one failed.
+       */
+      setRowErrors((previous) => ({
+        ...previous,
+        [bookId]: describeApiError(err, 'Could not remove this alert.'),
+      }));
+    } finally {
+      setRemoving((previous) => {
+        const next = new Set(previous);
+        next.delete(bookId);
+        return next;
+      });
     }
-  };
+  }, []);
+
+  const busy = loading || booksLoading;
 
   return (
     <main className="alerts-page">
       <h1 className="alerts-page__title">My Stock Alerts</h1>
       <p className="alerts-page__subtitle">Books you're waiting to come back in stock.</p>
 
-      {error && <div className="alerts-page__error">{error}<button onClick={() => setError('')}>✕</button></div>}
+      {error && (
+        <div className="alerts-page__error" role="alert">
+          {error}
+          <button type="button" onClick={() => setError('')} aria-label="Dismiss">
+            ✕
+          </button>
+        </div>
+      )}
 
-      {loading && (
-        <div className="alerts-page__loading">
+      {busy && (
+        <div className="alerts-page__loading" aria-busy="true">
           {[1, 2, 3].map((i) => <div key={i} className="alerts-page__skeleton" />)}
         </div>
       )}
 
-      {!loading && alerts.length === 0 && (
+      {!busy && alerts.length === 0 && (
         <div className="alerts-page__empty">
           <p>You don't have any stock alerts yet.</p>
           <Link to="/" className="alerts-page__browse">Browse books</Link>
         </div>
       )}
 
-      {!loading && alerts.length > 0 && (
+      {!busy && alerts.length > 0 && (
         <ul className="alerts-page__list">
-          {alerts.map((alert) => (
-            <li key={alert.bookId} className="alerts-page__item">
-              <div className="alerts-page__info">
-                <Link to={`/book/${alert.bookId}`} className="alerts-page__book-link">
-                  {alert.bookTitle || alert.bookId}
-                </Link>
-                <span className="alerts-page__date">
-                  Subscribed {new Date(alert.createdAt).toLocaleDateString()}
-                </span>
-              </div>
-              <button
-                className="alerts-page__remove"
-                onClick={() => handleRemove(alert.bookId)}
-              >
-                Remove
-              </button>
-            </li>
-          ))}
+          {alerts.map((alert) => {
+            const book = booksById.get(alert.bookId);
+            const isMissing = missing.has(alert.bookId);
+            const subscribedOn = formatSubscribedOn(alert.createdAt);
+            const isRemoving = removing.has(alert.bookId);
+
+            return (
+              <li key={alert.bookId} className="alerts-page__item">
+                {/*
+                  The cover is a colour in this catalogue, not an image — the
+                  same thing BookCard renders. A book that is missing gets no
+                  swatch rather than a black one from an undefined value.
+                */}
+                {book && (
+                  <span
+                    className="alerts-page__cover"
+                    style={{ background: book.cover }}
+                    aria-hidden="true"
+                  />
+                )}
+
+                <div className="alerts-page__info">
+                  {book ? (
+                    <>
+                      <Link
+                        to={`/book/${alert.bookId}`}
+                        className="alerts-page__book-link"
+                      >
+                        {book.title}
+                      </Link>
+                      {book.author && (
+                        <span className="alerts-page__author">{book.author}</span>
+                      )}
+                      {typeof book.price === 'number' && (
+                        <span className="alerts-page__price">
+                          {formatMoney(book.price)}
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      {/*
+                        The id is still shown, because it is the only thing
+                        known about this book — but with a sentence saying
+                        why, rather than as a bare "b3" that reads like a
+                        rendering fault.
+                      */}
+                      <span className="alerts-page__book-link alerts-page__book-link--missing">
+                        {alert.bookId}
+                      </span>
+                      <span className="alerts-page__unavailable">
+                        {isMissing
+                          ? 'No longer in the catalogue — this alert will not arrive.'
+                          : 'Details could not be loaded.'}
+                      </span>
+                    </>
+                  )}
+
+                  {subscribedOn && (
+                    <span className="alerts-page__date">Subscribed {subscribedOn}</span>
+                  )}
+
+                  {rowErrors[alert.bookId] && (
+                    <span className="alerts-page__row-error" role="alert">
+                      {rowErrors[alert.bookId]}
+                    </span>
+                  )}
+                </div>
+
+                <button
+                  type="button"
+                  className="alerts-page__remove"
+                  onClick={() => handleRemove(alert.bookId)}
+                  /*
+                   * Disabled while its own request is in flight. Two clicks
+                   * sent two DELETEs, and the second answered 404 — which
+                   * surfaced as an error about an alert that had just been
+                   * removed successfully.
+                   */
+                  disabled={isRemoving}
+                  aria-label={
+                    book ? `Remove stock alert for ${book.title}` : 'Remove stock alert'
+                  }
+                >
+                  {isRemoving ? 'Removing…' : 'Remove'}
+                </button>
+              </li>
+            );
+          })}
         </ul>
       )}
     </main>

--- a/bookshelf-frontend/src/pages/StockAlertsPage.test.jsx
+++ b/bookshelf-frontend/src/pages/StockAlertsPage.test.jsx
@@ -1,32 +1,270 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import StockAlertsPage from './StockAlertsPage.jsx';
+
+/**
+ * The stock alerts page.
+ *
+ * The bug (#422): the list rendered `alert.bookTitle || alert.bookId`, and
+ * nothing in the system has ever produced a `bookTitle` — `models/StockAlert.js`
+ * stores `userId`, `bookId`, `notified` and `notifiedAt`, and `getMyAlerts`
+ * returns those documents unchanged. So the fallback ran every time and every
+ * row showed a raw catalogue id.
+ *
+ * The tests that were here asserted the page's heading and its subtitle,
+ * which is how that shipped: neither of them rendered a single alert. These
+ * give the page alerts.
+ */
+
+const apiGet = vi.fn();
 
 vi.mock('../utils/api.js', () => ({
-  default: { get: vi.fn().mockResolvedValue({ data: [] }) },
+  default: { get: (...args) => apiGet(...args) },
 }));
+
+const unsubscribeStockAlert = vi.fn();
 
 vi.mock('../services/stockAlertService.js', () => ({
-  unsubscribeStockAlert: vi.fn(),
+  unsubscribeStockAlert: (...args) => unsubscribeStockAlert(...args),
 }));
 
+const getBooksByIds = vi.fn();
+
+vi.mock('../services/bookService.js', () => ({
+  getBooksByIds: (...args) => getBooksByIds(...args),
+}));
+
+import StockAlertsPage from './StockAlertsPage.jsx';
+
+const ALERTS = [
+  { _id: 'a1', bookId: 'b3', createdAt: '2026-02-01T00:00:00.000Z', notified: false },
+  { _id: 'a2', bookId: 'b7', createdAt: '2026-02-04T00:00:00.000Z', notified: false },
+];
+
+const CATALOGUE = [
+  { id: 'b3', title: 'Half Moon Bay', author: 'R. Iyer', price: 399, cover: '#B85C2C' },
+  { id: 'b7', title: 'The Quiet Ones', author: 'N. Rao', price: 349, cover: '#7A2E2E' },
+];
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <StockAlertsPage />
+    </MemoryRouter>
+  );
+}
+
+/** The happy path: alerts that all resolve against the catalogue. */
+function withAlerts(alerts = ALERTS, books = CATALOGUE) {
+  apiGet.mockResolvedValue({ data: alerts });
+  getBooksByIds.mockResolvedValue({ books, missingIds: [], failedIds: [] });
+}
+
 describe('StockAlertsPage', () => {
-  it('renders the page title', () => {
-    render(
-      <MemoryRouter>
-        <StockAlertsPage />
-      </MemoryRouter>
-    );
-    expect(screen.getByText('My Stock Alerts')).toBeInTheDocument();
+  beforeEach(() => {
+    apiGet.mockReset();
+    getBooksByIds.mockReset();
+    unsubscribeStockAlert.mockReset();
+    apiGet.mockResolvedValue({ data: [] });
+    getBooksByIds.mockResolvedValue({ books: [], missingIds: [], failedIds: [] });
   });
 
-  it('shows subtitle', () => {
-    render(
-      <MemoryRouter>
-        <StockAlertsPage />
-      </MemoryRouter>
-    );
+  it('renders the page title', async () => {
+    renderPage();
+    expect(screen.getByText('My Stock Alerts')).toBeInTheDocument();
+    await waitFor(() => expect(apiGet).toHaveBeenCalled());
+  });
+
+  it('shows subtitle', async () => {
+    renderPage();
     expect(screen.getByText(/waiting to come back/)).toBeInTheDocument();
+    await waitFor(() => expect(apiGet).toHaveBeenCalled());
+  });
+
+  it('names the books instead of showing raw ids', async () => {
+    // The regression. Every row used to read "b3" / "b7".
+    withAlerts();
+    renderPage();
+
+    expect(await screen.findByText('Half Moon Bay')).toBeInTheDocument();
+    expect(screen.getByText('The Quiet Ones')).toBeInTheDocument();
+
+    expect(screen.queryByText('b3')).not.toBeInTheDocument();
+    expect(screen.queryByText('b7')).not.toBeInTheDocument();
+  });
+
+  it('resolves the ids against the catalogue rather than a local copy', async () => {
+    withAlerts();
+    renderPage();
+
+    await screen.findByText('Half Moon Bay');
+
+    expect(getBooksByIds).toHaveBeenCalled();
+    expect(getBooksByIds.mock.calls[0][0]).toEqual(['b3', 'b7']);
+  });
+
+  it('shows the author and price alongside the title', async () => {
+    withAlerts();
+    renderPage();
+
+    await screen.findByText('Half Moon Bay');
+    expect(screen.getByText('R. Iyer')).toBeInTheDocument();
+    expect(screen.getByText('₹399.00')).toBeInTheDocument();
+  });
+
+  it('still links each row to the book page', async () => {
+    withAlerts();
+    renderPage();
+
+    const link = await screen.findByRole('link', { name: 'Half Moon Bay' });
+    expect(link).toHaveAttribute('href', '/book/b3');
+  });
+
+  it('keeps the rows in the order the alerts arrived', async () => {
+    withAlerts();
+    renderPage();
+
+    await screen.findByText('Half Moon Bay');
+
+    // useBooksByIds orders its result by the requested ids, so a slow
+    // response for the first book must not push it to the bottom.
+    const titles = screen
+      .getAllByRole('link', { name: /Half Moon Bay|The Quiet Ones/ })
+      .map((node) => node.textContent);
+
+    expect(titles).toEqual(['Half Moon Bay', 'The Quiet Ones']);
+  });
+
+  it('explains a book the catalogue no longer has, rather than showing a bare id', async () => {
+    apiGet.mockResolvedValue({ data: ALERTS });
+    getBooksByIds.mockResolvedValue({
+      books: [CATALOGUE[0]],
+      missingIds: ['b7'],
+      failedIds: [],
+    });
+
+    renderPage();
+
+    await screen.findByText('Half Moon Bay');
+    // The id is the only thing known about it, so it is still shown — but
+    // with a sentence saying why, not as a bare "b7".
+    expect(screen.getByText('b7')).toBeInTheDocument();
+    expect(screen.getByText(/no longer in the catalogue/i)).toBeInTheDocument();
+  });
+
+  it('does not claim a book is delisted when the request merely failed', async () => {
+    // failedIds is a network problem, not a delisting. Saying "no longer
+    // available" about a reachable book would be a lie told by the network.
+    apiGet.mockResolvedValue({ data: [ALERTS[1]] });
+    getBooksByIds.mockResolvedValue({ books: [], missingIds: [], failedIds: ['b7'] });
+
+    renderPage();
+
+    expect(await screen.findByText(/details could not be loaded/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no longer in the catalogue/i)).not.toBeInTheDocument();
+  });
+
+  it('renders no date rather than "Invalid Date" when createdAt is missing', async () => {
+    withAlerts([{ _id: 'a1', bookId: 'b3' }], [CATALOGUE[0]]);
+    renderPage();
+
+    await screen.findByText('Half Moon Bay');
+    expect(screen.queryByText(/Invalid Date/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Subscribed/)).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no alerts', async () => {
+    renderPage();
+    expect(
+      await screen.findByText(/don't have any stock alerts yet/i)
+    ).toBeInTheDocument();
+  });
+
+  it('does not flash the empty state while the books are still resolving', async () => {
+    apiGet.mockResolvedValue({ data: ALERTS });
+    // A request that never settles: the page must stay busy rather than
+    // conclude there are no alerts.
+    getBooksByIds.mockReturnValue(new Promise(() => {}));
+
+    renderPage();
+
+    await waitFor(() => expect(getBooksByIds).toHaveBeenCalled());
+    expect(
+      screen.queryByText(/don't have any stock alerts yet/i)
+    ).not.toBeInTheDocument();
+  });
+
+  describe('removing an alert', () => {
+    it('drops the row on success', async () => {
+      const user = userEvent.setup();
+      withAlerts();
+      unsubscribeStockAlert.mockResolvedValue({});
+
+      renderPage();
+      await screen.findByText('Half Moon Bay');
+
+      await user.click(
+        screen.getByRole('button', { name: /remove stock alert for Half Moon Bay/i })
+      );
+
+      await waitFor(() =>
+        expect(screen.queryByText('Half Moon Bay')).not.toBeInTheDocument()
+      );
+      expect(unsubscribeStockAlert).toHaveBeenCalledWith('b3');
+      expect(screen.getByText('The Quiet Ones')).toBeInTheDocument();
+    });
+
+    it('reports a failure on the row, not in the page banner', async () => {
+      const user = userEvent.setup();
+      withAlerts();
+      unsubscribeStockAlert.mockRejectedValue({ status: 500, message: 'Server error' });
+
+      renderPage();
+      await screen.findByText('Half Moon Bay');
+
+      await user.click(
+        screen.getByRole('button', { name: /remove stock alert for Half Moon Bay/i })
+      );
+
+      const rowError = await screen.findByRole('alert');
+      expect(rowError).toHaveTextContent(/could not remove this alert|server error/i);
+
+      // The row is still there — the alert was not removed.
+      expect(screen.getByText('Half Moon Bay')).toBeInTheDocument();
+    });
+
+    it('disables the button while its own request is in flight', async () => {
+      const user = userEvent.setup();
+      withAlerts();
+
+      let resolveRemoval;
+      unsubscribeStockAlert.mockReturnValue(
+        new Promise((resolve) => {
+          resolveRemoval = resolve;
+        })
+      );
+
+      renderPage();
+      await screen.findByText('Half Moon Bay');
+
+      const button = screen.getByRole('button', {
+        name: /remove stock alert for Half Moon Bay/i,
+      });
+
+      await user.click(button);
+
+      // A second click used to send a second DELETE, and the second answered
+      // 404 — an error about an alert that had just been removed.
+      await waitFor(() => expect(button).toBeDisabled());
+      expect(button).toHaveTextContent(/removing/i);
+
+      // The other row is unaffected.
+      expect(
+        screen.getByRole('button', { name: /remove stock alert for The Quiet Ones/i })
+      ).not.toBeDisabled();
+
+      resolveRemoval({});
+    });
   });
 });


### PR DESCRIPTION
Fixes #422.

## The bug

`/stock-alerts` listed a raw catalogue id — `b3`, `b7` — on every row.

```jsx
<Link to={`/book/${alert.bookId}`} className="alerts-page__book-link">
  {alert.bookTitle || alert.bookId}
</Link>
```

There is no `bookTitle` anywhere in the system. `models/StockAlert.js` stores four fields:

```js
{ userId, bookId, notified, notifiedAt }
```

and `getMyAlerts` returns those documents unchanged. `alert.bookTitle` is always `undefined`, so the fallback ran every time. The `||` reads like a defence against a rare case; it was the only branch that ever executed.

A page whose entire purpose is "here are the books you are waiting for" could not name a single one of them.

## The same bug the app has already fixed twice

- **#328** — the wishlist resolved saved ids against a stale local copy of the catalogue instead of the API.
- **#336** — Recently Viewed did the same against `src/data/books.js`, the hardcoded snapshot.

Both were fixed by resolving through the API, and the shared hook that came out of it already exists. Stock alerts was the third page with this problem and the last one still doing it by hand, so it uses `useBooksByIds` too. That hook already handles the parts that are easy to get wrong:

- results ordered by the **requested** ids, not by response arrival, so the list does not reshuffle between loads;
- the effect keyed on the joined ids, so a caller holding an array in state does not refetch forever;
- aborted on unmount, with the cancellation swallowed rather than rendered;
- `missingIds` (the catalogue answered 404) reported separately from `failedIds` (the request did not complete).

## Why that last distinction is load-bearing here

A **delisted** book's alert will never fire, and the customer should be told. A book behind a **flaky network** is perfectly fine, and saying "no longer available" about it would be a lie told by the network.

Both cases still show the id — it is the only thing known about that book — but with a sentence saying why, rather than as a bare `b3` that reads like a rendering fault.

## Rows now carry the cover, title, author and price

Matching how the wishlist presents the same information. The cover is a colour in this catalogue rather than an image, the same as `BookCard` renders.

## Four smaller things on the same page

- **No `usePageMetadata`**, so the browser tab kept whatever the previous route set. See #337 — this was one of the four pages still missing it.
- **`new Date(alert.createdAt).toLocaleDateString()` was unguarded** and rendered the literal string "Invalid Date" for an alert with no `createdAt`. It renders no date at all now; saying nothing beats saying something wrong.
- **A failed removal wrote into the page-level error banner**, which is at the top of the page, a long way from the button that was pressed, and with several alerts on screen does not say which one failed. It reports on the row.
- **The remove button was not disabled while its request was in flight**, so a double click sent two `DELETE`s and the second answered 404 — surfacing an error about an alert that had just been removed successfully.

## The tests are the other half of this

The two that were here asserted the page's heading and its subtitle. Neither rendered a single alert, which is exactly how a list that could not name any of its books stayed green. The suite gives the page alerts now — 15 cases covering the resolution, both failure modes, the ordering, the empty state, and the three removal paths.

## Checks

- `bookshelf-frontend`: 812 tests pass (799 on `main`, +13), lint clean at 0 errors, build clean.
- Backend untouched by this PR. The alert documents are fine as they are — denormalising a title onto them would put a second copy of the catalogue in the database, which is the shape of the bug #328 and #336 were about.
- Checked with `git merge-tree` against #423, #424, #425 and #426: no conflicts with any of them.

The two Vercel checks fail with "Authorization required to deploy" on every PR in this repo, including merged ones from other authors — it needs the repo owner to authorize the integration and is not caused by this change.
